### PR TITLE
Fix docs cross-link

### DIFF
--- a/docs/contribute/README.md
+++ b/docs/contribute/README.md
@@ -13,6 +13,6 @@ Detailed guidelines about writing code, tests, documentation, and more are below
 
 * [Rust Style Guide](styleguide.md)
 * [Unit Tests](unit-tests.md)
-* [Adding to the docs](writeDoc.md)
+* [Adding to the docs](add-docs.md)
 * [Security Policy](security.md)
 * [Code of Conduct](../community/conduct.md)


### PR DESCRIPTION
The "How to add docs" page was renamed in #222, without updating all links. Now it should be fine.


