### PR TITLE
update execve

### DIFF
--- a/src/RawPOSIX/src/safeposix/dispatcher.rs
+++ b/src/RawPOSIX/src/safeposix/dispatcher.rs
@@ -375,12 +375,10 @@ pub fn lind_syscall_api(
         }
 
         EXEC_SYSCALL => {
-            let child_cageid = arg1 as u64;
-        
             // Perform exec operation through cage implementation
             // Child cage validation handled by cage layer
             interface::cagetable_getref(cageid)
-                .exec_syscall(child_cageid)
+                .exec_syscall()
         }
 
         EXIT_SYSCALL => {

--- a/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
@@ -136,54 +136,12 @@ impl Cage {
     pub fn exec_syscall(&self) -> i32 { 
         fdtables::empty_fds_for_exec(self.cageid);
 
-        let zombies = self.zombies.read();
-        let cloned_zombies = zombies.clone();
-        let child_num = self.child_num.load(interface::RustAtomicOrdering::Relaxed);
-        drop(zombies);
+        self.cancelstatus.store(false, interface::RustAtomicOrdering::Relaxed);
+        self.rev_shm.lock().clear(); 
+        self.thread_table.clear();
+        let mut vmmap = self.vmmap.write();
+        vmmap.clear(); //this just clean the vmmap in the cage still need some modify for wasmtime and call to kernal
 
-        // we grab the parent cages main threads sigset and store it at 0
-        // this way the child can initialize the sigset properly when it establishes its own mainthreadid
-        let newsigset = interface::RustHashMap::new();
-        if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
-            // we don't add these for the test suite
-            // BUG: Signals are commented out until we add them to lind-wasm
-            let mainsigsetatomic = self
-                .sigset
-                .get(
-                    &self
-                        .main_threadid
-                        .load(interface::RustAtomicOrdering::Relaxed),
-                )
-                .unwrap();
-            let mainsigset = interface::RustAtomicU64::new(
-                mainsigsetatomic.load(interface::RustAtomicOrdering::Relaxed),
-            );
-            newsigset.insert(0, mainsigset);
-        }
-
-        let newcage = Cage {
-            cageid: self.cageid,
-            cwd: interface::RustLock::new(self.cwd.read().clone()),
-            parent: self.parent,
-            cancelstatus: interface::RustAtomicBool::new(false),
-            getgid: interface::RustAtomicI32::new(-1),
-            getuid: interface::RustAtomicI32::new(-1),
-            getegid: interface::RustAtomicI32::new(-1),
-            geteuid: interface::RustAtomicI32::new(-1),
-            rev_shm: interface::Mutex::new(vec![]),
-            thread_table: interface::RustHashMap::new(),
-            signalhandler: interface::RustHashMap::new(),
-            sigset: newsigset,
-            main_threadid: interface::RustAtomicU64::new(0),
-            interval_timer: self.interval_timer.clone_with_new_cageid(self.cageid), //
-            zombies: interface::RustLock::new(cloned_zombies), // when a process exec-ed, its child relationship should be perserved
-            child_num: interface::RustAtomicU64::new(0),
-            vmmap: interface::RustLock::new(Vmmap::new()), // memory is cleared after exec
-        };
-        //wasteful clone of fdtable, but mutability constraints exist
-        interface::cagetable_remove(self.cageid);
-
-        interface::cagetable_insert(self.cageid, newcage);
         0
     }
 

--- a/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
@@ -136,8 +136,8 @@ impl Cage {
     *   Unlike the `exec` syscalls from linux manual, exec syscall here does not take any arguments,
     *   such as the argument list or environment variables. This is because, in rawposix, 
     *   the `exec` syscall only functions as a "cage-level exec," focusing only on updating 
-    *   the `cage` struct with the necessary changes. The actual logic for process replacement 
-    *   is handled within the wasmtime codebase, which will eventually call this function to perform
+    *   the `cage` struct with the necessary changes. In a word in this Rawposix part it handles the cage resources management.
+    *   The excution and memory management is handled within the wasmtime codebase, which will eventually call this function to perform
     *   only a specific part of the `exec` operation.
     *
     *   The method we used here is remain the same cage and replace the component that need to be replaced,

--- a/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/sys_calls.rs
@@ -130,18 +130,21 @@ impl Cage {
         0
     }
 
-    /*
-    *   Here is the linux man page for execve: https://man7.org/linux/man-pages/man2/execve.2.html
-    *   exec() will only return if error happens
-    *   Unlike the `exec` syscalls from linux manual, exec syscall here does not take any arguments,
-    *   such as the argument list or environment variables. This is because, in rawposix, 
-    *   the `exec` syscall only functions as a "cage-level exec," focusing only on updating 
-    *   the `cage` struct with the necessary changes. In a word in this Rawposix part it handles the cage resources management.
-    *   The excution and memory management is handled within the wasmtime codebase, which will eventually call this function to perform
-    *   only a specific part of the `exec` operation.
-    *
-    *   The method we used here is remain the same cage and replace the component that need to be replaced,
-    *   since cageid, cwd, zombies and other components still exist, only need to replace cancelstatus, rev_shm, thread_table, vmmap.
+   /*
+    *  Here is the Linux man page for execve: https://man7.org/linux/man-pages/man2/execve.2.html
+    *  
+    *  exec() only returns if an error occurs.
+    *  
+    *  Unlike the `exec` syscalls in the Linux manual, the `exec` syscall here does not take any arguments,
+    *  such as an argument list or environment variables. This is because, in Rawposix, `exec` functions
+    *  solely as a "cage-level exec," focusing only on updating the `cage` struct with necessary changes.
+    *  
+    *  In short, this syscall in Rawposix part is responsible for managing cage resources.
+    *  Execution and memory management are handled within the Wasmtime codebase, which eventually calls
+    *  this function to perform only a specific part of the `exec` operation.
+    *  
+    *  Here, we retain the same cage and only replace the necessary components since `cageid`, `cwd`, `zombies`,
+    *  and other elements remain unchanged. Only `cancelstatus`, `rev_shm`, `thread_table`, and `vmmap` need to be replaced.
     */
     pub fn exec_syscall(&self) -> i32 { 
         fdtables::empty_fds_for_exec(self.cageid);

--- a/src/RawPOSIX/src/safeposix/vmmap.rs
+++ b/src/RawPOSIX/src/safeposix/vmmap.rs
@@ -266,7 +266,7 @@ impl Vmmap {
         }
     }
 
-    // Clear the vmmap struct
+    // Clear the vmmap struct, used for exec syscall
     pub fn clear(&mut self){
         self.entries = NoditMap::new();
         self.cached_entry = None;

--- a/src/RawPOSIX/src/safeposix/vmmap.rs
+++ b/src/RawPOSIX/src/safeposix/vmmap.rs
@@ -266,6 +266,15 @@ impl Vmmap {
         }
     }
 
+    // Clear the vmmap struct
+    pub fn clear(&mut self){
+        self.entries = NoditMap::new();
+        self.cached_entry = None;
+        self.base_address = None;
+        self.start_address = 0;
+        self.end_address = DEFAULT_VMMAP_SIZE;
+        self.program_break = 0;
+    }
     /// Rounds up a page number to the nearest multiple of pages_per_map
     ///
     /// Arguments:

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/execve.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/execve.c
@@ -5,3 +5,4 @@ int __execve (const char *__path, char *const __argv[], char *const __envp[])
 {
   return MAKE_SYSCALL(69, "syscall|execve", __path, __argv, __envp, NOTUSED, NOTUSED, NOTUSED);
 }
+weak_alias (__execve, execve)

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/execve.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/execve.c
@@ -5,4 +5,4 @@ int __execve (const char *__path, char *const __argv[], char *const __envp[])
 {
   return MAKE_SYSCALL(69, "syscall|execve", __path, __argv, __envp, NOTUSED, NOTUSED, NOTUSED);
 }
-weak_alias (__execve, execve)
+strong_alias (__execve, execve)

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -712,7 +712,6 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
         let real_path_str = String::from(real_path.to_str().unwrap());
 
         // if the file to exec does not exist
-        println!("");
         if !std::path::Path::new(&real_path_str).exists() {
             // return ENOENT
             return Ok(-2);

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -22,7 +22,7 @@ const ASYNCIFY_STOP_UNWIND: &str = "asyncify_stop_unwind";
 const ASYNCIFY_START_REWIND: &str = "asyncify_start_rewind";
 const ASYNCIFY_STOP_REWIND: &str = "asyncify_stop_rewind";
 
-const LIND_FS_ROOT: &str = "/home/lind-wasm/src/RawPOSIX/tmp";
+const LIND_FS_ROOT: &str = "/home/lind/lind-wasm/src/RawPOSIX/tmp";
 
 const UNWIND_METADATA_SIZE: u64 = 16;
 
@@ -644,6 +644,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                              argv: i64,
                              envs: Option<i64>
                      ) -> Result<i32> {
+        println!("execve");
         // get the base address of the memory
         let handle = caller.as_context().0.instance(InstanceId::from_index(0));
         let defined_memory = handle.get_memory(MemoryIndex::from_u32(0));
@@ -712,6 +713,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
         let real_path_str = String::from(real_path.to_str().unwrap());
 
         // if the file to exec does not exist
+        println!("");
         if !std::path::Path::new(&real_path_str).exists() {
             // return ENOENT
             return Ok(-2);

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -644,7 +644,6 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                              argv: i64,
                              envs: Option<i64>
                      ) -> Result<i32> {
-        println!("execve");
         // get the base address of the memory
         let handle = caller.as_context().0.instance(InstanceId::from_index(0));
         let defined_memory = handle.get_memory(MemoryIndex::from_u32(0));


### PR DESCRIPTION
Some modify with Wasmtime and Rawposix to support execve. I change the method to implement exec syscall. The previous method of exec syscall is to creat a new cage and remove the old cage. The current method is to remain the same cage and only modify some components(cancelstatus, rev_shm, vmmap). In this way, we only need to replace a few components which reduce many lines of code comparing to the previous method. More comments are provide in the updated files.