### PR TITLE
Add basic lint GHA workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Format
+        run: cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml

--- a/src/RawPOSIX/.rustfmt.toml
+++ b/src/RawPOSIX/.rustfmt.toml
@@ -1,5 +1,0 @@
-ignore = [
-    "src/safeposix/syscalls/net_constants.rs",
-    "src/safeposix/syscalls/sys_constants.rs",
-    "src/safeposix/syscalls/fs_constants.rs",
-]

--- a/src/RawPOSIX/src/interface/mem.rs
+++ b/src/RawPOSIX/src/interface/mem.rs
@@ -6,10 +6,10 @@ use sysdefs::constants::fs_const::{
 
 use crate::interface::cagetable_getref;
 use crate::safeposix::cage::Cage;
+use crate::safeposix::shm::ShmMetadata;
+use crate::safeposix::shm::{get_shm_length, SHM_METADATA};
 use crate::safeposix::vmmap::{MemoryBackingType, Vmmap, VmmapOps};
 use std::result::Result;
-use crate::safeposix::shm::{SHM_METADATA,get_shm_length};
-use crate::safeposix::shm::ShmMetadata;
 use std::sync::Arc;
 use sysdefs::constants::SHM_RDONLY;
 
@@ -166,13 +166,7 @@ pub fn munmap_handler(cageid: u64, addr: *mut u8, len: usize) -> i32 {
 /// # Errors
 /// * `EINVAL` - If the provided address is not page-aligned
 /// * `ENOMEM` - If there is insufficient memory to complete the attachment
-pub fn shmat_handler(
-    cageid: u64,
-    addr: *mut u8,
-    mut prot: i32,
-    shmflag: i32,
-    shmid: i32,
-) -> u32 {
+pub fn shmat_handler(cageid: u64, addr: *mut u8, mut prot: i32, shmflag: i32, shmid: i32) -> u32 {
     // Get the cage reference.
     let cage = cagetable_getref(cageid);
 
@@ -187,7 +181,7 @@ pub fn shmat_handler(
         Some(l) => l,
         None => return syscall_error(Errno::EINVAL, "shmat", "invalid shmid") as u32,
     };
-    
+
     // Check that the provided address is page aligned.
     let rounded_addr = round_up_page(addr as u64);
     if rounded_addr != addr as u64 {
@@ -270,7 +264,7 @@ pub fn shmat_handler(
 /// Handler of the `shmdt_syscall`, interacting with the `vmmap` structure.
 ///
 /// This function processes the `shmdt_syscall` by updating the `vmmap` entries and managing
-/// the shared memory detachment operation. It performs address validation, converts user 
+/// the shared memory detachment operation. It performs address validation, converts user
 /// addresses to system addresses, and updates the virtual memory mappings accordingly.
 ///
 /// # Arguments
@@ -304,11 +298,13 @@ pub fn shmdt_handler(cageid: u64, addr: *mut u8) -> i32 {
     // This call removes the range starting at the page-aligned user address,
     // for the number of pages that cover the shared memory region.
     let mut vmmap = cage.vmmap.write();
-    vmmap.remove_entry(rounded_addr as u32 >> PAGESHIFT, (length as u32) >> PAGESHIFT);
+    vmmap.remove_entry(
+        rounded_addr as u32 >> PAGESHIFT,
+        (length as u32) >> PAGESHIFT,
+    );
 
     0
 }
-
 
 /// Handles the `mmap_syscall`, interacting with the `vmmap` structure.
 ///
@@ -464,7 +460,7 @@ pub fn mmap_handler(
                 len as i64,
                 cageid,
             );
-    
+
             // Check if adding the entry was successful.
             if add_result.is_err() {
                 return syscall_error(Errno::ENOMEM, "mmap", "failed to add vmmap entry") as u32;
@@ -500,7 +496,11 @@ pub fn mprotect_handler(cageid: u64, addr: *mut u8, len: usize, prot: i32) -> i3
     // TODO: Remove this panic when we support PROT_EXEC for real user code
     if prot & PROT_EXEC > 0 {
         // Log the attempt through syscall_error's verbose logging
-        let _ = syscall_error(Errno::EINVAL, "mprotect", "PROT_EXEC attempt detected - this will panic in development");
+        let _ = syscall_error(
+            Errno::EINVAL,
+            "mprotect",
+            "PROT_EXEC attempt detected - this will panic in development",
+        );
         // Panic during development for early detection of unsupported operations
         panic!("PROT_EXEC is not currently supported in WASM");
     }
@@ -520,7 +520,7 @@ pub fn mprotect_handler(cageid: u64, addr: *mut u8, len: usize, prot: i32) -> i3
     let rounded_length = round_up_page(len as u64);
 
     let mut vmmap = cage.vmmap.write();
-    
+
     // Convert to page numbers for vmmap checking
     let start_page = (addr as u32) >> PAGESHIFT;
     let npages = (rounded_length >> PAGESHIFT) as u32;
@@ -532,7 +532,7 @@ pub fn mprotect_handler(cageid: u64, addr: *mut u8, len: usize, prot: i32) -> i3
 
     // Get system address for the actual mprotect call
     let sysaddr = vmmap.user_to_sys(addr as u32);
-    
+
     drop(vmmap);
 
     // Perform mprotect through cage implementation

--- a/src/RawPOSIX/src/safeposix/dispatcher.rs
+++ b/src/RawPOSIX/src/safeposix/dispatcher.rs
@@ -243,7 +243,7 @@ pub fn lind_syscall_api(
             let addr = arg1 as *mut u8;
             let len = arg2 as usize;
             let prot = arg3 as i32;
-            
+
             interface::mprotect_handler(cageid, addr, len, prot)
         }
 
@@ -737,7 +737,6 @@ pub fn lind_syscall_api(
             let shmflg = arg3 as i32;
             interface::shmat_handler(cageid, addr, 0, shmflg, shmid) as i32
         }
-                
 
         SHMDT_SYSCALL => {
             let addr = arg1 as *mut u8;

--- a/src/RawPOSIX/src/safeposix/shm.rs
+++ b/src/RawPOSIX/src/safeposix/shm.rs
@@ -144,9 +144,10 @@ impl ShmMetadata {
         }
     }
     pub fn get_shm_length(&self, shmid: i32) -> Option<usize> {
-        self.shmtable.get(&shmid).map(|segment| segment.get_shm_length())
+        self.shmtable
+            .get(&shmid)
+            .map(|segment| segment.get_shm_length())
     }
-    
 
     pub fn new_keyid(&self) -> i32 {
         self.nextid

--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -864,7 +864,7 @@ impl Cage {
     ///     - cageid: current cage identifier.
     ///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment to be closed.
     ///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused.
-    /// 
+    ///
     /// ## Returns:
     ///     Return 0 when success; -1 along with errno when fail.
     pub fn close_syscall(&self, virtual_fd: i32) -> i32 {
@@ -1154,14 +1154,12 @@ impl Cage {
 
     //------------------------------------MPROTECT SYSCALL------------------------------------
     /*
-    *   mprotect() changes protection for memory pages
-    *   Returns 0 on success, -1 on failure
-    *   Manual page: https://man7.org/linux/man-pages/man2/mprotect.2.html
-    */
+     *   mprotect() changes protection for memory pages
+     *   Returns 0 on success, -1 on failure
+     *   Manual page: https://man7.org/linux/man-pages/man2/mprotect.2.html
+     */
     pub fn mprotect_syscall(&self, addr: *mut u8, len: usize, prot: i32) -> i32 {
-        let ret = unsafe {
-            libc::mprotect(addr as *mut c_void, len, prot)
-        };
+        let ret = unsafe { libc::mprotect(addr as *mut c_void, len, prot) };
         if ret < 0 {
             let errno = get_errno();
             return handle_errno(errno, "mprotect");
@@ -1554,7 +1552,7 @@ impl Cage {
     //------------------SHMDT SYSCALL------------------
     /*
      * Detaches the shared memory segment located at the address specified by shmaddr.
-     * 
+     *
      * Return value:
      * - On success: returns the length of the detached segment
      * - On error: returns a negative errno value

--- a/src/RawPOSIX/src/tests/fs_tests.rs
+++ b/src/RawPOSIX/src/tests/fs_tests.rs
@@ -3,7 +3,10 @@
 pub mod fs_tests {
 
     use super::super::*;
-    use fdtables::{translate_virtual_fd};
+    use crate::interface;
+    use crate::safeposix::syscalls::fs_calls::*;
+    use crate::safeposix::{cage::*, dispatcher::*, filesystem};
+    use fdtables::translate_virtual_fd;
     use sysdefs::{
         constants::{
             err_const::get_errno,
@@ -13,14 +16,12 @@ pub mod fs_tests {
         },
         data::{
             fs_struct::{
-                ClippedDirent, FSData, PipeArray, ShmidsStruct, SockPair, StatData, CLIPPED_DIRENT_SIZE,
+                ClippedDirent, FSData, PipeArray, ShmidsStruct, SockPair, StatData,
+                CLIPPED_DIRENT_SIZE,
             },
             net_struct::{GenSockaddr, SockaddrV4},
         },
     };
-    use crate::interface;
-    use crate::safeposix::syscalls::fs_calls::*;
-    use crate::safeposix::{cage::*, dispatcher::*, filesystem};
 
     use libc::*;
     use libc::{c_void, O_DIRECTORY};
@@ -756,16 +757,15 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
 
-
         // Create an anonymous memory mapping with read-only permissions
         // This simulates the C program's mmap() call to allocate a read-only page
         let readonlydata = cage.mmap_syscall(
-            std::ptr::null_mut(),      // Let kernel choose address
-            PAGESIZE as usize,         // Map one page
-            PROT_READ,                 // Initially read-only
-            (MAP_ANONYMOUS | MAP_PRIVATE) as i32,  // Private anonymous mapping
-            -1,                        // No file descriptor for anonymous mapping
-            0                         // Offset is ignored for anonymous mappings
+            std::ptr::null_mut(),                 // Let kernel choose address
+            PAGESIZE as usize,                    // Map one page
+            PROT_READ,                            // Initially read-only
+            (MAP_ANONYMOUS | MAP_PRIVATE) as i32, // Private anonymous mapping
+            -1,                                   // No file descriptor for anonymous mapping
+            0,                                    // Offset is ignored for anonymous mappings
         );
         assert!(readonlydata >= 0, "mmap should succeed");
 
@@ -774,7 +774,7 @@ pub mod fs_tests {
         let result = cage.mprotect_syscall(
             readonlydata as *mut u8,
             PAGESIZE as usize,
-            PROT_READ | PROT_WRITE    // Add write permission
+            PROT_READ | PROT_WRITE, // Add write permission
         );
         assert_eq!(result, 0, "mprotect should succeed");
 
@@ -786,9 +786,9 @@ pub mod fs_tests {
             let result = libc::memcpy(
                 readonlydata as *mut libc::c_void,
                 text.as_ptr() as *const libc::c_void,
-                text.len()
+                text.len(),
             );
-            
+
             // Verify that the write operation succeeded by comparing memory contents
             let written = std::slice::from_raw_parts(readonlydata as *const u8, text.len());
             assert_eq!(written, text, "Written data should match test string");
@@ -815,7 +815,11 @@ pub mod fs_tests {
         // Try to protect an unmapped address
         let unmapped_addr = 0x1000 as *mut u8; // Some arbitrary address
         let result = cage.mprotect_syscall(unmapped_addr, 4096, PROT_READ);
-        assert_eq!(result, -(Errno::ENOMEM as i32), "mprotect should fail with ENOMEM for unmapped address");
+        assert_eq!(
+            result,
+            -(Errno::ENOMEM as i32),
+            "mprotect should fail with ENOMEM for unmapped address"
+        );
 
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
@@ -825,7 +829,7 @@ pub mod fs_tests {
     pub fn ut_lind_fs_mprotect_split_region() {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
-    
+
         // Map 4 pages with anonymous mapping
         let addr = cage.mmap_syscall(
             std::ptr::null_mut(),
@@ -833,22 +837,21 @@ pub mod fs_tests {
             PROT_READ | PROT_WRITE,
             (MAP_PRIVATE | MAP_ANONYMOUS) as i32,
             -1,
-            0
+            0,
         );
-        
+
         assert!(addr >= 0, "mmap failed with error: {}", addr);
-    
+
         // Change protection for middle two pages
         let middle_addr = (addr as usize + PAGESIZE as usize) as *mut u8;
-        let result = cage.mprotect_syscall(
-            middle_addr,
-            PAGESIZE as usize * 2,
-            PROT_READ
-        );
+        let result = cage.mprotect_syscall(middle_addr, PAGESIZE as usize * 2, PROT_READ);
         assert_eq!(result, 0, "mprotect failed");
-    
+
         // Clean up
-        assert_eq!(cage.munmap_syscall(addr as *mut u8, PAGESIZE as usize * 4), 0);
+        assert_eq!(
+            cage.munmap_syscall(addr as *mut u8, PAGESIZE as usize * 4),
+            0
+        );
     }
 
     #[test]
@@ -3031,7 +3034,7 @@ pub mod fs_tests {
 
         lindrustfinalize();
     }
-    
+
     #[test]
     pub fn ut_lind_fs_shmat_invalid_args() {
         // Acquire lock and init environment
@@ -3041,7 +3044,11 @@ pub mod fs_tests {
         // Test case 1: Invalid shmid
         let invalid_shmid = -1;
         let result = cage.shmat_syscall(invalid_shmid, 0 as *mut u8, 0);
-        assert_eq!(result, -(Errno::EINVAL as i32), "Expected EINVAL for invalid shmid");
+        assert_eq!(
+            result,
+            -(Errno::EINVAL as i32),
+            "Expected EINVAL for invalid shmid"
+        );
 
         // Test case 2: Create a valid segment first
         let key = 31337;
@@ -3055,8 +3062,11 @@ pub mod fs_tests {
 
         // Clean up
         let mut shmidstruct = ShmidsStruct::default();
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)), 0);
-        
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)),
+            0
+        );
+
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -3078,16 +3088,28 @@ pub mod fs_tests {
 
         // Verify attachment count
         let mut shmidstruct = ShmidsStruct::default();
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)), 0);
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)),
+            0
+        );
         assert_eq!(shmidstruct.shm_nattch, 1, "Expected 1 attachment");
 
         // Detach and verify count decreases
         assert_eq!(cage.shmdt_syscall(addr1 as *mut u8), shmid);
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)), 0);
-        assert_eq!(shmidstruct.shm_nattch, 0, "Expected 0 attachments after detach");
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)),
+            0
+        );
+        assert_eq!(
+            shmidstruct.shm_nattch, 0,
+            "Expected 0 attachments after detach"
+        );
 
         // Clean up
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)), 0);
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)),
+            0
+        );
 
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();
@@ -3095,7 +3117,7 @@ pub mod fs_tests {
 
     #[test]
     pub fn ut_lind_fs_shmat_read_only() {
-        // Acquire lock and init environment  
+        // Acquire lock and init environment
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
 
@@ -3110,12 +3132,18 @@ pub mod fs_tests {
 
         // Verify the segment was attached
         let mut shmidstruct = ShmidsStruct::default();
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)), 0);
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_STAT, Some(&mut shmidstruct)),
+            0
+        );
         assert_eq!(shmidstruct.shm_nattch, 1, "Expected 1 attachment");
 
         // Clean up
         assert_eq!(cage.shmdt_syscall(result as *mut u8), shmid);
-        assert_eq!(cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)), 0);
+        assert_eq!(
+            cage.shmctl_syscall(shmid, IPC_RMID, Some(&mut shmidstruct)),
+            0
+        );
 
         assert_eq!(cage.exit_syscall(libc::EXIT_SUCCESS), libc::EXIT_SUCCESS);
         lindrustfinalize();

--- a/src/sysdefs/src/constants/sys_const.rs
+++ b/src/sysdefs/src/constants/sys_const.rs
@@ -126,4 +126,3 @@ pub const FUTEX_WAKE_BITSET: i32 = 10;
 pub const FUTEX_WAIT_REQUEUE_PI: i32 = 11;
 pub const FUTEX_CMP_REQUEUE_PI: i32 = 12;
 pub const FUTEX_LOCK_PI2: i32 = 13;
-


### PR DESCRIPTION
Add basic GitHub Action workflow to run `cargo fmt --check ...`, and apply required fixes to make it pass.

Note: cargo fmt is run over the `wasmtime` workspace, which includes all custom crates (rawposix, ...).

See commit messages for details.
