### PR TITLE
Patch to lindtool

### DIFF
--- a/lind_config.sh
+++ b/lind_config.sh
@@ -5,22 +5,6 @@ rawposix_base="$script_dir/src/RawPOSIX"
 
 CC="${CLANG:=/home/lind/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04}/bin/clang"
 
-# compile_test_cmd_fork="$CC --target=wasm32-unknown-wasi \
-# --sysroot $glibc_base/sysroot \
-# -Wl, --export="__stack_pointer",--export=__stack_low \
-# [input] -g -O0 -o [output] && \
-# $script_dir/tools/binaryen/bin/wasm-opt --epoch-injection --asyncify -O2 --debuginfo [output] -o [output]"
-
-# compile_test_cmd_noshared="$CC --target=wasm32-unknown-wasi \
-# --sysroot $glibc_base/sysroot \
-# -Wl,--export="__stack_pointer",--export=__stack_low \
-# [input] -g -O0 -o [output]"
-
-# compile_test_cmd="$CC -pthread --target=wasm32-unknown-wasi \
-# --sysroot $glibc_base/sysroot \
-#  -Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_low \
-#  [input] -g -O0 -o [output]"
-
 precompile_wasm="$wasmtime_base/target/debug/wasmtime compile [input] -o [output]"
 
 compile_test_cmd_fork_test="$CC -pthread --target=wasm32-unknown-wasi \

--- a/lind_config.sh
+++ b/lind_config.sh
@@ -1,29 +1,25 @@
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 glibc_base="$script_dir/src/glibc"
 wasmtime_base="$script_dir/src/wasmtime"
-rustposix_base="$script_dir/src/safeposix-rust"
 rawposix_base="$script_dir/src/RawPOSIX"
-
 
 CC="${CLANG:=/home/lind/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04}/bin/clang"
 
-export_cmd="export LD_LIBRARY_PATH=$wasmtime_base/crates/rustposix:\$LD_LIBRARY_PATH"
+# compile_test_cmd_fork="$CC --target=wasm32-unknown-wasi \
+# --sysroot $glibc_base/sysroot \
+# -Wl, --export="__stack_pointer",--export=__stack_low \
+# [input] -g -O0 -o [output] && \
+# $script_dir/tools/binaryen/bin/wasm-opt --epoch-injection --asyncify -O2 --debuginfo [output] -o [output]"
 
-compile_test_cmd_fork="$CC --target=wasm32-unknown-wasi \
---sysroot $glibc_base/sysroot \
--Wl, --export="__stack_pointer",--export=__stack_low \
-[input] -g -O0 -o [output] && \
-wasm-opt --asyncify --debuginfo [output] -o [output]"
+# compile_test_cmd_noshared="$CC --target=wasm32-unknown-wasi \
+# --sysroot $glibc_base/sysroot \
+# -Wl,--export="__stack_pointer",--export=__stack_low \
+# [input] -g -O0 -o [output]"
 
-compile_test_cmd_noshared="$CC --target=wasm32-unknown-wasi \
---sysroot $glibc_base/sysroot \
--Wl,--export="__stack_pointer",--export=__stack_low \
-[input] -g -O0 -o [output]"
-
-compile_test_cmd="$CC -pthread --target=wasm32-unknown-wasi \
---sysroot $glibc_base/sysroot \
- -Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_low \
- [input] -g -O0 -o [output]"
+# compile_test_cmd="$CC -pthread --target=wasm32-unknown-wasi \
+# --sysroot $glibc_base/sysroot \
+#  -Wl,--import-memory,--export-memory,--max-memory=67108864,--export=__stack_low \
+#  [input] -g -O0 -o [output]"
 
 precompile_wasm="$wasmtime_base/target/debug/wasmtime compile [input] -o [output]"
 
@@ -31,7 +27,7 @@ compile_test_cmd_fork_test="$CC -pthread --target=wasm32-unknown-wasi \
 --sysroot $glibc_base/sysroot \
 -Wl,--import-memory,--export-memory,--max-memory=67108864,--export="__stack_pointer",--export=__stack_low \
 [input] -g -O0 -o [output] && \
- wasm-opt --asyncify --debuginfo [output] -o [output]"
+ $script_dir/tools/binaryen/bin/wasm-opt --epoch-injection --asyncify -O2 --debuginfo [output] -o [output]"
 
 run_cmd="$wasmtime_base/target/debug/wasmtime run --wasi \
 threads=y \
@@ -49,8 +45,7 @@ run_cmd_debug="gdb --args $wasmtime_base/target/debug/wasmtime run \
 --wasi preview2=n [target]"
 
 compile_wasmtime_cmd="cd $wasmtime_base && cargo build"
