### PR TITLE
Fix close kernel: disable closing host streams

### DIFF
--- a/src/RawPOSIX/src/safeposix/dispatcher.rs
+++ b/src/RawPOSIX/src/safeposix/dispatcher.rs
@@ -1148,19 +1148,27 @@ pub fn lindrustinit(verbosity: isize) {
     interface::cagetable_insert(0, utilcage);
     fdtables::init_empty_cage(0);
     // Set the first 3 fd to STDIN / STDOUT / STDERR
-    // STDIN
-    let dev_null = CString::new("/home/lind/lind_project/src/safeposix-rust/tmp/dev/null").unwrap();
+    // TODO:
+    // Replace the hardcoded values with variables (possibly by adding a LIND-specific constants file)
+    let dev_null = CString::new("/home/lind-wasm/src/RawPOSIX/tmp/dev/null").unwrap();
+
+    // Make sure that the standard file descriptor (stdin, stdout, stderr) is always valid, even if they 
+    // are closed before.
+    // Standard input (fd = 0) is redirected to /dev/null
+    // Standard output (fd = 1) is redirected to /dev/null
+    // Standard error (fd = 2) is set to copy of stdout
     unsafe {
         libc::open(dev_null.as_ptr(), libc::O_RDONLY);
         libc::open(dev_null.as_ptr(), libc::O_WRONLY);
         libc::dup(1);
     }
     
-    fdtables::get_specific_virtual_fd(0, 0, FDKIND_KERNEL, 0, false, 0).unwrap();
+    // STDIN
+    fdtables::get_specific_virtual_fd(0, STDIN_FILENO as u64, FDKIND_KERNEL, STDIN_FILENO as u64, false, 0).unwrap();
     // STDOUT
-    fdtables::get_specific_virtual_fd(0, 1, FDKIND_KERNEL, 1, false, 0).unwrap();
+    fdtables::get_specific_virtual_fd(0, STDOUT_FILENO as u64, FDKIND_KERNEL, STDOUT_FILENO as u64, false, 0).unwrap();
     // STDERR
-    fdtables::get_specific_virtual_fd(0, 2, FDKIND_KERNEL, 2, false, 0).unwrap();
+    fdtables::get_specific_virtual_fd(0, STDERR_FILENO as u64, FDKIND_KERNEL, STDERR_FILENO as u64, false, 0).unwrap();
 
     //init cage is its own parent
     let initcage = Cage {
@@ -1188,11 +1196,11 @@ pub fn lindrustinit(verbosity: isize) {
     fdtables::init_empty_cage(1);
     // Set the first 3 fd to STDIN / STDOUT / STDERR
     // STDIN
-    fdtables::get_specific_virtual_fd(1, 0, FDKIND_KERNEL, 0, false, 0).unwrap();
+    fdtables::get_specific_virtual_fd(1, STDIN_FILENO as u64, FDKIND_KERNEL, STDIN_FILENO as u64, false, 0).unwrap();
     // STDOUT
-    fdtables::get_specific_virtual_fd(1, 1, FDKIND_KERNEL, 1, false, 0).unwrap();
+    fdtables::get_specific_virtual_fd(1, STDOUT_FILENO as u64, FDKIND_KERNEL, STDOUT_FILENO as u64, false, 0).unwrap();
     // STDERR
-    fdtables::get_specific_virtual_fd(1, 2, FDKIND_KERNEL, 2, false, 0).unwrap();
+    fdtables::get_specific_virtual_fd(1, STDERR_FILENO as u64, FDKIND_KERNEL, STDERR_FILENO as u64, false, 0).unwrap();
 
 }
 

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -1903,8 +1903,20 @@ impl Cage {
     }
 }
 
+/// Lind-WASM is running as same Linux-Process from host kernel perspective, so standard fds shouldn't 
+/// be closed in Lind-WASM execution, which preventing issues where other threads might reassign these 
+/// fds, causing unintended behavior or errors. 
 pub fn kernel_close(fdentry: fdtables::FDTableEntry, _count: u64) {
-    let _ret = unsafe {
+    let kernel_fd = fdentry.underfd as i32;
+    if kernel_fd == STDIN_FILENO || kernel_fd == STDOUT_FILENO || kernel_fd == STDERR_FILENO {
+        return;
+    }
+
+    let ret = unsafe {
         libc::close(fdentry.underfd as i32)
     };
+    if ret < 0 {
+        let errno = get_errno();
+        panic!("kernel_close failed with errno: {:?}", errno);
+    }
 }

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -1908,7 +1908,12 @@ impl Cage {
 /// fds, causing unintended behavior or errors. 
 pub fn kernel_close(fdentry: fdtables::FDTableEntry, _count: u64) {
     let kernel_fd = fdentry.underfd as i32;
-    if kernel_fd == STDIN_FILENO || kernel_fd == STDOUT_FILENO || kernel_fd == STDERR_FILENO {
+
+    // TODO:
+    // Need to update once we merge with vmmap-alice
+    if kernel_fd == fs_constants::STDIN_FILENO 
+        || kernel_fd == fs_constants::STDOUT_FILENO 
+        || kernel_fd == fs_constants::STDERR_FILENO {
         return;
     }
 

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_constants.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_constants.rs
@@ -4,6 +4,13 @@
 
 use crate::interface;
 
+/// TODO:
+/// This is a temporary location for those three constants. Need to move after 
+/// merging with vmmap-alice
+pub const STDIN_FILENO: i32 = 0;    // File descriptor for standard input
+pub const STDOUT_FILENO: i32 = 1;   // File descriptor for standard output
+pub const STDERR_FILENO: i32 = 2;   // File descriptor for standard error
+
 // Define constants using static or const
 // Imported into fs_calls file
 // pub const DT_UNKNOWN: u8 = 0;


### PR DESCRIPTION
## Description

This PR addresses an issue encountered during the execution of the vmmap inner tests (reported by @ChinmayShringi). The test failures were caused by incorrect re-initialization of standard streams (stdin, stdout, stderr) in the cage setup during concurrent test execution in a multi-threaded cargo test environment, where the handling of standard file descriptors affected the test stability.

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

In fact, the test cases have all successfully executed (as evidenced by checking /tmp, where the corresponding test files are successfully created), so the issue is related to the inability to print out information. Since cargo test runs in a single process with multi-threading, theoretically, even after `kernel_close` closes stdin, stdout, and stderr, they should be re-initialized in the next cage setup (inside [`lindrustinit`](https://github.com/Lind-Project/lind-wasm/blob/main/src/RawPOSIX/src/safeposix/dispatcher.rs#L1119)). However, during `cargo test`, the failure might be caused by fd positions being occupied by other test threads (e.g., when a new test thread opens a test file), resulting in the cage initialization failing to reopen the host kernel's stdin, stdout, and stderr.

Considering scenarios such as running large applications (such as LAMP stacks), which may need to deal with background services or daemons, it may be necessary to close or redirect standard streams to /dev/null, and this problem still exists. From the perspective of the host kernel, Lind-WASM runs as the same Linux process, so standard fds should not be closed in Lind-WASM execution, which prevents other threads from reallocating these fds and causing unexpected behavior or errors. Therefore, the modification of this PR directly does not allow kernel close to close the standard fds of the host kernel, thereby avoiding more problems.

Additionally, I reviewed several error messages from the inner test suite of file system-related tests. Some of these errors were caused by running tests under `sudo` mode, which bypasses normal permission limitations, or by incorrect test case settings.

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->


## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
