### PR TITLE
mmap/sbrk/brk implementation and integration into glibc/wasmtime

### DIFF
--- a/src/RawPOSIX/src/interface/mem.rs
+++ b/src/RawPOSIX/src/interface/mem.rs
@@ -12,6 +12,13 @@ use std::result::Result;
 // heap is placed at the very top of the memory
 pub const HEAP_ENTRY_INDEX: u32 = 0;
 
+/// Round up the address length to be multiple of pages
+///
+/// # Arguments
+/// * `length` - length of the address
+///
+/// # Returns
+/// * `u64` - rounded up length
 pub fn round_up_page(length: u64) -> u64 {
     if length % PAGESIZE as u64 == 0 {
         length
@@ -20,6 +27,24 @@ pub fn round_up_page(length: u64) -> u64 {
     }
 }
 
+/// Copies the memory regions from parent to child based on the provided `vmmap` memory layout.
+///
+/// This function is designed to replicate the parent's memory space into the child immediately after
+/// a `fork_syscall` in Wasmtime. It assumes that the parent and child share the same `vmmap` structure,
+/// a valid assumption in this context.
+///
+/// The copying behavior varies based on the type of memory region:
+/// 1. **PROT_NONE regions**:
+///    - No action is taken, as memory regions are already configured with `PROT_NONE` by default.
+/// 2. **Shared memory regions**:
+///    - The function uses the `mremap` syscall to replicate shared memory efficiently. Refer to `man 2 mremap` for details.
+/// 3. **Private memory regions**:
+///    - The function uses `std::ptr::copy_nonoverlapping` to copy the memory contents directly.
+///    - **TODO**: Investigate whether using `writev` could improve performance for this case.
+/// 
+/// # Arguments
+/// * `parent_vmmap` - vmmap struct of parent
+/// * `child_vmmap` - vmmap struct of child
 pub fn fork_vmmap(parent_vmmap: &Vmmap, child_vmmap: &Vmmap) {
     let parent_base = parent_vmmap.base_address.unwrap();
     let child_base = child_vmmap.base_address.unwrap();
@@ -56,6 +81,20 @@ pub fn fork_vmmap(parent_vmmap: &Vmmap, child_vmmap: &Vmmap) {
     }
 }
 
+/// Handler of the `munmap_syscall`, interacting with the `vmmap` structure.
+///
+/// This function processes the `munmap_syscall` by updating the `vmmap` entries and managing
+/// the unmap operation. Instead of invoking the actual `munmap` syscall, the unmap operation
+/// is simulated by setting the specified region to `PROT_NONE`. The memory remains valid but
+/// becomes inaccessible due to the `PROT_NONE` setting.
+///
+/// # Arguments
+/// * `cageid` - Identifier of the cage that calls the `munmap`
+/// * `addr` - Starting address of the region to unmap
+/// * `length` - Length of the region to unmap
+/// 
+/// # Returns
+/// * `i32` - 0 for success and -1 for failure
 pub fn munmap_handler(cageid: u64, addr: *mut u8, len: usize) -> i32 {
     let cage = cagetable_getref(cageid);
 
@@ -85,6 +124,28 @@ pub fn munmap_handler(cageid: u64, addr: *mut u8, len: usize) -> i32 {
     0
 }
 
+/// Handles the `mmap_syscall`, interacting with the `vmmap` structure.
+///
+/// This function processes the `mmap_syscall` by updating the `vmmap` entries and performing
+/// the necessary mmap operations. The handling logic is as follows:
+/// 1. Restrict allowed flags to `MAP_FIXED`, `MAP_SHARED`, `MAP_PRIVATE`, and `MAP_ANONYMOUS`.
+/// 2. Disallow `PROT_EXEC`; return `EINVAL` if the `prot` argument includes `PROT_EXEC`.
+/// 3. If `MAP_FIXED` is not specified, query the `vmmap` structure to locate an available memory region.
+///    Otherwise, use the address provided by the user.
+/// 4. Invoke the actual `mmap` syscall with the `MAP_FIXED` flag to configure the memory region's protections.
+/// 5. Update the corresponding `vmmap` entry.
+///
+/// # Arguments
+/// * `cageid` - Identifier of the cage that initiated the `mmap` syscall.
+/// * `addr` - Starting address of the memory region to mmap.
+/// * `len` - Length of the memory region to mmap.
+/// * `prot` - Memory protection flags (e.g., `PROT_READ`, `PROT_WRITE`).
+/// * `flags` - Mapping flags (e.g., `MAP_SHARED`, `MAP_ANONYMOUS`).
+/// * `fildes` - File descriptor associated with the mapping, if applicable.
+/// * `off` - Offset within the file, if applicable.
+///
+/// # Returns
+/// * `u32` - Result of the `mmap` operation. See "man mmap" for details
 pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut flags: i32, mut fildes: i32, off: i64) -> u32 {
     let cage = cagetable_getref(cageid);
 
@@ -98,25 +159,21 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
     }
 
     if prot & PROT_EXEC > 0 {
-        println!("mmap syscall error 1!");
         return syscall_error(Errno::EINVAL, "mmap", "PROT_EXEC is not allowed") as u32;
     }
 
     // check if the provided address is multiple of pages
     let rounded_addr = round_up_page(addr as u64);
     if rounded_addr != addr as u64 {
-        println!("mmap syscall error 2!");
         return syscall_error(Errno::EINVAL, "mmap", "address it not aligned") as u32;
     }
 
     // offset should be non-negative and multiple of pages
     if off < 0 {
-        println!("mmap syscall error 3!");
         return syscall_error(Errno::EINVAL, "mmap", "offset cannot be negative") as u32;
     }
     let rounded_off = round_up_page(off as u64);
     if rounded_off != off as u64 {
-        println!("mmap syscall error 4!");
         return syscall_error(Errno::EINVAL, "mmap", "offset it not aligned") as u32;
     }
 
@@ -147,8 +204,6 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
         useraddr = (space.start() << PAGESHIFT) as u32;
     }
 
-    // TODO: validate useraddr (like checking whether within the program break)
-
     flags |= MAP_FIXED as i32;
 
     // either MAP_PRIVATE or MAP_SHARED should be set, but not both
@@ -159,7 +214,6 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
     let vmmap = cage.vmmap.read();
 
     let sysaddr = vmmap.user_to_sys(useraddr);
-    println!("useraddr: {}, sysaddr: {}", useraddr, sysaddr);
 
     drop(vmmap);
 
@@ -171,11 +225,10 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
         let result = cage.mmap_syscall(sysaddr as *mut u8, rounded_length as usize, prot, flags, fildes, off);
         
         let vmmap = cage.vmmap.read();
-        println!("sys addr: {}", result);
         let result = vmmap.sys_to_user(result);
-        println!("user addr: {}", result);
         drop(vmmap);
 
+        // if mmap addr is positive, that would mean the mapping is successful and we need to update the vmmap entry
         if result >= 0 {
             if result != useraddr {
                 panic!("MAP_FIXED not fixed");
@@ -196,13 +249,34 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
                 }
             };
 
-            vmmap.add_entry_with_overwrite(useraddr >> PAGESHIFT, (rounded_length >> PAGESHIFT) as u32, prot, maxprot, flags, backing, off, len as i64, cageid);
+            // update vmmap entry
+            vmmap.add_entry_with_overwrite(useraddr >> PAGESHIFT,
+                                           (rounded_length >> PAGESHIFT) as u32,
+                                           prot,
+                                           maxprot,
+                                           flags,
+                                           backing,
+                                           off,
+                                           len as i64,
+                                           cageid);
         }
     }
 
     useraddr as u32
 }
 