-compile_rustposix_cmd="cd $rustposix_base && cargo build && cp $rustposix_base/target/debug/librustposix.so $wasmtime_base/crates/rustposix"
-compile_rawposix_cmd="cd $rawposix_base && cargo build && cp $rawposix_base/target/debug/librustposix.so $wasmtime_base/crates/rustposix"
+compile_rawposix_cmd="cd $rawposix_base && cargo build"
 
 compile_pthread_create="$CC --target=wasm32-unkown-wasi \
 -v -Wno-int-conversion pthread_create.c \

--- a/lindtool.sh
+++ b/lindtool.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Load configuration
 source "$(dirname "$0")/lind_config.sh"
 

--- a/lindtool.sh
+++ b/lindtool.sh
@@ -173,10 +173,6 @@ if [ "${!#}" = "-p" ]; then
 fi
 
 case $1 in
-    export)
-        echo -e "${GREEN}$export_cmd${RESET}"
-        echo "please manually run the export command"
-        ;;
     compile_test|cptest)
         if [ -z "$2" ]; then
             echo -e "${RED}error: source file name not provided${RESET}"
@@ -257,12 +253,6 @@ case $1 in
             eval "$compile_wasmtime_cmd"
         fi
         ;;
-    compile_rustposix|cpposix)
-        echo -e "${GREEN}$compile_rustposix_cmd${RESET}"
-        if [ "$pmode" -eq 0 ]; then
-            eval "$compile_rustposix_cmd"
-        fi
-        ;;
     compile_rawposix|cpraw)
         echo -e "${GREEN}$compile_rawposix_cmd${RESET}"
         if [ "$pmode" -eq 0 ]; then
@@ -277,64 +267,20 @@ case $1 in
 
         compile_src $2 $3
         ;;
-    make_all)
+    make_all|make_glibc)
         unset LD_LIBRARY_PATH
         echo -e "${GREEN}$make_cmd${RESET}"
         if [ "$pmode" -eq 0 ]; then
             eval "$make_cmd"
         fi
         ;;
-    make)
-        result=$(lindmake "$glibc_base" "$pmode")
-        if [ -z "$result" ]; then
-            echo -e "${GREEN}No changes detected.${RESET}"
-            exit 0
-        fi
-        echo $result
-
-        # Set IFS to semicolon and read the string into an array
-        IFS=';' read -r -a array <<< "$result"
-
-        compiled=()
-
-        # Print each element of the array
-        for line in "${array[@]}"; do
-            # Split the string into two variables
-            if [[ "$line" =~ ^([^[:space:]]+)([[:space:]]+)(.+)$ ]]; then
-                src_file=${BASH_REMATCH[1]}
-                compiled+=($src_file)
-                compile_src $src_file ${BASH_REMATCH[3]}
-
-                if [ $? -ne 0 ]; then
-                    echo -e "${RED}Compilation Failed.${RESET}"
-                    exit 1
-                fi
-            else
-                compile_src $line
-
-                if [ $? -ne 0 ]; then
-                    echo -e "${RED}Compilation Failed.${RESET}"
-                    exit 1
-                fi
-            fi
-        done
-
-        echo ""
-        for file in "${compiled[@]}"; do
-            echo -e "${GREEN}Compiled $file successfully.${RESET}"
-        done
-
-        ;;
     help)
         echo "avaliable commands are:"
-        echo "1. export"
-        echo "2. compile_test"
-        echo "3. run"
-        echo "4. compile_wasmtime"
-        echo "5. compile_rustposix"
-        echo "6. compile_src"
-        echo "7. make_all"
-        echo "8. make"
+        echo "1. compile_test"
+        echo "2. run"
+        echo "3. compile_wasmtime"
+        echo "4. compile_src"
+        echo "5. make_all"
         ;;
     *)
         echo "Unknown command identifier."


### PR DESCRIPTION
A quick patch to the `lindtool`/`lind_config`. Previous [CI PR](https://github.com/Lind-Project/lind-wasm/pull/128) refactored the lindtool but missed the fresh updates in `lindtool` from the signal PR. This causes current `lindtool` unable to compile and run the test file correctly. (since the test file is compiled without signal support, which wasmtime would expect).

Cleaned up some unused code in `lindtool` by the way.