### PR TITLE
Add experimental Dockerfile for end-to-end testing  (WIP)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,13 @@
+name: End-to-end testing
+
+on:
+  push:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build e2e
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,85 @@
+# syntax=docker/dockerfile:1.7-labs
+# (use non-stable syntax for convenient --parents option in COPY command)
+
+# Download clang
+# NOTE: chmod is required to extract as user below
+FROM scratch AS clang
+ADD --chmod=644 https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.4/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz /clang.tar.xz
+
+FROM ubuntu:latest
+
+#####################
+# SYSTEM DEPENDENCIES
+#####################
+# TODO: only install required deps, and only in the stage, where needed
+# TODO: https://docs.docker.com/build/building/best-practices/#apt-get
+RUN apt-get update && \
+    apt-get install -y -qq \
+        apt-transport-https \
+        bash \
+        binaryen \
+        bison \
+        build-essential \
+        curl \
+        g++ \
+        g++-i686-linux-gnu \
+        gawk \
+        gcc \
+        gcc-i686-linux-gnu \
+        git \
+        gnupg \
+        golang \
+        libssl-dev \
+        libxml2 \
+        openssl \
+        python3 \
+        sudo \
+        unzip \
+        vim \
+        wget \
+        zip
+
+#####################
+# USER SETUP
+#####################
+# TODO: do not require user and abspaths (in build/test scripts)
+RUN usermod --login lind --move-home --home /home/lind ubuntu && \
+    groupmod --new-name lind ubuntu
+RUN echo "lind ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+USER lind
+RUN mkdir /home/lind/lind-wasm
+WORKDIR /home/lind/lind-wasm
+
+
+###################
+# USER DEPENDENCIES
+###################
+# Install pinned rust nightly version (known to work)
+# TODO: Figure out why newer versions break the build and unpin
+# TODO: Beware of RUN layer caching: cache not invalidated by remote change
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --default-toolchain nightly-2025-06-01
+ENV PATH="/home/lind/.cargo/bin:${PATH}"
+
+# Extract Clang
+# see best practices for downloading and extracting large files
+# https://docs.docker.com/build/building/best-practices/#add-or-copy
+RUN --mount=from=clang,target=/clang tar xf /clang/clang.tar.xz
+
+###################
+# Build GLIBC
+###################
+COPY --chown=lind:lind src/glibc src/glibc
+RUN ./src/glibc/gen_sysroot.sh
+
+###################
+# Build WASMTIME
+###################
+COPY --chown=lind:lind --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs .
+RUN cargo build --manifest-path src/wasmtime/Cargo.toml
+
+###################
+# Run TESTS
+###################
+COPY --chown=lind:lind --parents scripts tests tools .
+RUN ./scripts/wasmtestreport.py

--- a/src/glibc/gen_sysroot.sh
+++ b/src/glibc/gen_sysroot.sh
@@ -1,46 +1,130 @@
 #!/bin/bash
 
-GLIBC_BASE="/home/lind/lind-wasm/src/glibc"
-# Define the source directory for object files (change ./build to your desired path)
-src_dir="$GLIBC_BASE/build"
+set -x
 
-# Define paths for copying additional resources
-include_source_dir="$GLIBC_BASE/target/include"
-crt1_source_path="$GLIBC_BASE/lind_syscall/crt1.o"
-lind_syscall_path="$GLIBC_BASE/build/lind_syscall.o" # Path to the lind_syscall.o file
+# Define absolute paths expected by lindtool.sh and wasmtestreport.sh
+GLIBC="/home/lind/lind-wasm/src/glibc"
+CLANG="/home/lind/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04"
+BUILD="$GLIBC/build"
+CC="$CLANG/bin/clang"
+SYSROOT="$GLIBC/sysroot"
+SYSROOT_ARCHIVE="$SYSROOT/lib/wasm32-wasi/libc.a"
 