+/// Handles the `sbrk_syscall`, interacting with the `vmmap` structure.
+///
+/// This function processes the `sbrk_syscall` by updating the `vmmap` entries and managing
+/// the program break. It calculates the target program break after applying the specified
+/// increment and delegates further processing to the `brk_handler`.
+///
+/// # Arguments
+/// * `cageid` - Identifier of the cage that initiated the `sbrk` syscall.
+/// * `brk` - Increment to adjust the program break, which can be negative.
+///
+/// # Returns
+/// * `u32` - Result of the `sbrk` operation. Refer to `man sbrk` for details.
 pub fn sbrk_handler(cageid: u64, brk: i32) -> u32 {
     let cage = cagetable_getref(cageid);
 
@@ -210,13 +284,16 @@ pub fn sbrk_handler(cageid: u64, brk: i32) -> u32 {
     let mut vmmap = cage.vmmap.read();
     let heap = vmmap.find_page(HEAP_ENTRY_INDEX).unwrap().clone();
 
+    // program break should always be the same as the heap entry end
     assert!(heap.npages == vmmap.program_break);
 
+    // pass 0 to sbrk will just return the current brk
     if brk == 0 {
         return (PAGESIZE * heap.npages) as u32;
     }
 
     // round up the break to multiple of pages
+    // brk increment could possibly be negative
     let brk_page;
     if brk < 0 {
         brk_page = -((round_up_page(-brk as u64) >> PAGESHIFT) as i32);
@@ -224,15 +301,30 @@ pub fn sbrk_handler(cageid: u64, brk: i32) -> u32 {
         brk_page = (round_up_page(brk as u64) >> PAGESHIFT) as i32;
     }
 
+    // drop the vmmap so that brk_handler will not deadlock
     drop(vmmap);
 
     if brk_handler(cageid, ((heap.npages as i32 + brk_page) << PAGESHIFT) as u32) < 0 {
         return syscall_error(Errno::ENOMEM, "sbrk", "no memory") as u32;
     }
 
+    // sbrk syscall should return previous brk address before increment
     (PAGESIZE * heap.npages) as u32
 }
 
+/// Handles the `brk_syscall`, interacting with the `vmmap` structure.
+///
+/// This function processes the `brk_syscall` by updating the `vmmap` entries and performing
+/// the necessary operations to adjust the program break. Specifically, it updates the program 
+/// break by modifying the end of the heap entry (the first entry in `vmmap`) and invokes `mmap` 
+/// to adjust the memory protection as needed.
+///
+/// # Arguments
+/// * `cageid` - Identifier of the cage that initiated the `brk` syscall.
+/// * `brk` - The new program break address.
+///
+/// # Returns
+/// * `u32` - Returns `0` on success or `-1` on failure.
 pub fn brk_handler(cageid: u64, brk: u32) -> i32 {
     let cage = cagetable_getref(cageid);
 
@@ -247,6 +339,14 @@ pub fn brk_handler(cageid: u64, brk: u32) -> i32 {
 
     // TODO: check if brk has enough space
 
+    // if we are incrementing program break, we need to check if we have enough space
+    if brk_page > old_brk_page {
+        if vmmap.check_existing_mapping(old_brk_page, brk_page - old_brk_page, 0) {
+            return syscall_error(Errno::ENOMEM, "brk", "no memory");
+        }
+    }
+
+    // update vmmap entry
     vmmap.add_entry_with_overwrite(0, brk_page, heap.prot, heap.maxprot, heap.flags, heap.backing, heap.file_offset, heap.file_size, heap.cage_id);
     
     let old_heap_end_usr = (old_brk_page * PAGESIZE) as u32;
@@ -330,7 +430,6 @@ pub fn check_and_convert_addr_ext(cage: &Cage, arg: u64, length: usize, prot: i3
     
     // Validate memory mapping and permissions
     if vmmap.check_addr_mapping(page_num, npages, prot).is_none() {
-        println!("invalid address: {}", arg);
         return Err(Errno::EFAULT);  // Return error if mapping invalid
     }
 

--- a/src/RawPOSIX/src/interface/mem.rs
+++ b/src/RawPOSIX/src/interface/mem.rs
@@ -337,8 +337,6 @@ pub fn brk_handler(cageid: u64, brk: u32) -> i32 {
     // round up the break to multiple of pages
     let brk_page = (round_up_page(brk as u64) >> PAGESHIFT) as u32;
 
-    // TODO: check if brk has enough space
-
     // if we are incrementing program break, we need to check if we have enough space
     if brk_page > old_brk_page {
         if vmmap.check_existing_mapping(old_brk_page, brk_page - old_brk_page, 0) {

--- a/src/RawPOSIX/src/interface/mem.rs
+++ b/src/RawPOSIX/src/interface/mem.rs
@@ -96,21 +96,25 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
     }
 
     if prot & PROT_EXEC > 0 {
+        println!("mmap syscall error 1!");
         return syscall_error(Errno::EINVAL, "mmap", "PROT_EXEC is not allowed");
     }
 
     // check if the provided address is multiple of pages
     let rounded_addr = round_up_page(addr as u64);
     if rounded_addr != addr as u64 {
+        println!("mmap syscall error 2!");
         return syscall_error(Errno::EINVAL, "mmap", "address it not aligned");
     }
 
     // offset should be non-negative and multiple of pages
     if off < 0 {
+        println!("mmap syscall error 3!");
         return syscall_error(Errno::EINVAL, "mmap", "offset cannot be negative");
     }
     let rounded_off = round_up_page(off as u64);
     if rounded_off != off as u64 {
+        println!("mmap syscall error 4!");
         return syscall_error(Errno::EINVAL, "mmap", "offset it not aligned");
     }
 
@@ -267,6 +271,7 @@ pub fn check_and_convert_addr_ext(cage: &Cage, arg: u64, length: usize, prot: i3
     
     // Validate memory mapping and permissions
     if vmmap.check_addr_mapping(page_num, npages, prot).is_none() {
+        println!("invalid address: {}", arg);
         return Err(Errno::EFAULT);  // Return error if mapping invalid
     }
 

--- a/src/RawPOSIX/src/interface/mem.rs
+++ b/src/RawPOSIX/src/interface/mem.rs
@@ -189,7 +189,6 @@ pub fn mmap_handler(cageid: u64, addr: *mut u8, len: usize, mut prot: i32, mut f
         // pick an address of appropriate size, anywhere
         if useraddr == 0 {
             result = vmmap.find_map_space(rounded_length as u32 >> PAGESHIFT, 1);
-            println!("find map space result: {:?}", result);
         } else {
             // use address user provided as hint to find address
             result = vmmap.find_map_space_with_hint(rounded_length as u32 >> PAGESHIFT, 1, addr as u32);

--- a/src/RawPOSIX/src/safeposix/dispatcher.rs
+++ b/src/RawPOSIX/src/safeposix/dispatcher.rs
@@ -201,17 +201,6 @@ pub fn lind_syscall_api(
 ) -> i32 {
     let call_number = call_number as i32;
 
-    if call_number as i32 != WRITE_SYSCALL {
-        match call_name {
-            0 => {
-                println!("\x1b[90mcage {} calls UNNAMED ({})\x1b[0m", cageid, call_number);
-            },
-            _ => {
-                println!("\x1b[90mcage {} calls {} ({})\x1b[0m", cageid, interface::get_cstr(start_address + call_name).unwrap(), call_number);
-            }
-        }
-    }
-
     let ret = match call_number {
         WRITE_SYSCALL => {
             let fd = arg1 as i32;
@@ -1230,25 +1219,6 @@ pub fn lind_syscall_api(
         _ => -1, // Return -1 for unknown syscalls
     };
 
-    if call_number as i32 != WRITE_SYSCALL {
-        match call_name {
-            0 => {
-                if ret < 0 {
-                    println!("\x1b[31mcage {} calls UNNAMED ({}) returns {}\x1b[0m", cageid, call_number, ret);
-                } else {
-                    println!("\x1b[90mcage {} calls UNNAMED ({}) returns {}\x1b[0m", cageid, call_number, ret);
-                }
-            },
-            _ => {
-                if ret < 0 {
-                    println!("\x1b[31mcage {} calls {} ({}) returns {}\x1b[0m", cageid, interface::get_cstr(start_address + call_name).unwrap(), call_number, ret);
-                } else {
-                    println!("\x1b[90mcage {} calls {} ({}) returns {}\x1b[0m", cageid, interface::get_cstr(start_address + call_name).unwrap(), call_number, ret);
-                }
-            }
-        }
-    }
-
     ret
 }
 
@@ -1271,6 +1241,7 @@ pub fn fork_vmmap_helper(parent_cageid: u64, child_cageid: u64) {
 
     interface::fork_vmmap(&parent_vmmap, &child_vmmap);
 
+    // update program break for child
     drop(child_vmmap);
     let mut child_vmmap = child_cage.vmmap.write();
     child_vmmap.set_program_break(parent_vmmap.program_break);

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -779,7 +779,8 @@ impl Cage {
         flags: i32,
         virtual_fd: i32,
         off: i64
-    ) -> i64 {
+    ) -> usize {
+        println!("mmap_syscall: addr: {:?}, len: {}, prot: {} flags: {}, fd: {}, off: {}", addr, len, prot, flags, virtual_fd, off);
         if virtual_fd != -1 {
             match fdtables::translate_virtual_fd(self.cageid, virtual_fd as u64) {
                 Ok(kernel_fd) => {
@@ -789,13 +790,13 @@ impl Cage {
 
                     // Check if mmap failed and return the appropriate error if so
                     if ret == -1 {
-                        return syscall_error(Errno::EINVAL, "mmap", "mmap failed with invalid flags") as i64;
+                        return syscall_error(Errno::EINVAL, "mmap", "mmap failed with invalid flags") as usize;
                     }
 
-                    ret
+                    ret as usize
                 },
                 Err(_e) => {
-                    return syscall_error(Errno::EBADF, "mmap", "Bad File Descriptor") as i64;
+                    return syscall_error(Errno::EBADF, "mmap", "Bad File Descriptor") as usize;
                 }
             }
         } else {
@@ -805,10 +806,10 @@ impl Cage {
             };
             // Check if mmap failed and return the appropriate error if so
             if ret == -1 {
-                return syscall_error(Errno::EINVAL, "mmap", "mmap failed with invalid flags") as i64;
+                return syscall_error(Errno::EINVAL, "mmap", "mmap failed with invalid flags") as usize;
             }
 
-            ret
+            ret as usize
         }
     }
 

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -780,7 +780,6 @@ impl Cage {
         virtual_fd: i32,
         off: i64
     ) -> usize {
-        println!("mmap_syscall: addr: {:?}, len: {}, prot: {} flags: {}, fd: {}, off: {}", addr, len, prot, flags, virtual_fd, off);
         if virtual_fd != -1 {
             match fdtables::translate_virtual_fd(self.cageid, virtual_fd as u64) {
                 Ok(kernel_fd) => {

--- a/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
@@ -179,7 +179,7 @@ impl Cage {
             sigset: newsigset,
             main_threadid: interface::RustAtomicU64::new(0),
             interval_timer: interface::IntervalTimer::new(child_cageid),
-            vmmap: interface::RustLock::new(Vmmap::new()), // Initialize empty virtual memory map for new process
+            vmmap: interface::RustLock::new(new_vmmap), // Initialize empty virtual memory map for new process
             zombies: interface::RustLock::new(vec![]),
             child_num: interface::RustAtomicU64::new(0),
         };

--- a/src/RawPOSIX/src/safeposix/vmmap.rs
+++ b/src/RawPOSIX/src/safeposix/vmmap.rs
@@ -1,14 +1,16 @@
 use crate::constants::{
-    PROT_NONE, PROT_READ, PROT_WRITE, PROT_EXEC,
-    MAP_SHARED, MAP_PRIVATE, MAP_FIXED, MAP_ANONYMOUS,
-    MAP_FAILED
+    MAP_ANONYMOUS, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, MAP_SHARED, PAGESHIFT, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE
 };
 use std::io;
+use nodit::interval::ii;
 use nodit::NoditMap;
 use nodit::{interval::ie, Interval};
 use crate::fdtables;
 use crate::safeposix::cage::syscall_error;
 use crate::safeposix::cage::Errno;
+
+const DEFAULT_VMMAP_SIZE: u32 = 1 << (32 - PAGESHIFT);
+
 /// Used to identify whether the vmmap entry is backed anonymously,
 /// by an fd, or by a shared memory segment
 /// 
@@ -247,8 +249,11 @@ pub struct Vmmap {
     pub entries: NoditMap<u32, Interval<u32>, VmmapEntry>, // Keyed by `page_num`
     pub cached_entry: Option<VmmapEntry>,                  // TODO: is this still needed?
                                                            // Use Option for safety
-    pub base_address: Option<i64>,                         // wasm base address. None means uninitialized yet
+    pub base_address: Option<usize>,                       // wasm base address. None means uninitialized yet
 
+    pub start_address: u32,                                // start address of valid vmmap address range
+    pub end_address: u32,                                  // end address of valid vmmap address range
+    pub program_break: u32,                                // program break (i.e. heap bottom) of the memory
 }
 
 #[allow(dead_code)]
@@ -259,7 +264,10 @@ impl Vmmap {
         Vmmap {
             entries: NoditMap::new(),
             cached_entry: None,
-            base_address: None
+            base_address: None,
+            start_address: 0,
+            end_address: DEFAULT_VMMAP_SIZE,
+            program_break: 0,
         }
     }
 
@@ -291,9 +299,17 @@ impl Vmmap {
     ///
     /// Arguments:
     /// - base_address: The base address to set
-    pub fn set_base_address(&mut self, base_address: i64) {
+    pub fn set_base_address(&mut self, base_address: usize) {
         // Store the provided base address
         self.base_address = Some(base_address);
+    }
+
+    /// Sets the program break for the memory
+    ///
+    /// Arguments:
+    /// - program_break: The program break to set
+    pub fn set_program_break(&mut self, program_break: u32) {
+        self.program_break = program_break;
     }
 
     /// Converts a user address to a system address
@@ -302,9 +318,9 @@ impl Vmmap {
     /// - address: User space address to convert
     ///
     /// Returns the corresponding system address
-    pub fn user_to_sys(&self, address: i32) -> i64 {
+    pub fn user_to_sys(&self, address: u32) -> usize {
         // Add base address to user address to get system address
-        address as i64 + self.base_address.unwrap()
+        address as usize + self.base_address.unwrap()
     }
 
     /// Converts a system address to a user address
@@ -313,9 +329,9 @@ impl Vmmap {
     /// - address: System address to convert
     ///
     /// Returns the corresponding user space address
-    pub fn sys_to_user(&self, address: i64) -> i32 {
+    pub fn sys_to_user(&self, address: usize) -> u32 {
         // Subtract base address from system address to get user address
-        (address as i64 - self.base_address.unwrap()) as i32
+        (address as usize - self.base_address.unwrap()) as u32
     }
 
     // Visits each entry in the vmmap, applying a visitor function to each entry
@@ -818,24 +834,17 @@ impl VmmapOps for Vmmap {
     /// - Some(Interval) containing the found space
     /// - None if no suitable space found
     fn find_space(&self, npages: u32) -> Option<Interval<u32>> {
-        let start = self.first_entry();
-        let end = self.last_entry();
+        let start = self.start_address;
+        let end = self.end_address;
 
-        if start == None || end == None {
-            return None;
-        } else {
-            let start_unwrapped = start.unwrap().0.start();
-            let end_unwrapped = end.unwrap().0.end();
+        let desired_space = npages + 1; // TODO: check if this is correct
 
-            let desired_space = npages + 1; // TODO: check if this is correct
-
-            for gap in self
-                .entries
-                .gaps_trimmed(ie(start_unwrapped, end_unwrapped))
-            {
-                if gap.end() - gap.start() >= desired_space {
-                    return Some(gap);
-                }
+        for gap in self
+            .entries
+            .gaps_trimmed(ie(start, end))
+        {
+            if gap.end() - gap.start() >= desired_space {
+                return Some(gap);
             }
         }
 
@@ -856,19 +865,13 @@ impl VmmapOps for Vmmap {
     /// - None if no suitable space found
     fn find_space_above_hint(&self, npages: u32, hint: u32) -> Option<Interval<u32>> {
         let start = hint;
-        let end = self.last_entry();
+        let end = self.end_address;
 
-        if end == None {
-            return None;
-        } else {
-            let end_unwrapped = end.unwrap().0.end();
+        let desired_space = npages + 1; // TODO: check if this is correct
 
-            let desired_space = npages + 1; // TODO: check if this is correct
-
-            for gap in self.entries.gaps_trimmed(ie(start, end_unwrapped)) {
-                if gap.end() - gap.start() >= desired_space {
-                    return Some(gap);
-                }
+        for gap in self.entries.gaps_trimmed(ie(start, end)) {
+            if gap.end() - gap.start() >= desired_space {
+                return Some(gap);
             }
         }
 
@@ -892,31 +895,27 @@ impl VmmapOps for Vmmap {
     /// - Rounds page numbers up to alignment boundaries
     /// - Handles alignment constraints for start and end addresses
     fn find_map_space(&self, num_pages: u32, pages_per_map: u32) -> Option<Interval<u32>> {
-        let start = self.first_entry();
-        let end = self.last_entry();
+        let start = self.start_address;
+        let end = self.end_address;
 
-        if start == None || end == None {
-            return None;
-        } else {
-            let start_unwrapped = start.unwrap().0.start();
-            let end_unwrapped = end.unwrap().0.end();
+        let rounded_num_pages =
+            self.round_page_num_up_to_map_multiple(num_pages, pages_per_map);
+        println!("rounded_num_pages: {}", rounded_num_pages);
 
-            let rounded_num_pages =
-                self.round_page_num_up_to_map_multiple(num_pages, pages_per_map);
+        for gap in self
+            .entries
+            .gaps_trimmed(ie(start, end))
+        {
+            println!("gap: {:?}", gap);
+            let aligned_start_page =
+                self.trunc_page_num_down_to_map_multiple(gap.start(), pages_per_map);
+            let aligned_end_page =
+                self.round_page_num_up_to_map_multiple(gap.end(), pages_per_map);
 
-            for gap in self
-                .entries
-                .gaps_trimmed(ie(start_unwrapped, end_unwrapped))
-            {
-                let aligned_start_page =
-                    self.trunc_page_num_down_to_map_multiple(gap.start(), pages_per_map);
-                let aligned_end_page =
-                    self.round_page_num_up_to_map_multiple(gap.end(), pages_per_map);
-
-                let gap_size = aligned_end_page - aligned_start_page;
-                if gap_size >= rounded_num_pages {
-                    return Some(ie(aligned_end_page - rounded_num_pages, aligned_end_page));
-                }
+            println!("aligned gap: {} {}", aligned_start_page, aligned_end_page);
+            let gap_size = aligned_end_page - aligned_start_page;
+            if gap_size >= rounded_num_pages {
+                return Some(ie(aligned_end_page - rounded_num_pages, aligned_end_page));
             }
         }
 
@@ -948,26 +947,20 @@ impl VmmapOps for Vmmap {
         hint: u32,
     ) -> Option<Interval<u32>> {
         let start = hint;
-        let end = self.last_entry();
+        let end = self.end_address;
 
-        if end == None {
-            return None;
-        } else {
-            let end_unwrapped = end.unwrap().0.end();
+        let rounded_num_pages =
+            self.round_page_num_up_to_map_multiple(num_pages, pages_per_map);
 
-            let rounded_num_pages =
-                self.round_page_num_up_to_map_multiple(num_pages, pages_per_map);
+        for gap in self.entries.gaps_trimmed(ie(start, end)) {
+            let aligned_start_page =
+                self.trunc_page_num_down_to_map_multiple(gap.start(), pages_per_map);
+            let aligned_end_page =
+                self.round_page_num_up_to_map_multiple(gap.end(), pages_per_map);
 
-            for gap in self.entries.gaps_trimmed(ie(start, end_unwrapped)) {
-                let aligned_start_page =
-                    self.trunc_page_num_down_to_map_multiple(gap.start(), pages_per_map);
-                let aligned_end_page =
-                    self.round_page_num_up_to_map_multiple(gap.end(), pages_per_map);
-
-                let gap_size = aligned_end_page - aligned_start_page;
-                if gap_size >= rounded_num_pages {
-                    return Some(ie(aligned_end_page - rounded_num_pages, aligned_end_page));
-                }
+            let gap_size = aligned_end_page - aligned_start_page;
+            if gap_size >= rounded_num_pages {
+                return Some(ie(aligned_end_page - rounded_num_pages, aligned_end_page));
             }
         }
 

--- a/src/RawPOSIX/src/safeposix/vmmap.rs
+++ b/src/RawPOSIX/src/safeposix/vmmap.rs
@@ -2,7 +2,6 @@ use crate::constants::{
     MAP_ANONYMOUS, MAP_FAILED, MAP_FIXED, MAP_PRIVATE, MAP_SHARED, PAGESHIFT, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE
 };
 use std::io;
-use nodit::interval::ii;
 use nodit::NoditMap;
 use nodit::{interval::ie, Interval};
 use crate::fdtables;
@@ -896,19 +895,16 @@ impl VmmapOps for Vmmap {
 
         let rounded_num_pages =
             self.round_page_num_up_to_map_multiple(num_pages, pages_per_map);
-        println!("rounded_num_pages: {}", rounded_num_pages);
 
         for gap in self
             .entries
             .gaps_trimmed(ie(start, end))
         {
-            println!("gap: {:?}", gap);
             let aligned_start_page =
                 self.trunc_page_num_down_to_map_multiple(gap.start(), pages_per_map);
             let aligned_end_page =
                 self.round_page_num_up_to_map_multiple(gap.end(), pages_per_map);
 
-            println!("aligned gap: {} {}", aligned_start_page, aligned_end_page);
             let gap_size = aligned_end_page - aligned_start_page;
             if gap_size >= rounded_num_pages {
                 return Some(ie(aligned_end_page - rounded_num_pages, aligned_end_page));

--- a/src/glibc/lind_syscall/lind_syscall.c
+++ b/src/glibc/lind_syscall/lind_syscall.c
@@ -32,15 +32,23 @@ int __imported_wasi_snapshot_preview1_lind_syscall(unsigned int callnumber, unsi
 //            handled here instead
 int lind_syscall (unsigned int callnumber, unsigned long long callname, unsigned long long arg1, unsigned long long arg2, unsigned long long arg3, unsigned long long arg4, unsigned long long arg5, unsigned long long arg6)
 {
-  int ret = __imported_wasi_snapshot_preview1_lind_syscall(callnumber, callname, arg1, arg2, arg3, arg4, arg5, arg6);
-  // handle the errno
-  if(ret < 0)
-  {
-    errno = -ret;
-  }
-  else
-  {
-    errno = 0;
-  }
-  return ret;
+    int ret = __imported_wasi_snapshot_preview1_lind_syscall(callnumber, callname, arg1, arg2, arg3, arg4, arg5, arg6);
+    // handle the errno
+    // in rawposix, we use -errno as the return value to indicate the error
+    // but this may cause some issues for mmap syscall, because mmap syscall
+    // is returning an 32-bit address, which may overflow the int type (i32)
+    // luckily we can handle this easily because the return value of mmap is always
+    // multiple of pages (typically 4096) even when overflow, therefore we can distinguish
+    // the errno and mmap result by simply checking if the return value is
+    // within the valid errno range
+    if(ret < 0 && ret > -256)
+    {
+        errno = -ret;
+        return -1;
+    }
+    else
+    {
+        errno = 0;
+    }
+    return ret;
 }

--- a/src/glibc/malloc/malloc.c
+++ b/src/glibc/malloc/malloc.c
@@ -4444,8 +4444,8 @@ _int_malloc (mstate av, size_t bytes)
       victim = av->top;
       size = chunksize (victim);
 
-      if (__glibc_unlikely (size > av->system_mem))
-        malloc_printerr ("malloc(): corrupted top size");
+      // if (__glibc_unlikely (size > av->system_mem))
+      //   malloc_printerr ("malloc(): corrupted top size");
 
       if ((unsigned long) (size) >= (unsigned long) (nb + MINSIZE))
         {

--- a/src/glibc/malloc/malloc.c
+++ b/src/glibc/malloc/malloc.c
@@ -4444,8 +4444,8 @@ _int_malloc (mstate av, size_t bytes)
       victim = av->top;
       size = chunksize (victim);
 
-      // if (__glibc_unlikely (size > av->system_mem))
-      //   malloc_printerr ("malloc(): corrupted top size");
+      if (__glibc_unlikely (size > av->system_mem))
+        malloc_printerr ("malloc(): corrupted top size");
 
       if ((unsigned long) (size) >= (unsigned long) (nb + MINSIZE))
         {

--- a/src/glibc/misc/sbrk.c
+++ b/src/glibc/misc/sbrk.c
@@ -44,41 +44,6 @@ void *
 __sbrk (intptr_t increment)
 {
 	return MAKE_SYSCALL(176, "syscall|sbrk", (uint64_t) increment, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
-    // __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
-    
-    // // sbrk(0) returns the current memory size.
-    // if (increment == 0) {
-    //     // The wasm spec doesn't guarantee that memory.grow of 0 always succeeds.
-    //     return __curbrk;
-    // }
-
-    // // FIXME: now two threads calling this sbrk simultaneously
-    // // will lead to the corruption of __curbrk, so we should move
-    // // this implementation into the runtime, and protect the __curbrk
-    // // with mutex (i.e.  preventing two sbrk to be executed at the same time)
-
-    // void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
-    // void * old_break = __curbrk;
-    // void * new_break = old_break + increment;
-
-    // if (new_break <= linear_mem_end) {
-    //     // In this case, we don't need to grow linear mem
-    //     __curbrk = new_break;
-    //     return old_break;
-    // }
-
-    // // Now we need to grow linear mem
-    // // int new_pages = (new_break - linear_mem_end) / PAGESIZE;
-    // int new_pages = (new_break - linear_mem_end + PAGESIZE - 1) / PAGESIZE;
-
-	// MAKE_SYSCALL(176, "syscall|sbrk", (uint64_t) increment, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
-    // if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
-    //     errno = ENOMEM;
-    //     return (void *)-1;
-    // }
-
-    // __curbrk = new_break;
-    // return old_break;
 }
 
 // void *

--- a/src/glibc/misc/sbrk.c
+++ b/src/glibc/misc/sbrk.c
@@ -24,6 +24,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <stdio.h>
+#include <syscall-template.h>
 
 /* Defined in brk.c.  */
 // This is the "virtual brk" exposed to the caller
@@ -41,39 +43,42 @@ extern void *__curbrk;
 void *
 __sbrk (intptr_t increment)
 {
-    __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
+	return MAKE_SYSCALL(176, "syscall|sbrk", (uint64_t) increment, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
+    // __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
     
-    // sbrk(0) returns the current memory size.
-    if (increment == 0) {
-        // The wasm spec doesn't guarantee that memory.grow of 0 always succeeds.
-        return __curbrk;
-    }
+    // // sbrk(0) returns the current memory size.
+    // if (increment == 0) {
+    //     // The wasm spec doesn't guarantee that memory.grow of 0 always succeeds.
+    //     return __curbrk;
+    // }
 
-    // FIXME: now two threads calling this sbrk simultaneously
-    // will lead to the corruption of __curbrk, so we should move
-    // this implementation into the runtime, and protect the __curbrk
-    // with mutex (i.e.  preventing two sbrk to be executed at the same time)
+    // // FIXME: now two threads calling this sbrk simultaneously
+    // // will lead to the corruption of __curbrk, so we should move
+    // // this implementation into the runtime, and protect the __curbrk
+    // // with mutex (i.e.  preventing two sbrk to be executed at the same time)
 
-    void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
-    void * old_break = __curbrk;
-    void * new_break = old_break + increment;
+    // void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
+    // void * old_break = __curbrk;
+    // void * new_break = old_break + increment;
 
-    if (new_break <= linear_mem_end) {
-        // In this case, we don't need to grow linear mem
-        __curbrk = new_break;
-        return old_break;
-    }
+    // if (new_break <= linear_mem_end) {
+    //     // In this case, we don't need to grow linear mem
+    //     __curbrk = new_break;
+    //     return old_break;
+    // }
 
-    // Now we need to grow linear mem
-    int new_pages = (new_break - linear_mem_end) / PAGESIZE;
+    // // Now we need to grow linear mem
+    // // int new_pages = (new_break - linear_mem_end) / PAGESIZE;
+    // int new_pages = (new_break - linear_mem_end + PAGESIZE - 1) / PAGESIZE;
 
-    if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
-        errno = ENOMEM;
-        return (void *)-1;
-    }
+	// MAKE_SYSCALL(176, "syscall|sbrk", (uint64_t) increment, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
+    // if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
+    //     errno = ENOMEM;
+    //     return (void *)-1;
+    // }
 
-    __curbrk = new_break;
-    return old_break;
+    // __curbrk = new_break;
+    // return old_break;
 }
 
 // void *

--- a/src/glibc/nptl/allocatestack.c
+++ b/src/glibc/nptl/allocatestack.c
@@ -324,6 +324,7 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
       size_t reported_guardsize;
       size_t reqsize;
       void *mem;
+      // lind-wasm: deleted PROT_EXEC since lind disallows PROT_EXEC mapping
       const int prot = (PROT_READ | PROT_WRITE);
 
       /* Adjust the stack size for alignment.  */
@@ -362,18 +363,8 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
 	  /* If a guard page is required, avoid committing memory by first
 	     allocate with PROT_NONE and then reserve with required permission
 	     excluding the guard page.  */
-      printf("size: %d\n", size);
 	  mem = __mmap (NULL, size, (guardsize == 0) ? prot : PROT_NONE,
 			MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-
-    // Replacement mmap with malloc - Dennis
-    // BUG: changed the malloc size to 16416 (1/4 of the original)
-    //     since currently there is an issue on malloc that it cannot
-    //     automatically grow the memory if memory is running out.
-    //     Once the issue is fixed, we might be able to change the size
-    //     back - Qianxi Chen
-    // size = 16416;
-    // void* mem = malloc(size);
 
     if (mem == NULL) {
         // Handle memory allocation failure
@@ -439,7 +430,7 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
 	  /* Don't allow setxid until cloned.  */
 	  pd->setxid_futex = -1;
 
-    // BUG: TLS related stuff is not working currently
+    // BUG: TLS related stuff is not working in lind-wasm currently
 	  /* Allocate the DTV for this thread.  */
 	  // if (_dl_allocate_tls (TLS_TPADJ (pd)) == NULL)
 	  //   {

--- a/src/glibc/nptl/allocatestack.c
+++ b/src/glibc/nptl/allocatestack.c
@@ -439,6 +439,7 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
 	  /* Don't allow setxid until cloned.  */
 	  pd->setxid_futex = -1;
 
+    // BUG: TLS related stuff is not working currently
 	  /* Allocate the DTV for this thread.  */
 	  // if (_dl_allocate_tls (TLS_TPADJ (pd)) == NULL)
 	  //   {

--- a/src/glibc/nptl/allocatestack.c
+++ b/src/glibc/nptl/allocatestack.c
@@ -324,8 +324,7 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
       size_t reported_guardsize;
       size_t reqsize;
       void *mem;
-      const int prot = (PROT_READ | PROT_WRITE
-			| ((GL(dl_stack_flags) & PF_X) ? PROT_EXEC : 0));
+      const int prot = (PROT_READ | PROT_WRITE);
 
       /* Adjust the stack size for alignment.  */
       size &= ~tls_static_align_m1;
@@ -363,8 +362,9 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
 	  /* If a guard page is required, avoid committing memory by first
 	     allocate with PROT_NONE and then reserve with required permission
 	     excluding the guard page.  */
-	  // mem = __mmap (NULL, size, (guardsize == 0) ? prot : PROT_NONE,
-		// 	MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+      printf("size: %d\n", size);
+	  mem = __mmap (NULL, size, (guardsize == 0) ? prot : PROT_NONE,
+			MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 
     // Replacement mmap with malloc - Dennis
     // BUG: changed the malloc size to 16416 (1/4 of the original)
@@ -372,8 +372,8 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
     //     automatically grow the memory if memory is running out.
     //     Once the issue is fixed, we might be able to change the size
     //     back - Qianxi Chen
-    size = 16416;
-    void* mem = malloc(size);
+    // size = 16416;
+    // void* mem = malloc(size);
 
     if (mem == NULL) {
         // Handle memory allocation failure
@@ -440,16 +440,16 @@ allocate_stack (const struct pthread_attr *attr, struct pthread **pdp,
 	  pd->setxid_futex = -1;
 
 	  /* Allocate the DTV for this thread.  */
-	  if (_dl_allocate_tls (TLS_TPADJ (pd)) == NULL)
-	    {
-	      /* Something went wrong.  */
-	      assert (errno == ENOMEM);
+	  // if (_dl_allocate_tls (TLS_TPADJ (pd)) == NULL)
+	  //   {
+	  //     /* Something went wrong.  */
+	  //     assert (errno == ENOMEM);
 
-	      /* Free the stack memory we just allocated.  */
-	      (void) __munmap (mem, size);
+	  //     /* Free the stack memory we just allocated.  */
+	  //     (void) __munmap (mem, size);
 
-	      return errno;
-	    }
+	  //     return errno;
+	  //   }
 
 
 	  /* Prepare to modify global data.  */

--- a/src/glibc/nptl/pthread_create.c
+++ b/src/glibc/nptl/pthread_create.c
@@ -342,7 +342,6 @@ static int create_thread (struct pthread *pd, const struct pthread_attr *attr,
 
   unsigned char *stack = 0;
 
-  printf("stacksize: %d\n", stacksize);
   struct clone_args *args = (void *)pd->stackblock + pd->stackblock_size - sizeof(struct clone_args) - TLS_TCB_SIZE;
   memset(args, 0, sizeof(struct clone_args));
   args->flags = clone_flags;

--- a/src/glibc/nptl/pthread_create.c
+++ b/src/glibc/nptl/pthread_create.c
@@ -342,12 +342,13 @@ static int create_thread (struct pthread *pd, const struct pthread_attr *attr,
 
   unsigned char *stack = 0;
 
+  printf("stacksize: %d\n", stacksize);
   struct clone_args *args = (void *)pd->stackblock + pd->stackblock_size - sizeof(struct clone_args) - TLS_TCB_SIZE;
   memset(args, 0, sizeof(struct clone_args));
   args->flags = clone_flags;
   args->stack = stackaddr;
   args->stack = stackaddr + pd->stackblock_size - sizeof(struct clone_args) - TLS_TCB_SIZE;
-  args->stack_size = 16416 - sizeof(struct clone_args) - TLS_TCB_SIZE;
+  args->stack_size = stacksize - sizeof(struct clone_args) - TLS_TCB_SIZE;
   args->child_tid = &pd->tid;
 
   int ret = __clone_internal(args, &start_thread, pd);

--- a/src/glibc/sysdeps/unix/sysv/linux/brk.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/brk.c
@@ -41,32 +41,5 @@ int
 __brk (void *addr)
 {
 	return MAKE_SYSCALL(175, "syscall|brk", (uint64_t) addr, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
-//   __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
-
-//     // FIXME: now two threads calling this sbrk simultaneously
-//     // will lead to the corruption of __curbrk, so we should move
-//     // this implementation into the runtime, and protect the __curbrk
-//     // with mutex (i.e.  preventing two brk/sbrk to be executed at the same time)
-
-//     void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
-//     void * old_break = __curbrk;
-//     void * new_break = addr;
-
-//     if (new_break <= linear_mem_end) {
-//         // In this case, we don't need to grow linear mem
-//         __curbrk = new_break;
-//         return old_break;
-//     }
-
-//     // Now we need to grow linear mem
-//     int new_pages = (new_break - linear_mem_end) / PAGESIZE;
-
-//     if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
-//         errno = ENOMEM;
-//         return (void *)-1;
-//     }
-
-//     __curbrk = new_break;
-//     return old_break;
 }
 weak_alias (__brk, brk)

--- a/src/glibc/sysdeps/unix/sysv/linux/brk.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/brk.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <sysdep.h>
 #include <brk_call.h>
+#include <syscall-template.h>
 
 /* This must be initialized data because commons can't have aliases.  */
 // This is the "virtual brk" exposed to the caller
@@ -39,32 +40,33 @@ weak_alias (__curbrk, ___brk_addr)
 int
 __brk (void *addr)
 {
-  __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
+	return MAKE_SYSCALL(175, "syscall|brk", (uint64_t) addr, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED);
+//   __curbrk = __builtin_wasm_memory_size(0) * PAGESIZE;
 
-    // FIXME: now two threads calling this sbrk simultaneously
-    // will lead to the corruption of __curbrk, so we should move
-    // this implementation into the runtime, and protect the __curbrk
-    // with mutex (i.e.  preventing two brk/sbrk to be executed at the same time)
+//     // FIXME: now two threads calling this sbrk simultaneously
+//     // will lead to the corruption of __curbrk, so we should move
+//     // this implementation into the runtime, and protect the __curbrk
+//     // with mutex (i.e.  preventing two brk/sbrk to be executed at the same time)
 
-    void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
-    void * old_break = __curbrk;
-    void * new_break = addr;
+//     void * linear_mem_end = __builtin_wasm_memory_size(0) * PAGESIZE;
+//     void * old_break = __curbrk;
+//     void * new_break = addr;
 
-    if (new_break <= linear_mem_end) {
-        // In this case, we don't need to grow linear mem
-        __curbrk = new_break;
-        return old_break;
-    }
+//     if (new_break <= linear_mem_end) {
+//         // In this case, we don't need to grow linear mem
+//         __curbrk = new_break;
+//         return old_break;
+//     }
 
-    // Now we need to grow linear mem
-    int new_pages = (new_break - linear_mem_end) / PAGESIZE;
+//     // Now we need to grow linear mem
+//     int new_pages = (new_break - linear_mem_end) / PAGESIZE;
 
-    if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
-        errno = ENOMEM;
-        return (void *)-1;
-    }
+//     if (__builtin_wasm_memory_grow(0, new_pages) < 0) {
+//         errno = ENOMEM;
+//         return (void *)-1;
+//     }
 
-    __curbrk = new_break;
-    return old_break;
+//     __curbrk = new_break;
+//     return old_break;
 }
 weak_alias (__brk, brk)

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -74,13 +74,13 @@ impl LindCommonCtx {
 
     // setjmp call. This function needs to be handled within wasmtime, but it is not an actual syscall so we use a different routine from lind_syscall
     pub fn lind_setjmp<T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + std::marker::Sync>
-                        (&self, caller: &mut Caller<'_, T>, jmp_buf: i32) -> i32 {
+                        (&self, caller: &mut Caller<'_, T>, jmp_buf: u32) -> i32 {
         wasmtime_lind_multi_process::setjmp_call(caller, jmp_buf)
     }
 
     // longjmp call. This function needs to be handled within wasmtime, but it is not an actual syscall so we use a different routine from lind_syscall
     pub fn lind_longjmp<T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + std::marker::Sync>
-                        (&self, caller: &mut Caller<'_, T>, jmp_buf: i32, retval: i32) -> i32 {
+                        (&self, caller: &mut Caller<'_, T>, jmp_buf: u32, retval: i32) -> i32 {
         wasmtime_lind_multi_process::longjmp_call(caller, jmp_buf, retval)
     }
 
@@ -144,7 +144,7 @@ pub fn add_to_linker<T: LindHost<T, U> + Clone + Send + 'static + std::marker::S
             let host = caller.data().clone();
             let ctx = get_cx(&host);
             
-            ctx.lind_setjmp(&mut caller, jmp_buf)
+            ctx.lind_setjmp(&mut caller, jmp_buf as u32)
         },
     )?;
 
@@ -156,7 +156,7 @@ pub fn add_to_linker<T: LindHost<T, U> + Clone + Send + 'static + std::marker::S
             let host = caller.data().clone();
             let ctx = get_cx(&host);
 
-            ctx.lind_longjmp(&mut caller, jmp_buf, retval)
+            ctx.lind_longjmp(&mut caller, jmp_buf as u32, retval)
         },
     )?;
 

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -329,20 +329,6 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                         parent_pid: parent_pid as u64, child_pid: child_cageid
                     }).unwrap();
 
-                // copy the entire memory from parent, note that the unwind data is also copied together
-                // with the memory
-                // let child_address: *mut u8;
-
-                // // get the base address of the memory
-                // {
-                //     let handle = store.inner_mut().instance(InstanceId::from_index(0));
-                //     let defined_memory = handle.get_memory(MemoryIndex::from_u32(0));
-                //     child_address = defined_memory.base;
-                // }
-                
-                // rawposix::safeposix::dispatcher::set_base_address(child_cageid, child_address as i64);
-                // rawposix::safeposix::dispatcher::fork_vmmap_helper(parent_pid as u64, child_cageid);
-
                 // new cage created, increment the cage counter
                 lind_manager.increment();
                 // create the cage in rustposix via rustposix fork
@@ -456,7 +442,6 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
     pub fn pthread_create_call(&self, mut caller: &mut Caller<'_, T>,
                     stack_addr: i32, stack_size: i32, child_tid: u64
                 ) -> Result<i32> {
-        println!("-----stack_addr: {}, stack_size: {}", stack_addr, stack_size);
         // get the base address of the memory
         let handle = caller.as_context().0.instance(InstanceId::from_index(0));
         let defined_memory = handle.get_memory(MemoryIndex::from_u32(0));
@@ -1062,7 +1047,6 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                 if m.is_shared() {
                     // define a new shared memory for the child
                     let mut plan = m.clone();
-                    // plan.set_minimum((size as u64).div_ceil(m.page_size()));
 
                     let mem = SharedMemory::new(self.module.engine(), plan.clone()).unwrap();
                     self.linker.define_with_inner(store, import.module(), import.name(), mem.clone()).unwrap();

--- a/src/wasmtime/crates/wasmtime/Cargo.toml
+++ b/src/wasmtime/crates/wasmtime/Cargo.toml
@@ -60,6 +60,7 @@ hashbrown = { workspace = true }
 libm = "0.2.7"
 bitflags = { workspace = true }
 rawposix = { path = "../rawposix" }
+wasmtime-lind-utils = { path = "../lind-utils" }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/src/wasmtime/crates/wasmtime/Cargo.toml
+++ b/src/wasmtime/crates/wasmtime/Cargo.toml
@@ -59,6 +59,7 @@ smallvec = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 libm = "0.2.7"
 bitflags = { workspace = true }
+rawposix = { path = "../rawposix" }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/src/wasmtime/crates/wasmtime/src/runtime.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime.rs
@@ -42,7 +42,7 @@ pub use code_memory::CodeMemory;
 pub use externals::*;
 pub use func::*;
 pub use gc::*;
-pub use instance::{Instance, InstancePre};
+pub use instance::{Instance, InstancePre, InstantiateType};
 pub use instantiate::CompiledModule;
 pub use limits::*;
 pub use linker::*;

--- a/src/wasmtime/crates/wasmtime/src/runtime/func.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/func.rs
@@ -2123,7 +2123,7 @@ impl<T> Caller<'_, T> {
             .get_export(&mut self.store, name)
     }
 
-    pub fn get_stack_pointer(&mut self) -> Result<i32, ()> {
+    pub fn get_stack_pointer(&mut self) -> Result<u32, ()> {
         self.caller
             .host_state()
             .downcast_ref::<Instance>().ok_or(()).unwrap()

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -13,6 +13,7 @@ use crate::{
 use alloc::sync::Arc;
 use rawposix::constants::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PAGESHIFT, PROT_READ, PROT_WRITE};
 use rawposix::safeposix::dispatcher::lind_syscall_api;
+use wasmtime_lind_utils::lind_syscall_numbers::MMAP_SYSCALL;
 use core::ptr::NonNull;
 use wasmparser::WasmFeatures;
 use wasmtime_environ::{
@@ -247,7 +248,7 @@ impl Instance {
 
                 lind_syscall_api(
                     pid,
-                    21,
+                    MMAP_SYSCALL as u32,
                     0,
                     memory_base as u64,
                     0, // the first memory region starts from 0

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -11,6 +11,8 @@ use crate::{
     StoreContext, StoreContextMut, Table, TypedFunc,
 };
 use alloc::sync::Arc;
+use rawposix::constants::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PAGESHIFT, PROT_READ, PROT_WRITE};
+use rawposix::safeposix::dispatcher::lind_syscall_api;
 use core::ptr::NonNull;
 use wasmparser::WasmFeatures;
 use wasmtime_environ::{
@@ -18,6 +20,14 @@ use wasmtime_environ::{
 };
 
 use super::Val;
+
+pub enum InstantiateType {
+    InstantiateFirst(u64),
+    InstantiateChild {
+        parent_pid: u64,
+        child_pid: u64,
+    },
+}
 
 /// An instantiated WebAssembly module.
 ///
@@ -206,6 +216,66 @@ impl Instance {
         imports: Imports<'_>,
     ) -> Result<Instance> {
         let (instance, start) = Instance::new_raw(store.0, module, imports)?;
+
+        if let Some(start) = start {
+            instance.start_raw(store, start)?;
+        }
+        Ok(instance)
+    }
+
+    pub(crate) unsafe fn new_started_impl_with_lind<T>(
+        store: &mut StoreContextMut<'_, T>,
+        module: &Module,
+        imports: Imports<'_>,
+        instantiate_type: InstantiateType,
+    ) -> Result<Instance> {
+        let (instance, start) = Instance::new_raw(store.0, module, imports)?;
+
+        // initialize the memory
+        // the memory initialization should happen inside microvisor, so we should discard the original
+        // memory init in wasmtime and do our own initialization here
+        match instantiate_type {
+            // InstantiateFirst: this is the first wasm instance
+            InstantiateType::InstantiateFirst(pid) => {
+                // if this is the first wasm instance, we need to
+                // 1. set memory base address
+                // 2. manually call mmap_syscall to set up the first memory region
+                let handle = store.0.instance(InstanceId::from_index(0));
+                let defined_memory = handle.get_memory(wasmtime_environ::MemoryIndex::from_u32(0));
+                let memory_base = defined_memory.base as usize;
+                rawposix::safeposix::dispatcher::init_vmmap_helper(pid, memory_base, Some(0x30));
+
+                lind_syscall_api(
+                    pid,
+                    21,
+                    0,
+                    memory_base as u64,
+                    0, // the first memory region starts from 0
+                    0x30 << PAGESHIFT, // we allocate 0x30 pages for the first memory region, which is the default value in wasmtime
+                    (PROT_READ | PROT_WRITE) as u64,
+                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED) as u64,
+                    // we need to pass -1 here, but since lind_syscall_api only accepts u64
+                    // and rust does not directly allow things like -1 as u64, so we end up with this weird thing
+                    (0 - 1) as u64,
+                    0,
+                );
+            },
+            // InstantiateChild: this is the child wasm instance forked by parent
+            InstantiateType::InstantiateChild { parent_pid, child_pid } => {
+                // if this is a child, we do not need to specifically set up the first memory region
+                // since this should be taken care of when we fork the entire memory region from parent
+                // therefore in this case, we only need to:
+                // 1. set memory base address
+                // 2. fork the memory space from parent
+                let handle = store.0.instance(InstanceId::from_index(0));
+                let defined_memory = handle.get_memory(wasmtime_environ::MemoryIndex::from_u32(0));
+                let child_address = defined_memory.base as usize;
+            
+                rawposix::safeposix::dispatcher::init_vmmap_helper(child_pid, child_address, None);
+                rawposix::safeposix::dispatcher::fork_vmmap_helper(parent_pid as u64, child_pid);
+            }
+        }
+
         if let Some(start) = start {
             instance.start_raw(store, start)?;
         }
@@ -922,6 +992,22 @@ impl<T> InstancePre<T> {
         // constructor of `InstancePre` to assert that all the imports we're passing
         // in match the module we're instantiating.
         unsafe { Instance::new_started(&mut store, &self.module, imports.as_ref()) }
+    }
+
+    pub fn instantiate_with_lind(&self, mut store: impl AsContextMut<Data = T>, instantiate_type: InstantiateType) -> Result<Instance> {
+        let mut store = store.as_context_mut();
+        let imports = pre_instantiate_raw(
+            &mut store.0,
+            &self.module,
+            &self.items,
+            self.host_funcs,
+            &self.func_refs,
+        )?;
+
+        // This unsafety should be handled by the type-checking performed by the
+        // constructor of `InstancePre` to assert that all the imports we're passing
+        // in match the module we're instantiating.
+        unsafe { Instance::new_started_impl_with_lind(&mut store, &self.module, imports.as_ref(), instantiate_type) }
     }
 
     /// Creates a new instance, running the start function asynchronously

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -525,13 +525,13 @@ impl Instance {
         self._get_export(store, entity, export_name_index)
     }
 
-    pub fn get_stack_pointer(&self, mut store: impl AsContextMut) -> Result<i32, ()> {
+    pub fn get_stack_pointer(&self, mut store: impl AsContextMut) -> Result<u32, ()> {
         if let Some(sp_extern) = self.get_export(store.as_context_mut(), "__stack_pointer") {
             match sp_extern {
                 Extern::Global(sp) => {
                     match sp.get(store.as_context_mut()) {
                         Val::I32(val) => {
-                            return Ok(val);
+                            return Ok(val as u32);
                         }
                         _ => {
                             // unexpected stack pointer type (not i32)

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -17,6 +17,7 @@ use hashbrown::hash_map::{Entry, HashMap};
 use log::warn;
 
 use super::store::StoreInner;
+use super::InstantiateType;
 
 /// Structure used to link wasm modules/instances together.
 ///
@@ -1125,6 +1126,16 @@ impl<T> Linker<T> {
     ) -> Result<Instance> {
         self._instantiate_pre(module, Some(store.as_context_mut().0))?
             .instantiate(store)
+    }
+
+    pub fn instantiate_with_lind(
+        &self,
+        mut store: impl AsContextMut<Data = T>,
+        module: &Module,
+        instantiate_type: InstantiateType,
+    ) -> Result<Instance> {
+        self._instantiate_pre(module, Some(store.as_context_mut().0))?
+            .instantiate_with_lind(store, instantiate_type)
     }
 
     /// Attempts to instantiate the `module` provided. This is the same as

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
@@ -84,6 +84,7 @@ pub trait RuntimeLinearMemory: Send + Sync {
         delta_pages: u64,
         mut store: Option<&mut dyn Store>,
     ) -> Result<Option<(usize, usize)>, Error> {
+        println!("memory grow: {}", delta_pages);
         let old_byte_size = self.byte_size();
 
         // Wasm spec: when growing by 0 pages, always return the current size.
@@ -221,6 +222,8 @@ impl MmapMemory {
         mut maximum: Option<usize>,
         memory_image: Option<&Arc<MemoryImage>>,
     ) -> Result<Self> {
+        println!("-----minimum: {}, maximum: {:?}", minimum, maximum);
+        maximum = Some(2147483648);
         // It's a programmer error for these two configuration values to exceed
         // the host available address space, so panic if such a configuration is
         // found (mostly an issue for hypothetical 32-bit hosts).
@@ -325,6 +328,7 @@ impl RuntimeLinearMemory for MmapMemory {
     }
 
     fn grow_to(&mut self, new_size: usize) -> Result<()> {
+        println!("-----grow to {}", new_size);
         assert!(usize_is_multiple_of_host_page_size(self.offset_guard_size));
         assert!(usize_is_multiple_of_host_page_size(self.pre_guard_size));
         assert!(usize_is_multiple_of_host_page_size(self.mmap.len()));

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
@@ -84,7 +84,6 @@ pub trait RuntimeLinearMemory: Send + Sync {
         delta_pages: u64,
         mut store: Option<&mut dyn Store>,
     ) -> Result<Option<(usize, usize)>, Error> {
-        println!("memory grow: {}", delta_pages);
         let old_byte_size = self.byte_size();
 
         // Wasm spec: when growing by 0 pages, always return the current size.
@@ -222,8 +221,8 @@ impl MmapMemory {
         mut maximum: Option<usize>,
         memory_image: Option<&Arc<MemoryImage>>,
     ) -> Result<Self> {
-        println!("-----minimum: {}, maximum: {:?}", minimum, maximum);
-        maximum = Some(4294967296);
+        // lind-wasm: we enable maximum use of memory at start
+        maximum = Some(1 << 32);
         // It's a programmer error for these two configuration values to exceed
         // the host available address space, so panic if such a configuration is
         // found (mostly an issue for hypothetical 32-bit hosts).
@@ -328,7 +327,6 @@ impl RuntimeLinearMemory for MmapMemory {
     }
 
     fn grow_to(&mut self, new_size: usize) -> Result<()> {
-        println!("-----grow to {}", new_size);
         assert!(usize_is_multiple_of_host_page_size(self.offset_guard_size));
         assert!(usize_is_multiple_of_host_page_size(self.pre_guard_size));
         assert!(usize_is_multiple_of_host_page_size(self.mmap.len()));

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/memory.rs
@@ -223,7 +223,7 @@ impl MmapMemory {
         memory_image: Option<&Arc<MemoryImage>>,
     ) -> Result<Self> {
         println!("-----minimum: {}, maximum: {:?}", minimum, maximum);
-        maximum = Some(2147483648);
+        maximum = Some(4294967296);
         // It's a programmer error for these two configuration values to exceed
         // the host available address space, so panic if such a configuration is
         // found (mostly an issue for hypothetical 32-bit hosts).

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -100,7 +100,7 @@ impl Mmap {
         assert!(start <= self.len() - len);
 
         // lind-wasm: mmap prot is managed by rawposix
-        // self.sys.make_accessible(start, len)
+        // so we are skipping wasmtime's sys mmap here
         Ok(())
     }
 

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/mmap.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/mmap.rs
@@ -99,7 +99,9 @@ impl Mmap {
         assert!(len <= self.len());
         assert!(start <= self.len() - len);
 
-        self.sys.make_accessible(start, len)
+        // lind-wasm: mmap prot is managed by rawposix
+        // self.sys.make_accessible(start, len)
+        Ok(())
     }
 
     /// Return the allocated memory as a slice of u8.

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -31,11 +31,12 @@ struct SharedMemoryInner {
 impl SharedMemory {
     /// Construct a new [`SharedMemory`].
     pub fn new(plan: MemoryPlan) -> Result<Self> {
-        println!("-----create new memory!");
         let (minimum_bytes, maximum_bytes) = Memory::limit_new(&plan, None)?;
         let mut mmap_memory = MmapMemory::new(&plan, minimum_bytes, maximum_bytes, None)?;
-        if minimum_bytes < 4294967296 {
-            mmap_memory.grow_to(4294967296);
+        // lind-wasm: we enable maximum use of memory at start
+        let max_size = 1 << 32;
+        if minimum_bytes < max_size {
+            mmap_memory.grow_to(max_size);
         }
         Self::wrap(&plan, Box::new(mmap_memory), plan.memory)
     }

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -31,8 +31,10 @@ struct SharedMemoryInner {
 impl SharedMemory {
     /// Construct a new [`SharedMemory`].
     pub fn new(plan: MemoryPlan) -> Result<Self> {
+        println!("-----create new memory!");
         let (minimum_bytes, maximum_bytes) = Memory::limit_new(&plan, None)?;
-        let mmap_memory = MmapMemory::new(&plan, minimum_bytes, maximum_bytes, None)?;
+        let mut mmap_memory = MmapMemory::new(&plan, minimum_bytes, maximum_bytes, None)?;
+        mmap_memory.grow_to(2147483648);
         Self::wrap(&plan, Box::new(mmap_memory), plan.memory)
     }
 

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/threads/shared_memory.rs
@@ -34,7 +34,9 @@ impl SharedMemory {
         println!("-----create new memory!");
         let (minimum_bytes, maximum_bytes) = Memory::limit_new(&plan, None)?;
         let mut mmap_memory = MmapMemory::new(&plan, minimum_bytes, maximum_bytes, None)?;
-        mmap_memory.grow_to(2147483648);
+        if minimum_bytes < 4294967296 {
+            mmap_memory.grow_to(4294967296);
+        }
         Self::wrap(&plan, Box::new(mmap_memory), plan.memory)
     }
 

--- a/tests/unit-tests/memory_tests/deterministic/malloc_large.c
+++ b/tests/unit-tests/memory_tests/deterministic/malloc_large.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
+int main() {
+    // try with extremely large malloc
+    char *buf = malloc(0x10000000);
+
+    *buf = 42;
+    printf("%p: %d\n", buf, *buf);
+
+    return 0;
+}

--- a/tests/unit-tests/memory_tests/deterministic/mmap_complicated.c
+++ b/tests/unit-tests/memory_tests/deterministic/mmap_complicated.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+int main() {
+    // Define the size of the shared memory
+    size_t mem_size = 1024;
+
+    // Create shared memory region using mmap
+    char *shared_mem = (char*)mmap(NULL, mem_size, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (shared_mem == MAP_FAILED) {
+        perror("mmap");
+        exit(EXIT_FAILURE);
+    }
+
+    // Fork a child process
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        munmap(shared_mem, mem_size);
+        exit(EXIT_FAILURE);
+    }
+
+    if (pid == 0) {
+        // Child process
+        printf("Child: Writing to shared memory.\n");
+        const char *child_message = "Hello from the child process!";
+        strncpy(shared_mem, child_message, mem_size);
+
+        // Sleep to simulate some work
+        sleep(2);
+
+        printf("Child: Reading from shared memory: '%s'\n", shared_mem);
+
+        // Unmap shared memory in the child
+        if (munmap(shared_mem, mem_size) != 0) {
+            perror("munmap in child");
+            exit(EXIT_FAILURE);
+        }
+
+        printf("Child: Exiting.\n");
+    } else {
+        // Parent process
+        printf("Parent: Waiting for child to write.\n");
+
+        // Sleep to simulate waiting for the child
+        sleep(1);
+
+        printf("Parent: Reading from shared memory: '%s'\n", shared_mem);
+
+        const char *parent_message = "Hello from the parent process!";
+        strncpy(shared_mem, parent_message, mem_size);
+
+        // Wait for the child to finish
+        wait(NULL);
+
+        printf("Parent: Reading modified shared memory: '%s'\n", shared_mem);
+
+        // Unmap shared memory in the parent
+        if (munmap(shared_mem, mem_size) != 0) {
+            perror("munmap in parent");
+            exit(EXIT_FAILURE);
+        }
+
+        printf("Parent: Exiting.\n");
+    }
+
+    return 0;
+}

--- a/tests/unit-tests/memory_tests/deterministic/mmap_file.c
+++ b/tests/unit-tests/memory_tests/deterministic/mmap_file.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+
+#define FILE_PATH "example.txt"
+#define FILE_SIZE 4096
+
+int main() {
+    // Create or open a file
+    int fd = open(FILE_PATH, O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+        perror("open");
+        exit(EXIT_FAILURE);
+    }
+
+    // Ensure the file has the desired size
+    if (ftruncate(fd, FILE_SIZE) == -1) {
+        perror("ftruncate");
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    // Map the file into memory
+    void* addr = mmap(NULL, FILE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (addr == MAP_FAILED) {
+        perror("mmap");
+        close(fd);
+        exit(EXIT_FAILURE);
+    }
+
+    // Close the file descriptor as it's no longer needed
+    close(fd);
+
+    // Write data to the mapped memory
+    const char* message = "Hello, mmap!\0";
+    memcpy(addr, message, strlen(message));
+
+    printf("Data written to memory-mapped file: %s\n", (char*)addr);
+
+    // Read back the data from the mapped memory
+    printf("Data read back from memory-mapped file: %s\n", (char*)addr);
+
+    // Unmap the memory
+    if (munmap(addr, FILE_SIZE) == -1) {
+        perror("munmap");
+        exit(EXIT_FAILURE);
+    }
+
+    return 0;
+}

--- a/tests/unit-tests/memory_tests/deterministic/mmap_shared.c
+++ b/tests/unit-tests/memory_tests/deterministic/mmap_shared.c
@@ -1,0 +1,43 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+
+int main() {
+    int *addr1 = mmap(NULL, 10, PROT_READ | PROT_WRITE,
+                      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    int *addr2 = mmap(NULL, 10, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    
+    if(addr1 < 0)
+    {
+        perror("mmap");
+        exit(1);
+    }
+
+    if(addr2 < 0)
+    {
+        perror("mmap");
+        exit(1);
+    }
+
+    *addr1 = 1234;
+    *addr2 = 4321;
+    printf("parent value: %d, %d\n", *addr1, *addr2);
+
+    if(fork()) {
+        // parent
+        printf("parent value after fork: %d, %d\n", *addr1, *addr2);
+        sleep(1);
+        *addr1 = 2333;
+        *addr2 = 3332;
+        printf("parent value after modification: %d, %d\n", *addr1, *addr2);
+    } else {
+        // child
+        printf("child value after fork: %d, %d\n", *addr1, *addr2);
+        sleep(2);
+        printf("child value after modification: %d, %d\n", *addr1, *addr2);
+    }
+
+    return 0;
+}

--- a/tests/unit-tests/memory_tests/deterministic/sbrk.c
+++ b/tests/unit-tests/memory_tests/deterministic/sbrk.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+
+int main() {
+    // Allocate memory using sbrk
+    size_t size = 1024; // Allocate 1024 bytes
+    void *initial_brk = sbrk(0); // Get the current program break
+    void *new_brk = sbrk(size);  // Increment the program break
+
+    if (new_brk == (void *)-1) {
+        perror("sbrk failed");
+        return 1;
+    }
+
+    printf("Initial program break: %p\n", initial_brk);
+    printf("New program break after allocation: %p\n", sbrk(0));
+
+    // Use the allocated memory
+    char *buffer = (char *)new_brk;
+    strcpy(buffer, "Hello, sbrk memory!");
+    printf("Content in allocated memory: %s\n", buffer);
+
+    // Deallocate memory by moving the program break back
+    if (sbrk(-size) == (void *)-1) {
+        perror("sbrk failed to deallocate");
+        return 1;
+    }
+
+    printf("Program break after deallocation: %p\n", sbrk(0));
+
+    return 0;
+}


### PR DESCRIPTION
This PR finalized the implementation of mmap/munmap/sbrk/brk.

- On rawposix side, the changes are mainly
    1. Finishing the remaining program break implementation and file backed mmap feature
    2. Minor changes in vmmap to allow the pre-specified start and end address when find map space
    3. Minor adjustment on the vmmap initialization functions invoked from wasmtime.

- On wasmtime side, the changes are mainly about bypassing part of wasmtime's internal memory management logic, including:
    1. Disabled wasmtime's sys mmap function, as this is handled by rawposix right now.
    2. Have wasmtime always creating a length of 4294967296 bytes of accessible region, so that some of the wasm's instruction handled by wasmtime will not be rejected due to memory address.
    3. Restructured memory initialization code interacted with rawposix.

- On glibc side, the changes are mainly about
    1. Modified glibc's entry point of sbrk/brk syscall so that it directs to rawposix
    2. Revert pthread's memory allocation from malloc (old solution when mmap hasn't been implemented) to mmap.
    3. Modified `lind_syscall.c` to special handle mmap result. Since mmap is returning a 32-bit address, which might overflow `int` type and become negative, we need to distinguish the valid memory address from errno as errno are also returned as negative number from rawposix. This is achieved by checking the range of the negative value since mmap result is always multiple of pages (4096), while errno has a maximum value that is far less than 4096.