### PR TITLE
Integrate Clippy CI Tool

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ENV GLIBC_TAR_CACHE=${GLIBC_TAR_CACHE:-false}
 # Install all the required dependencies
 RUN apt-get -qq update && \
     apt-get install -y -qq build-essential git wget gcc-i686-linux-gnu g++-i686-linux-gnu \
-    bison gawk vim libxml2 python3 curl gcc g++ binaryen unzip zip golang bash
+    bison gawk vim libxml2 python3 curl gcc g++ binaryen unzip zip golang bash openssl libssl-dev
 
 RUN apt install -qq apt-transport-https curl gnupg -y && \
     curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ ARG BRANCH_NAME
 ENV BRANCH_NAME=${BRANCH_NAME:-main}
 
 ARG GLIBC_TAR_CACHE
+ENV GLIBC_TAR_CACHE=${GLIBC_TAR_CACHE:-false}
 
 # Install all the required dependencies
 RUN apt-get -qq update && \

--- a/BUILD
+++ b/BUILD
@@ -28,7 +28,7 @@ genrule(
         cd ../nptl
         
         # Define common flags
-        CFLAGS="--target=wasm32-unknown-wasi -v -Wno-int-conversion -std=gnu11 -fgnu89-inline -matomics -mbulk-memory -O0 -g"
+        CFLAGS="--target=wasm32-unknown-wasi -v -Wno-int-conversion -std=gnu11 -fgnu89-inline -matomics -mbulk-memory -O2 -g"
         WARNINGS="-Wall -Wwrite-strings -Wundef -Wstrict-prototypes -Wold-style-definition"
         EXTRA_FLAGS="-fmerge-all-constants -ftrapping-math -fno-stack-protector -fno-common"
         EXTRA_FLAGS+=" -Wp,-U_FORTIFY_SOURCE -fmath-errno -fPIE -ftls-model=local-exec"

--- a/BUILD
+++ b/BUILD
@@ -83,17 +83,8 @@ genrule(
 
         $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \
             $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES \
-            -o $$GLIBC_BASE/build/lind_syscall.o \
-            -c pthread_create.c -MD -MP -MF $$GLIBC_BASE/build/nptl/pthread_create.o.dt \
-            -MT $$GLIBC_BASE/build/nptl/pthread_create.o
-
-        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \
-            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES \
-            -c lind_syscall.c -o lind_syscall.o
-        
-        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \ 
-            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES -o $$GLIBC_BASE/build/lind_syscall/lind_syscall.o \
-            -c lind_syscall/lind_syscall.c 
+            -o $$GLIBC_BASE/build/lind_syscall/lind_syscall.o \
+            -c $$GLIBC_BASE/lind_syscall/lind_syscall.c
         
         # Compile assembly files
         cd ../ && \

--- a/BUILD
+++ b/BUILD
@@ -189,7 +189,8 @@ genrule(
     echo "  bazel-bin/tests/ci-tests/clippy/clippy_out.json"
     echo "==================================================="
     
-    exit $$status
+    # Should succeed so logs are passed even if clippy issues are found
+    exit 0
     """,
     executable = True,
     tags = ["no-cache", "no-sandbox"],

--- a/BUILD
+++ b/BUILD
@@ -170,13 +170,11 @@ genrule(
     export GIT_DIR=$$PWD/.git
     export GIT_WORK_TREE=$$PWD
 
-    echo "Fetching full git history if shallow..."
-    if git rev-parse --is-shallow-repository | grep true; then
-      git fetch --unshallow || echo "Warning: unshallow failed (maybe already full repo)"
-    fi
+    echo "Checking for shallow clone..."
+    git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || echo "Repo is already full clone"
 
-    echo "Fetching origin/main branch specifically..."
-    git fetch origin main || echo "Warning: fetching origin/main failed"
+    echo "Fetching origin/main..."
+    git fetch origin main || echo "Warning: git fetch main failed"
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)
@@ -198,6 +196,7 @@ genrule(
     executable = True,
     tags = ["no-cache", "no-sandbox"],
 )
+
 
 
 

--- a/BUILD
+++ b/BUILD
@@ -174,7 +174,7 @@ genrule(
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)
-    status=$?
+    status=$$?
     set -e
 
     echo ""

--- a/BUILD
+++ b/BUILD
@@ -170,7 +170,8 @@ genrule(
     export GIT_DIR=$$PWD/.git
     export GIT_WORK_TREE=$$PWD
 
-    
+    echo "Fetching origin/main..."
+    git fetch origin main || echo "Warning: git fetch failed"
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)
@@ -192,6 +193,7 @@ genrule(
     executable = True,
     tags = ["no-cache", "no-sandbox"],
 )
+
 
 
 #FileGroup for .git files

--- a/BUILD
+++ b/BUILD
@@ -170,8 +170,13 @@ genrule(
     export GIT_DIR=$$PWD/.git
     export GIT_WORK_TREE=$$PWD
 
-    echo "Fetching origin/main..."
-    git fetch --unshallow || echo "Warning: git fetch failed"
+    echo "Fetching full git history if shallow..."
+    if git rev-parse --is-shallow-repository | grep true; then
+      git fetch --unshallow || echo "Warning: unshallow failed (maybe already full repo)"
+    fi
+
+    echo "Fetching origin/main branch specifically..."
+    git fetch origin main || echo "Warning: fetching origin/main failed"
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)
@@ -193,6 +198,7 @@ genrule(
     executable = True,
     tags = ["no-cache", "no-sandbox"],
 )
+
 
 
 

--- a/BUILD
+++ b/BUILD
@@ -80,11 +80,6 @@ genrule(
             -o $$GLIBC_BASE/build/nptl/pthread_create.o \
             -c pthread_create.c -MD -MP -MF $$GLIBC_BASE/build/nptl/pthread_create.o.dt \
             -MT $$GLIBC_BASE/build/nptl/pthread_create.o
-
-        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \
-            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES \
-            -o $$GLIBC_BASE/build/lind_syscall/lind_syscall.o \
-            -c $$GLIBC_BASE/lind_syscall/lind_syscall.c
         
         # Compile assembly files
         cd ../ && \

--- a/BUILD
+++ b/BUILD
@@ -171,7 +171,7 @@ genrule(
     export GIT_WORK_TREE=$$PWD
 
     echo "Fetching origin/main..."
-    git fetch origin main || echo "Warning: git fetch failed"
+    git fetch --unshallow || echo "Warning: git fetch failed"
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)

--- a/BUILD
+++ b/BUILD
@@ -170,10 +170,7 @@ genrule(
     export GIT_DIR=$$PWD/.git
     export GIT_WORK_TREE=$$PWD
 
-    echo "=== GIT STATUS ==="
-    git status || echo "git status failed"
-    echo "=== GIT REMOTE SHOW ==="
-    git remote -v || echo "git remote failed"
+    
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)

--- a/BUILD
+++ b/BUILD
@@ -81,6 +81,10 @@ genrule(
             -c pthread_create.c -MD -MP -MF $$GLIBC_BASE/build/nptl/pthread_create.o.dt \
             -MT $$GLIBC_BASE/build/nptl/pthread_create.o
         
+        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \ 
+            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES -o $$GLIBC_BASE/build/lind_syscall.o \
+            -c lind_syscall.c 
+        
         # Compile assembly files
         cd ../ && \
         $$CC --target=wasm32-wasi-threads -matomics \

--- a/BUILD
+++ b/BUILD
@@ -92,8 +92,8 @@ genrule(
             -c lind_syscall.c -o lind_syscall.o
         
         $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \ 
-            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES -o $$GLIBC_BASE/build/lind_syscall.o \
-            -c lind_syscall.c 
+            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES -o $$GLIBC_BASE/build/lind_syscall/lind_syscall.o \
+            -c lind_syscall/lind_syscall.c 
         
         # Compile assembly files
         cd ../ && \

--- a/BUILD
+++ b/BUILD
@@ -174,7 +174,7 @@ genrule(
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)
-    status=$$
+    status=$?
     set -e
 
     echo ""

--- a/BUILD
+++ b/BUILD
@@ -80,6 +80,16 @@ genrule(
             -o $$GLIBC_BASE/build/nptl/pthread_create.o \
             -c pthread_create.c -MD -MP -MF $$GLIBC_BASE/build/nptl/pthread_create.o.dt \
             -MT $$GLIBC_BASE/build/nptl/pthread_create.o
+
+        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \
+            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES \
+            -o $$GLIBC_BASE/build/lind_syscall.o \
+            -c pthread_create.c -MD -MP -MF $$GLIBC_BASE/build/nptl/pthread_create.o.dt \
+            -MT $$GLIBC_BASE/build/nptl/pthread_create.o
+
+        $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \
+            $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES \
+            -c lind_syscall.c -o lind_syscall.o
         
         $$CC $$CFLAGS $$WARNINGS $$EXTRA_FLAGS \ 
             $$INCLUDE_PATHS $$SYS_INCLUDE $$DEFINES $$EXTRA_DEFINES -o $$GLIBC_BASE/build/lind_syscall.o \

--- a/BUILD
+++ b/BUILD
@@ -170,11 +170,9 @@ genrule(
     export GIT_DIR=$$PWD/.git
     export GIT_WORK_TREE=$$PWD
 
-    echo "Checking for shallow clone..."
-    git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow || echo "Repo is already full clone"
-
-    echo "Fetching origin/main..."
-    git fetch origin main || echo "Warning: git fetch main failed"
+    echo "Fetching origin/main without removing remotes..."
+    git remote get-url origin || git remote add origin https://github.com/Lind-Project/lind-wasm.git
+    git fetch origin main:refs/remotes/origin/main || echo "Warning: could not fetch origin/main"    
 
     set +e
     ./clippy_delta_bin --output-file $(location tests/ci-tests/clippy/clippy_out.json)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,3 +4,34 @@
 #
 # For more details, please check https://github.com/bazelbuild/bazel/issues/18958
 ###############################################################################
+
+bazel_dep(name = "rules_rust", version = "0.60.0")
+bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "rules_python", version = "0.40.0")
+
+crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
+crate.spec(
+    features = ["derive"],
+    package = "serde",
+    version = "1.0",
+)
+crate.spec(
+    package = "atty",
+    version = "0.2",
+)
+crate.spec(
+    package = "serde_json",
+    version = "1.0",
+)
+crate.spec(
+    default_features = False,
+    features = [
+        "macros",
+        "net",
+        "rt-multi-thread",
+    ],
+    package = "tokio",
+    version = "1.38",
+)
+crate.from_specs()
+use_repo(crate, "crates")

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -225,7 +225,7 @@ steps:
           curl -X POST -H "Authorization: Bearer $$GITHUB_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
-             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**\\n**[View Clippy Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/clippy.json)**"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
+             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**\\n**[View Clippy Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/clippy_out.json)**"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
           "https://api.github.com/repos/$REPO_FULL_NAME/issues/$_PR_NUMBER/comments"
 
 # Cloud Build machine and logging options

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -180,7 +180,7 @@ steps:
       - |
         gsutil cp /workspace/results.json gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/results.json && 
         gsutil cp /workspace/report.html gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/report.html && 
-        gutil cp /workspace/clippy_out.json gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/clippy_out.json &&        
+        gsutil cp /workspace/clippy_out.json gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/clippy_out.json &&        
         gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/results.json &&
         gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/report.html &&
         gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/clippy_out.json
@@ -225,7 +225,7 @@ steps:
           curl -X POST -H "Authorization: Bearer $$GITHUB_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
-             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**\\n**[View Clippy Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/clippy.json)"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
+             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**\\n**[View Clippy Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/clippy.json)**"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
           "https://api.github.com/repos/$REPO_FULL_NAME/issues/$_PR_NUMBER/comments"
 
 # Cloud Build machine and logging options

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -150,7 +150,7 @@ steps:
         fi
 
         echo "Running tests"
-        docker exec "$$CONTAINER_ID" bazel run //:python_tests && bazel build --experimental_ui_max_stdouterr_bytes=16777216 //:run_clippy_manifest_scan
+        docker exec "$$CONTAINER_ID" /bin/bash -c "bazel run //:python_tests && bazel build //:run_clippy_manifest_scan"
 
         
         echo "Copying test results"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -150,7 +150,8 @@ steps:
         fi
 
         echo "Running tests"
-        docker exec "$$CONTAINER_ID" /bin/bash -c "bazel run //:python_tests && bazel build //:run_clippy_manifest_scan"
+        docker exec "$$CONTAINER_ID" /bin/bash -c "bazel build //:run_clippy_manifest_scan"
+        docker exec "$$CONTAINER_ID" /bin/bash -c "bazel run //:python_tests"
 
         
         echo "Copying test results"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -150,11 +150,13 @@ steps:
         fi
 
         echo "Running tests"
-        docker exec "$$CONTAINER_ID" bazel run //:python_tests
+        docker exec "$$CONTAINER_ID" bazel run //:python_tests && bazel build --experimental_ui_max_stdouterr_bytes=16777216 //:run_clippy_manifest_scan
 
+        
         echo "Copying test results"
         docker cp "$$CONTAINER_ID":/home/lind/lind-wasm/src/RawPOSIX/tmp/results.json /workspace/results.json
         docker cp "$$CONTAINER_ID":/home/lind/lind-wasm/src/RawPOSIX/tmp/report.html /workspace/report.html
+        docker cp "$$CONTAINER_ID":/home/lind/lind-wasm/bazel-bin/tests/ci-tests/clippy/clippy_out.json /workspace/clippy_out.json
         docker rm -fv "$$CONTAINER_ID"
         
     env:
@@ -177,8 +179,10 @@ steps:
       - |
         gsutil cp /workspace/results.json gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/results.json && 
         gsutil cp /workspace/report.html gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/report.html && 
+        gutil cp /workspace/clippy_out.json gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/clippy_out.json &&        
         gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/results.json &&
-        gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/report.html  
+        gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/report.html &&
+        gsutil acl ch -u allUsers:R gs://test_result_json_bucket/$BRANCH_NAME/$BUILD_ID/clippy_out.json
         source /workspace/env.txt
         if [ "$$GLIBC_TAR_CACHE" != "true" ]; then
           echo "creating tar ball"
@@ -220,7 +224,7 @@ steps:
           curl -X POST -H "Authorization: Bearer $$GITHUB_TOKEN" \
               -H "Accept: application/vnd.github.v3+json" \
               -H "Content-Type: application/json" \
-             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
+             -d "$(printf '{"body":"**Test Report**\\n\\n**[View HTML Report](https://storage.googleapis.com/test_result_json_bucket/%s/%s/report.html)**\\n**[View JSON Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/results.json)**\\n**[View Clippy Results](https://storage.googleapis.com/test_result_json_bucket/%s/%s/clippy.json)"}' "$BRANCH_NAME" "$BUILD_ID" "$BRANCH_NAME" "$BUILD_ID")" \
           "https://api.github.com/repos/$REPO_FULL_NAME/issues/$_PR_NUMBER/comments"
 
 # Cloud Build machine and logging options

--- a/tests/ci-tests/clippy/Cargo.toml
+++ b/tests/ci-tests/clippy/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 git2 = "0.18"
 cargo_metadata = "0.18"
 atty = "0.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/tests/ci-tests/clippy/Cargo.toml
+++ b/tests/ci-tests/clippy/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "clippy_delta"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+git2 = "0.18"
+cargo_metadata = "0.18"
+atty = "0.2"

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -74,6 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if changed_rs_files.is_empty() {
         println!("{}", colors::green("No changed Rust files found since origin/main."));
+        output::write_results(&[])?;
         return Ok(());
     }
 
@@ -92,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if manifest_paths.is_empty() {
         println!("{}", colors::red("No Cargo.toml files found for changed files."));
+        output::write_results(&[])?;
         return Ok(());
     }
 

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -149,6 +149,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if affected_crates.is_empty() {
         println!("{}", colors::red("No crate names matched changed files."));
+        println!("{}", colors::green("Running Clippy for current package instead."));
+    
+        let status = Command::new("cargo")
+            .args([
+                "clippy",
+                "--manifest-path",
+                "tests/ci-tests/clippy/Cargo.toml",
+                "--all-targets",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+            ])
+            .status()?;
+    
+        if !status.success() {
+            eprintln!("{}", colors::red("Clippy failed on fallback run."));
+            std::process::exit(1);
+        }
+    
+        println!("{}", colors::green("Fallback Clippy run passed successfully."));
         return Ok(());
     }
 

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -64,27 +64,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or_else(|| "tests/ci-tests/clippy/clippy_out.json".to_string());
 
 
-    let merge_base = String::from_utf8(
-        Command::new("git")
-            .args(["merge-base", "HEAD", "origin/main"])
-            .output()?
-            .stdout,
-    )?
-    .trim()
-    .to_string();
-
     let diff_output = Command::new("git")
-        .args(["diff", "--name-only", &format!("{merge_base}...HEAD")])
-        .output()?;
-
+    .args(["diff", "--name-only", "HEAD^..HEAD", "--","*.rs"])
+    .output()?;
+    
     let changed_rs_files: Vec<PathBuf> = String::from_utf8(diff_output.stdout)?
-        .lines()
-        .filter(|line| line.trim_end().ends_with(".rs"))
+        .lines()        
         .map(PathBuf::from)
         .collect();
+    
 
     if changed_rs_files.is_empty() {
-        println!("{}", colors::green("No changed Rust files found since origin/main."));
+        println!("{}", colors::green("No changed Rust files found in HEAD commit."));
         output::write_results(&[], &output_file)?;
         return Ok(());
     }

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -1,0 +1,179 @@
+//! Clippy Delta Checker
+//!
+//! This tool detects which Rust files have changed since the last common commit with `origin/main`,
+//! identifies which crates those files belong to, and runs `cargo clippy` on each affected crate.
+//!
+//! Intended to be used in CI or pre-push workflows to avoid running Clippy on the entire workspace.
+//!
+//! # Behavior
+//! - All changed `.rs` files are collected via shell `git diff`.
+//! - Each file is traced upward to the nearest `Cargo.toml`.
+//! - The list of affected crates is deduplicated to ensure Clippy only runs once per crate.
+//!
+//! Even if multiple Rust files are changed within the same crate, that crate is only linted once.
+//!
+//! # Usage
+//! ```sh
+//! cargo run --manifest-path tests/ci-tests/clippy/Cargo.toml
+//! ```
+
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+/// Simple ANSI escape codes and color logic for output.
+mod colors {
+    pub const RED: &str = "\x1b[31m";
+    pub const GREEN: &str = "\x1b[32m";
+    pub const RESET: &str = "\x1b[0m";
+
+    /// Returns a red-colored string if outputting to a TTY.
+    pub fn red(text: &str) -> String {
+        if is_tty() {
+            format!("{RED}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    /// Returns a green-colored string if outputting to a TTY.
+    pub fn green(text: &str) -> String {
+        if is_tty() {
+            format!("{GREEN}{text}{RESET}")
+        } else {
+            text.to_string()
+        }
+    }
+
+    fn is_tty() -> bool {
+        atty::is(atty::Stream::Stdout)
+    }
+}
+
+/// Runs Clippy on all crates that contain `.rs` files changed since the last shared commit
+/// with `origin/main`.
+///
+/// # Behavior
+/// 1. Uses `git` via subprocess to find the merge base between HEAD and `origin/main`.
+/// 2. Diffs the two commits to find all changed `.rs` files.
+/// 3. Walks up from each file to locate the nearest `Cargo.toml`.
+/// 4. Uses `cargo_metadata` to find canonical crate names.
+/// 5. Deduplicates affected crates and runs `cargo clippy` on each one.
+///
+/// If multiple files change within the same crate, that crate is only checked once.
+///
+/// # Errors
+/// Returns an error if:
+/// - Git commands fail or produce invalid output
+/// - Metadata cannot be extracted from `cargo metadata`
+/// - Any `cargo clippy` command fails
+///
+/// # Panics
+/// This function does not intentionally panic.
+///
+/// # Examples
+/// ```sh
+/// cargo run --manifest-path tests/ci-tests/clippy/Cargo.toml
+/// ```
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Step 1: Get the merge base between HEAD and origin/main
+    let merge_base = Command::new("git")
+        .args(["merge-base", "HEAD", "origin/main"])
+        .output()?;
+
+    if !merge_base.status.success() {
+        return Err("Failed to get merge base from git.".into());
+    }
+
+    let merge_base_sha = String::from_utf8(merge_base.stdout)?.trim().to_string();
+
+    // Step 2: Get list of changed Rust files since the merge base
+    let diff_output = Command::new("git")
+        .args(["diff", "--name-only", &format!("{merge_base_sha}...HEAD")])
+        .output()?;
+
+    if !diff_output.status.success() {
+        return Err("Failed to get diff from git.".into());
+    }
+
+    let changed_rs_files: Vec<PathBuf> = String::from_utf8(diff_output.stdout)?
+        .lines()
+        .filter(|line| line.trim_end().ends_with(".rs"))
+        .map(PathBuf::from)
+        .collect();
+
+    if changed_rs_files.is_empty() {
+        println!("{}", colors::green("No changed Rust files found since origin/main."));
+        return Ok(());
+    }
+
+    println!("Changed Rust files:");
+    for f in &changed_rs_files {
+        println!("  {}", f.display());
+    }
+
+    // Step 3: Walk up to find Cargo.toml for each changed file
+    let mut crate_dirs = HashSet::new();
+    for file in &changed_rs_files {
+        let mut current = file.parent();
+        while let Some(dir) = current {
+            if dir.join("Cargo.toml").exists() {
+                crate_dirs.insert(dir.to_path_buf());
+                break;
+            }
+            current = dir.parent();
+        }
+    }
+
+    if crate_dirs.is_empty() {
+        println!("{}", colors::red("No crates found for changed files."));
+        return Ok(());
+    }
+
+    // Step 4: Use cargo_metadata to resolve canonical crate names
+    let metadata = cargo_metadata::MetadataCommand::new()
+    .manifest_path("tests/ci-tests/clippy/Cargo.toml")
+    .exec()?;
+    let mut affected_crates = HashSet::new();
+
+    for crate_dir in crate_dirs {
+        for package in &metadata.packages {
+            let manifest_path = Path::new(&package.manifest_path);
+            if manifest_path.starts_with(&crate_dir) {
+                affected_crates.insert(package.name.clone());
+            }
+        }
+    }
+
+    if affected_crates.is_empty() {
+        println!("{}", colors::red("No crate names matched changed files."));
+        return Ok(());
+    }
+
+    // Step 5: Run Clippy for each affected crate
+    for krate in &affected_crates {
+        println!("Running Clippy for crate `{}`...", krate);
+        let status = Command::new("cargo")
+            .args([
+                "clippy",
+                "-p",
+                krate,
+                "--all-targets",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+            ])
+            .status()?;
+
+        if !status.success() {
+            eprintln!("{}", colors::red(&format!("Clippy failed on crate `{}`.", krate)));
+            std::process::exit(1);
+        }
+    }
+
+    println!("{}", colors::green("All Clippy checks passed successfully."));
+    Ok(())
+}

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -10,8 +10,6 @@
 //! - Each file is traced upward to the nearest `Cargo.toml`.
 //! - The list of affected crates is deduplicated to ensure Clippy only runs once per crate.
 //!
-//! Even if multiple Rust files are changed within the same crate, that crate is only linted once.
-//!
 //! # Usage
 //! ```sh
 //! cargo run --manifest-path tests/ci-tests/clippy/Cargo.toml

--- a/tests/ci-tests/clippy/src/main.rs
+++ b/tests/ci-tests/clippy/src/main.rs
@@ -175,7 +175,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Step 5: Run Clippy for each affected crate
     for krate in &affected_crates {
-        println!("Running Clippy for crate `{}`...", krate);
+        println!("Running Clippy for crate `{krate}`...");
         let status = Command::new("cargo")
             .args([
                 "clippy",
@@ -190,7 +190,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .status()?;
 
         if !status.success() {
-            eprintln!("{}", colors::red(&format!("Clippy failed on crate `{}`.", krate)));
+            eprintln!("{}", colors::red(&format!("Clippy failed on crate `{krate}`.")));
             std::process::exit(1);
         }
     }

--- a/tests/ci-tests/clippy/src/output.rs
+++ b/tests/ci-tests/clippy/src/output.rs
@@ -1,0 +1,48 @@
+//! Output Module for Clippy Delta Checker
+//!
+//! This module defines the JSON reporting format for Clippy results.
+//! It serializes the run status for each manifest into `tests/ci-tests/clippy/clippy_out.json`
+//! for use in CI systems, web reporting, or later analysis.
+
+use serde::Serialize;
+use std::{fs::File, path::Path};
+
+/// A single Clippy run result for a specific Cargo manifest.
+#[derive(Serialize)]
+pub struct RunResult {
+    /// Path to the Cargo.toml that was checked.
+    pub manifest_path: String,
+    /// Outcome of the Clippy run: either "success" or "failure".
+    pub status: String,
+    /// Full stderr output from Clippy if the run failed; omitted for successes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_body: Option<String>,
+}
+
+/// Serialize all collected Clippy results into a structured JSON file.
+///
+/// Saves results to `tests/ci-tests/clippy/clippy_out.json`.
+/// Ensures the output folder exists before writing.
+///
+/// # Arguments
+/// * `results` - A slice of `RunResult` entries describing each Clippy run.
+///
+/// # Errors
+/// Returns an error if the output file cannot be created or written.
+///
+/// # Example
+/// ```
+/// output::write_results(&results)?;
+/// ```
+pub fn write_results(results: &[RunResult]) -> Result<(), Box<dyn std::error::Error>> {
+    let output_path = Path::new("tests/ci-tests/clippy/clippy_out.json");
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let file = File::create(output_path)?;
+    serde_json::to_writer_pretty(file, &serde_json::json!({ "results": results }))?;
+
+    Ok(())
+}

--- a/tests/ci-tests/clippy/src/output.rs
+++ b/tests/ci-tests/clippy/src/output.rs
@@ -34,15 +34,13 @@ pub struct RunResult {
 /// ```
 /// output::write_results(&results)?;
 /// ```
-pub fn write_results(results: &[RunResult]) -> Result<(), Box<dyn std::error::Error>> {
-    let output_path = Path::new("tests/ci-tests/clippy/clippy_out.json");
-
+pub fn write_results(results: &[RunResult], output_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let output_path = Path::new(output_path);
     if let Some(parent) = output_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-
     let file = File::create(output_path)?;
     serde_json::to_writer_pretty(file, &serde_json::json!({ "results": results }))?;
-
     Ok(())
 }
+


### PR DESCRIPTION
This PR includes a tool for clippy to run against modified rs files.

To summarize the behavior of it:

1. It determines where the branch diverged from origin/main
2. It finds all modified rust files since the divergence point
3. It traces the changes upward to the nearest `Cargo.toml`  and runs `cargo clippy --manifest-path <path> --all-targets --all-features -- -D warnings`
 for each.
4. It marks a pass/fail for the clippy tool and logs them all to a json file at `tests/ci-tests/clippy/clippy_out.json`
5.  Wraps the tool in a bazel rule that can be executed either standalone or via CI
6.  Includes changes to cloudbuild.yaml for feedback to PRs