### PR TITLE
Add signal interruption handling for syscalls

### DIFF
--- a/src/RawPOSIX/src/interface/misc.rs
+++ b/src/RawPOSIX/src/interface/misc.rs
@@ -304,3 +304,44 @@ pub struct AdvisoryLock {
     advisory_lock: RustRfc<Mutex<i32>>,
     advisory_condvar: Condvar,
 }
+
+pub fn timeout_setup(rposix_timeout: Option<Duration>) -> (Duration, libc::timeval) {
+    let end_time = match rposix_timeout {
+        Some(duration) => duration,
+        None => Duration::MAX,
+    };
+
+    let mut timeout;
+    if end_time > Duration::from_millis(100) {
+        timeout = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 1000000, // 100ms
+        };
+    } else {
+        timeout = libc::timeval {
+            tv_sec: 0,
+            tv_usec: end_time.subsec_micros() as i64,
+        };
+    }
+
+    (end_time, timeout)
+}
+
+pub fn timeout_setup_ms(timeout_ms: i32) -> (Duration, i32) {
+    let end_time = {
+        if timeout_ms >= 0 {
+            Duration::from_millis(timeout_ms as u64)
+        } else {
+            Duration::MAX
+        }
+    };
+
+    let mut timeout;
+    if end_time > Duration::from_millis(100) {
+        timeout = 100;
+    } else {
+        timeout = timeout_ms;
+    }
+
+    (end_time, timeout)
+}

--- a/src/RawPOSIX/src/safeposix/syscalls/net_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/net_calls.rs
@@ -595,9 +595,9 @@ impl Cage {
         let ret = unsafe {
             libc::select(
                 realnewnfds as i32,
-                &mut real_readfds as *mut _,
-                &mut real_writefds as *mut _,
-                &mut real_errorfds as *mut _,
+                readfds.is_some().then_some(&mut real_readfds as *mut _).unwrap_or(ptr::null_mut()),
+                writefds.is_some().then_some(&mut real_writefds as *mut _).unwrap_or(ptr::null_mut()),
+                errorfds.is_some().then_some(&mut real_errorfds as *mut _).unwrap_or(ptr::null_mut()),
                 &mut timeout as *mut timeval,
             )
         };


### PR DESCRIPTION
## Description

Fixes #118  (Blocking Calls for Signals)

This PR implements signal handling for the `select` syscall. Since we never actually block in the kernel for select/poll operations, we've added direct signal checks before and after the syscall to return EINTR when a signal is pending.

Key changes:
- Added signal checks using `lind_check_no_pending_signal` before and after select operation
- Return EINTR error code when a signal is detected
- Set default timeout to 100ms when no timeout is specified
- Simplified code by removing unnecessary comments

This change is required to support proper signal interruption behavior, particularly for PostgreSQL's pgbench which relies on signal interruption during select syscalls.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- `cargo build`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works