### PR TITLE
Run clippy in GHA lint workflow 

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,3 +18,25 @@ jobs:
 
       - name: Format
         run: cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
+
+      # Using rust nightly, invalidates cache every day
+      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+
+      - name: Switch to Rust nightly
+        run: |
+          rustup update nightly
+          rustup default nightly
+          rustup component add clippy
+
+      - name: Clippy
+        run: |
+          # Run clippy over wasmtime and its dependencies
+          # See `cargo clippy` and `cargo check` for available options
+          cargo clippy \
+              --manifest-path src/wasmtime/Cargo.toml \
+              --all-features \
+              --keep-going \
+              -- \
+              -A warnings \
+              -A clippy::not_unsafe_ptr_arg_deref \
+              -A clippy::absurd_extreme_comparisons

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Switch to Rust nightly
         run: |
-          rustup update nightly
-          rustup default nightly
+          # Pin to last working nightly version (see #242)
+          rustup default nightly-2025-06-08
           rustup component add clippy
 
       - name: Clippy


### PR DESCRIPTION
Runs clippy over wasmtime and its dependencies (including rawposix,
fdtables and sysdefs). This is lightweight enough, to run on GHA.

The following exemptions (-A) are currently enabled, but should be
disabled and fixed in follow-up PRs:
- warnings -- there are plenty all over the place
- not_unsafe_ptr_arg_deref -- a few found in rawposix
- absurd_extreme_comparisons -- ditto

The following additional lints could be enabled:
- --all-targets -- includes tests, benches and examples, in addition to
  libs and bins, which are included by default
- --workspace -- includes workspace members, which aren't also
  dependencies

related to #220