### PR TITLE
fixed epoch_interruption on new wasm instance creation

### DIFF
--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -316,6 +316,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
 
                 let lind_manager = child_ctx.lind_manager.clone();
                 let mut store = Store::new_with_inner(&engine, child_host, store_inner);
+                // set epoch deadline for new wasm instance to 1
                 store.set_epoch_deadline(1);
 
                 // if parent is a thread, so does the child
@@ -557,6 +558,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                 let instance_pre = Arc::new(child_ctx.linker.instantiate_pre(&child_ctx.module).unwrap());
 
                 let mut store = Store::new_with_inner(&engine, child_host, store_inner);
+                // set epoch deadline for new wasm instance to 1
                 store.set_epoch_deadline(1);
 
                 // mark as thread

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
-use wasmtime::{AsContext, AsContextMut, Caller, ExternType, Linker, Module, SharedMemory, Store, Val, OnCalledAction, RewindingReturn, StoreOpaque, InstanceId};
+use wasmtime::{AsContext, AsContextMut, Caller, Engine, ExternType, InstanceId, Linker, Module, OnCalledAction, RewindingReturn, SharedMemory, Store, StoreOpaque, Val};
 
 use wasmtime_environ::MemoryIndex;
 
@@ -316,6 +316,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
 
                 let lind_manager = child_ctx.lind_manager.clone();
                 let mut store = Store::new_with_inner(&engine, child_host, store_inner);
+                store.set_epoch_deadline(1);
 
                 // if parent is a thread, so does the child
                 if is_parent_thread {
@@ -556,6 +557,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                 let instance_pre = Arc::new(child_ctx.linker.instantiate_pre(&child_ctx.module).unwrap());
 
                 let mut store = Store::new_with_inner(&engine, child_host, store_inner);
+                store.set_epoch_deadline(1);
 
                 // mark as thread
                 store.set_is_thread(true);

--- a/src/wasmtime/crates/wasmtime/src/engine.rs
+++ b/src/wasmtime/crates/wasmtime/src/engine.rs
@@ -634,6 +634,10 @@ impl Engine {
         self.inner.epoch.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn decrement_epoch(&self) {
+        self.inner.epoch.fetch_sub(1, Ordering::Relaxed);
+    }
+
     /// Returns a [`std::hash::Hash`] that can be used to check precompiled WebAssembly compatibility.
     ///
     /// The outputs of [`Engine::precompile_module`] and [`Engine::precompile_component`]

--- a/src/wasmtime/crates/wasmtime/src/engine.rs
+++ b/src/wasmtime/crates/wasmtime/src/engine.rs
@@ -634,6 +634,7 @@ impl Engine {
         self.inner.epoch.fetch_add(1, Ordering::Relaxed);
     }
 
+    // decrement the value of epoch. Potentially serving as a way to restore epoch
     pub fn decrement_epoch(&self) {
         self.inner.epoch.fetch_sub(1, Ordering::Relaxed);
     }

--- a/src/wasmtime/crates/wasmtime/src/runtime/store.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/store.rs
@@ -1115,6 +1115,7 @@ impl<T> Store<T> {
         self.inner.set_epoch_deadline(ticks_beyond_current);
     }
 
+    // get current epoch deadline
     pub fn get_epoch_deadline(&self) -> u64 {
         self.inner.get_epoch_deadline()
     }

--- a/src/wasmtime/crates/wasmtime/src/runtime/store.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/store.rs
@@ -1115,6 +1115,10 @@ impl<T> Store<T> {
         self.inner.set_epoch_deadline(ticks_beyond_current);
     }
 
+    pub fn get_epoch_deadline(&self) -> u64 {
+        self.inner.get_epoch_deadline()
+    }
+
     /// Configures epoch-deadline expiration to trap.
     ///
     /// When epoch-interruption-instrumented code is executed on this

--- a/src/wasmtime/src/commands/run.rs
+++ b/src/wasmtime/src/commands/run.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use wasi_common::sync::{ambient_authority, Dir, TcpListener, WasiCtxBuilder};
-use wasmtime::{AsContextMut, Engine, Func, Module, Store, StoreLimits, Val, ValType};
+use wasmtime::{AsContextMut, Engine, Func, Module, Store, StoreLimits, UpdateDeadline, Val, ValType};
 use wasmtime_wasi::WasiView;
 
 use wasmtime_lind_utils::LindCageManager;
@@ -424,6 +424,8 @@ impl RunCommand {
                 thread::sleep(timeout);
                 engine.increment_epoch();
             });
+        } else if self.run.common.wasm.epoch_interruption.is_some() {
+            store.set_epoch_deadline(1);
         }
 
         Ok(Box::new(|_store| {}))

--- a/src/wasmtime/src/commands/run.rs
+++ b/src/wasmtime/src/commands/run.rs
@@ -424,6 +424,8 @@ impl RunCommand {
                 thread::sleep(timeout);
                 engine.increment_epoch();
             });
+        // if epoch_interruption is enabled, we need to set the epoch deadline to at least 1
+        // otherwise the wasm process will be interrupted immediately once started as the default deadline is 0
         } else if self.run.common.wasm.epoch_interruption.is_some() {
             store.set_epoch_deadline(1);
         }


### PR DESCRIPTION
A very minor PR. Fixed this [issue](https://github.com/Lind-Project/lind-wasm/issues/73) by initializing epoch when new wasm instance is created.

This is the initial integration of epoch_interruption into lind's architecture. We plan to use epoch_interruption to implement several features ([thread cancelation feature](https://github.com/Lind-Project/lind-wasm/issues/34) and [signal implementation](https://github.com/Lind-Project/lind-wasm/issues/17)), so having a basic epoch_interruption working here is a good start.

Epoch is an u64 variable and we can use it as an integer if we want. But currently we only need to use epoch has a way to interrupt the wasm process, it is sufficient to just use 0 and 1 on epoch to represent `normal` and `interrupted` respectively. So I am setting epoch deadline to be always 1 here.