### PR TITLE
Fix close syscall and incorrect path in gen_root.sh 

### DIFF
--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -826,20 +826,36 @@ impl Cage {
     }
 
     //------------------------------------CLOSE SYSCALL------------------------------------
-    /*
-     *   Get the kernel fd with provided virtual fd first
-     *   close() will return 0 when sucess, -1 when fail
-     */
+    /// Reference to Linux: https://man7.org/linux/man-pages/man2/close.2.html
+    ///
+    /// Linux `close()` syscall closes a file descriptor. In our implementation, we use a file descriptor management
+    /// subsystem (called `fdtables`) to handle virtual file descriptors. This syscall removes the virtual file
+    /// descriptor from the subsystem, and if necessary, closes the underlying kernel file descriptor.
+    ///
+    /// ## Arguments:
+    ///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+    ///     - cageid: current cage identifier.
+    ///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment to be closed.
+    ///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused.
+    /// 
+    /// ## Returns:
+    ///     Return 0 when success; -1 along with errno when fail.
     pub fn close_syscall(&self, virtual_fd: i32) -> i32 {
+
+        if virtual_fd < 0 || virtual_fd > MAXFD {
+            return syscall_error(Errno::EBADF, "close", "Bad File Descriptor");
+        }
+
         match fdtables::close_virtualfd(self.cageid, virtual_fd as u64) {
-            Ok(()) => {
-                return 0;
-            }
+            Ok(()) => 0,
             Err(e) => {
                 if e == Errno::EBADFD as u64 {
-                    return syscall_error(Errno::EBADF, "close", "bad file descriptor");
+                    syscall_error(Errno::EBADF, "close", "Bad File Descriptor")
+                } else if e == Errno::EINTR as u64 {
+                    syscall_error(Errno::EINTR, "close", "Interrupted system call")
+                } else {
+                    syscall_error(Errno::EIO, "close", "I/O error")
                 }
-                return -1;
             }
         }
     }
@@ -1571,8 +1587,6 @@ impl Cage {
 pub fn kernel_close(fdentry: fdtables::FDTableEntry, _count: u64) {
     let kernel_fd = fdentry.underfd as i32;
 
-    // TODO:
-    // Need to update once we merge with vmmap-alice
     if kernel_fd == STDIN_FILENO || kernel_fd == STDOUT_FILENO || kernel_fd == STDERR_FILENO {
         return;
     }

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -5,7 +5,7 @@ use sysdefs::constants::err_const::{get_errno, handle_errno, syscall_error, Errn
 use sysdefs::constants::fs_const::{
     LIND_ROOT, MAP_PRIVATE, MAP_SHARED, O_CLOEXEC, O_CREAT, O_RDONLY, O_RDWR, O_TRUNC, O_WRONLY,
     PROT_READ, PROT_WRITE, SEEK_CUR, SEEK_END, SEEK_SET, SEM_VALUE_MAX, SHMMAX, SHMMIN, SHM_DEST,
-    SHM_RDONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, S_IRWXG, S_IRWXO, S_IRWXU,
+    SHM_RDONLY, STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO, S_IRWXG, S_IRWXO, S_IRWXU, MAXFD,
 };
 use sysdefs::constants::sys_const::{DEFAULT_GID, DEFAULT_UID};
 // Import data structure

--- a/src/glibc/gen_sysroot.sh
+++ b/src/glibc/gen_sysroot.sh
@@ -34,7 +34,7 @@ fi
 mkdir -p "$sysroot_dir/include/wasm32-wasi" "$sysroot_dir/lib/wasm32-wasi"
 
 # Pack all found .o files into a single .a archive
-${CLANG:=/home/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04}/bin/llvm-ar rcs "$output_archive" $object_files
+${CLANG:=/home/lind/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04}/bin/llvm-ar rcs "$output_archive" $object_files
 "$CLANG/bin/llvm-ar" crs "sysroot/lib/wasm32-wasi/libpthread.a"
 
 # Check if llvm-ar succeeded

--- a/src/sysdefs/src/constants/fs_const.rs
+++ b/src/sysdefs/src/constants/fs_const.rs
@@ -25,6 +25,11 @@ pub const STDERR_FILENO: i32 = 2; // File descriptor for standard error
 // Source: include/dirent.h
 pub const DT_UNKNOWN: u8 = 0;
 
+pub const STARTINGFD: i32 = 0; // Starting file descriptor number
+pub const MAXFD: i32 = 1024; // Maximum number of file descriptors
+pub const STARTINGPIPE: i32 = 0; // Starting pipe descriptor number
+pub const MAXPIPE: i32 = 1024; // Maximum number of pipes
+
 // ===== File Access Permission Flags =====
 pub const F_OK: u32 = 0; // Test for existence
 pub const X_OK: u32 = 1; // Test for execute permission


### PR DESCRIPTION
Currently, the main branch returns -errno on syscall failure instead of -1. This behavior is likely caused by two issues:

1. `lind_syscall.o` is not being compiled, which seems to be missing from `lindtool.sh`.
2. `gen_sysroot.sh` contains an incorrect path.

As a result, some test cases fail because they expect and compare the return value to be -1 on failure.

The bug in `close_syscall` is fixed and the path issue in `gen_sysroot.sh` is corrected in this PR. I've talked with `devops` team about updating `lindtool.sh`, so that should be included in another PR.