### PR TITLE
Shorten PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,35 +1,9 @@
-## Description
+<!-- Before submitting a PR, make sure:
 
-Fixes # (issue)
+* new code is tested
+* tests pass locally
+* docs are up-to-date
 
-<!-- Please include a summary of the changes and the related issue. --> 
-<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
-<!-- List any dependencies that are required for this change. -->
+For details, see https://lind-project.github.io/lind-wasm/contribute/
 
-### Type of change
-
-<!-- Please delete options that are not relevant. -->
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-## How Has This Been Tested?
-
-<!-- Please describe the tests that you ran to verify your changes. -->
-<!-- Provide instructions so we can reproduce. -->
-<!-- Please also list any relevant details for your test configuration -->
-
-- Test A - `lind_project/tests/test_cases/test_a.c`
-- Test B - `lind_project/tests/test_cases/test_b.c`
-
-## Checklist:
-
-<!-- Add details about the checklist whenever needed -->
-
-- [ ] My code follows the style guidelines of this project
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] My changes generate no new warnings
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, safeposix-rust)
+Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->


### PR DESCRIPTION
fixes https://github.com/Lind-Project/lind-wasm/issues/208 (see issue for reasoning)

The main goal here is to give contributors enough instructions, to make
reviews easier, without inducing guideline fatigue. If the new template
turns out to be too succinct, I'm happy to add back any of the removed
details.