-# TARGET_TRIPLE = wasm32-wasi
-TARGET_TRIPLE=wasm32-wasi-threads
+# Define common flags
+CFLAGS="--target=wasm32-unknown-wasi -v -Wno-int-conversion -std=gnu11 -fgnu89-inline -matomics -mbulk-memory -O2 -g"
+WARNINGS="-Wall -Wwrite-strings -Wundef -Wstrict-prototypes -Wold-style-definition"
+EXTRA_FLAGS="-fmerge-all-constants -ftrapping-math -fno-stack-protector -fno-common"
+EXTRA_FLAGS+=" -Wp,-U_FORTIFY_SOURCE -fmath-errno -fPIE -ftls-model=local-exec"
+INCLUDE_PATHS="
+    -I../include
+    -I$BUILD/nptl
+    -I$BUILD
+    -I../sysdeps/lind
+    -I../lind_syscall
+    -I../sysdeps/unix/sysv/linux/i386/i686
+    -I../sysdeps/unix/sysv/linux/i386
+    -I../sysdeps/unix/sysv/linux/x86/include
+    -I../sysdeps/unix/sysv/linux/x86
+    -I../sysdeps/x86/nptl
+    -I../sysdeps/i386/nptl
+    -I../sysdeps/unix/sysv/linux/include
+    -I../sysdeps/unix/sysv/linux
+    -I../sysdeps/nptl
+    -I../sysdeps/pthread
+    -I../sysdeps/gnu
+    -I../sysdeps/unix/inet
+    -I../sysdeps/unix/sysv
+    -I../sysdeps/unix/i386
+    -I../sysdeps/unix
+    -I../sysdeps/posix
+    -I../sysdeps/i386/fpu
+    -I../sysdeps/x86/fpu
+    -I../sysdeps/i386
+    -I../sysdeps/x86/include
+    -I../sysdeps/x86
+    -I../sysdeps/wordsize-32
+    -I../sysdeps/ieee754/float128
+    -I../sysdeps/ieee754/ldbl-96/include
+    -I../sysdeps/ieee754/ldbl-96
+    -I../sysdeps/ieee754/dbl-64
+    -I../sysdeps/ieee754/flt-32
+    -I../sysdeps/ieee754
+    -I../sysdeps/generic
+    -I..
+    -I../libio
+    -I.
+"
+SYS_INCLUDE="-nostdinc -isystem $CLANG/lib/clang/16/include -isystem /usr/i686-linux-gnu/include"
+DEFINES="-D_LIBC_REENTRANT -include $BUILD/libc-modules.h -DMODULE_NAME=libc"
+EXTRA_DEFINES="-include ../include/libc-symbols.h -DPIC -DTOP_NAMESPACE=glibc"
 
-# Define the output archive and sysroot directory
-output_archive="$GLIBC_BASE/sysroot/lib/wasm32-wasi/libc.a"
-sysroot_dir="$GLIBC_BASE/sysroot"
+# Copy clang wasi libs
+cp -r $GLIBC/wasi $CLANG/lib/clang/16/lib
 
+# Build glibc
+rm -rf $BUILD
+mkdir -p $BUILD
+cd $BUILD
+
+../configure \
+  --disable-werror \
+  --disable-hidden-plt \
+  --disable-profile \
+  --with-headers=/usr/i686-linux-gnu/include \
+  --prefix=$GLIBC/target \
+  --host=i686-linux-gnu \
+  --build=i686-linux-gnu \
+  CFLAGS=" -matomics -mbulk-memory -O2 -g" \
+  CC="$CC --target=wasm32-unkown-wasi -v -Wno-int-conversion"
+
+make -j8 --keep-going 2>&1 THREAD_MODEL=posix | tee check.log
+
+# Build extra
+cd ../nptl
+$CC $CFLAGS $WARNINGS $EXTRA_FLAGS \
+    $INCLUDE_PATHS $SYS_INCLUDE $DEFINES $EXTRA_DEFINES \
+    -o $BUILD/nptl/pthread_create.o \
+    -c pthread_create.c -MD -MP -MF $BUILD/nptl/pthread_create.o.dt \
+    -MT $BUILD/nptl/pthread_create.o
+
+$CC $CFLAGS $WARNINGS $EXTRA_FLAGS \
+    $INCLUDE_PATHS $SYS_INCLUDE $DEFINES $EXTRA_DEFINES \
+    -o $BUILD/lind_syscall.o \
+    -c $GLIBC/lind_syscall/lind_syscall.c
+
+# Compile assembly files
+cd ../
+$CC --target=wasm32-wasi-threads -matomics \
+    -o $BUILD/csu/wasi_thread_start.o \
+    -c $GLIBC/csu/wasm32/wasi_thread_start.s
+
+$CC --target=wasm32-wasi-threads -matomics \
+    -o $BUILD/csu/set_stack_pointer.o \
+    -c $GLIBC/csu/wasm32/set_stack_pointer.s
+
+# Generate sysroot
 # First, remove the existing sysroot directory to start cleanly
