### PR TITLE
add function to create expected outputs for deterministic tests

### DIFF
--- a/wasmtest.sh
+++ b/wasmtest.sh
@@ -284,11 +284,11 @@ generate_expected_outputs() {
 # Function: cleanup_expected
 # Purpose:
 # For cleaning up all expected outputs.
-# Deletes the folder "expected" under each of the subfolders
+# Deletes the folder "expected" under each of the subfolders and the test lists(testlist_safe.txt and testlist_unsafe.txt).
 #
 # Variables:
 # - Input: None required; Works on the created expected folders 
-# - Output: Logs the deleted expected folders to stdout.
+# - Output: Logs the deleted folders and files to stdout.
 #
 # ----------------------------------------------------------------------
 cleanup_expected() {


### PR DESCRIPTION
PR for https://github.com/Lind-Project/lind-wasm/issues/11

Added a function in wasmtest.sh file for creating expected outputs. 
The function can be ran using "wasmtest.sh createexpected" or "wasmtest.sh ce"

All c files under each of the deterministic subfolder are taken and compiled using gcc. 
A new folder expected is created in each deterministic subfolder and the output is saved in a <test_case_filename>.output file
If there are any compile or runtime error, they are displayed in the console and alse added to the .output file.
The compiled files are deleted after running
Finally a count of total/success/failure is displayed in the console
