### PR TITLE
Add files for PR Checklist comment via github workflows

### DIFF
--- a/.github/templates/PR_Checklist.md
+++ b/.github/templates/PR_Checklist.md
@@ -1,0 +1,35 @@
+## Description
+
+Fixes # (issue)
+
+<!-- Please include a summary of the changes and the related issue. --> 
+<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
+<!-- List any dependencies that are required for this change. -->
+
+### Type of change
+
+<!-- Please delete options that are not relevant. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## How Has This Been Tested?
+
+<!-- Please describe the tests that you ran to verify your changes. -->
+<!-- Provide instructions so we can reproduce. -->
+<!-- Please also list any relevant details for your test configuration -->
+
+- Test A - `lind_project/tests/test_cases/test_a.c`
+- Test B - `lind_project/tests/test_cases/test_b.c`
+
+## Checklist:
+
+<!-- Add details about the checklist whenever needed -->
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)

--- a/.github/workflows/pr-comment.yaml
+++ b/.github/workflows/pr-comment.yaml
@@ -1,0 +1,37 @@
+# This is a GitHub Actions workflow that automatically posts a comment
+# on every new Pull Request (PR), using a markdown template stored in the repo.
+
+name: Comment on PR with Template
+
+# Trigger this workflow when a new pull request is opened
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  # Define a job named 'comment' that runs on the latest Ubuntu runner
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the contents of the repository
+      # This ensures the markdown template file is available for later steps
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Step 2: Read the markdown template and post it as a comment on the PR
+      # Uses GitHub's REST API via the github-script action
+      - name: Read PR checklist and post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.github/templates/PR_Checklist.md';
+            const body = fs.readFileSync(path, 'utf8');
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });


### PR DESCRIPTION
This pull request introduces a GitHub workflow that automatically posts a checklist comment on every newly opened pull request.

How it works:

- The workflow is triggered when a new pull request is opened (pull_request: types: [opened])
- It uses actions/github-script to read .github/templates/PR_Checklist.md
- The contents of that file are posted as a comment on the pull request using GitHub’s REST API
- The checklist provides contributors with a consistent set of review criteria before maintainers begin a review


Template location:
.github/templates/PR_Checklist.md

Workflow location:
.github/workflows/pr-comment.yml

Purpose:
This ensures that contributors are reminded to follow key quality checks, helping to streamline reviews and maintain code quality across the project.