-rm -rf "$sysroot_dir"
+rm -rf "$SYSROOT"
 
 # Find all .o files recursively in the source directory, ignoring stamp.o
-object_files=$(find "$src_dir" -type f -name "*.o" ! \( -name "stamp.o" -o -name "argp-pvh.o" -o -name "repertoire.o" -o -name "static-stubs.o" \))
-
-# Add the lind_syscall.o file to the list of object files
-object_files="$object_files $lind_syscall_path"
+object_files=$(find "$BUILD" -type f -name "*.o" ! \( -name "stamp.o" -o -name "argp-pvh.o" -o -name "repertoire.o" -o -name "static-stubs.o" \))
 
 # Check if object files were found
 if [ -z "$object_files" ]; then
-  echo "No suitable .o files found in '$src_dir'."
+  echo "No suitable .o files found in '$BUILD'."
   exit 1
 fi
 
 # Create the sysroot directory structure
-mkdir -p "$sysroot_dir/include/wasm32-wasi" "$sysroot_dir/lib/wasm32-wasi"
+mkdir -p "$SYSROOT/include/wasm32-wasi" "$SYSROOT/lib/wasm32-wasi"
 
 # Pack all found .o files into a single .a archive
-${CLANG:=/home/lind/lind-wasm/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04}/bin/llvm-ar rcs "$output_archive" $object_files
-"$CLANG/bin/llvm-ar" crs "$GLIBC_BASE/sysroot/lib/wasm32-wasi/libpthread.a"
+"$CLANG/bin/llvm-ar" rcs "$SYSROOT_ARCHIVE" $object_files
+"$CLANG/bin/llvm-ar" crs "$GLIBC/sysroot/lib/wasm32-wasi/libpthread.a"
 
 # Check if llvm-ar succeeded
 if [ $? -eq 0 ]; then
-  echo "Successfully created $output_archive with the following .o files:"
+  echo "Successfully created $SYSROOT_ARCHIVE with the following .o files:"
   echo "$object_files"
 else
   echo "Failed to create the archive."
@@ -48,8 +132,7 @@ else
 fi
 
 # Copy all files from the external include directory to the new sysroot include directory
-cp -r "$include_source_dir"/* "$sysroot_dir/include/wasm32-wasi/"
+cp -r "$GLIBC/target/include/"* "$SYSROOT/include/wasm32-wasi/"
 
 # Copy the crt1.o file into the new sysroot lib directory
-cp "$crt1_source_path" "$sysroot_dir/lib/wasm32-wasi/"
-
+cp "$GLIBC/lind_syscall/crt1.o" "$SYSROOT/lib/wasm32-wasi/"


### PR DESCRIPTION
The new Dockerfile is based on `.devcontainer/Dockerfile`, and simplified to allow optimzation for layer caching. Most notably, it
- introduces multi-stage builds, and
- copies sources from the build context, when they are used to invalidate caches only when relevant files are updated

The goal is to run the Docker build in a GitHub Action (e.g. https://github.com/docker/build-push-action), which requires strategic caching to not exceed allowed build minutes and cache sizes.

**Caveat**
This is an experimental/explorative patch and **does not fit in** with the rest of the toolchain. It:
* ignores `bazel` for a lighter toolchain and to focus on one caching mechanism
* moves all glibc-related build instructions into `gen_sysroot.sh` to reduce complexity

Depending on how well this works, we may replace or revert back to existing tools.