### PR TITLE
ci: fix e2e cache re-use between branches

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,9 @@ name: End-to-end testing
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 permissions: {}
 


### PR DESCRIPTION
Prior to this PR e2e builds were only triggered und thus cached on PR. This allows re-using caches for new pushes to a PR, but not for new PRs from sibling branches. This is because GitHub only shares caches between branches, if one branch is based off another.

As a fix, we also trigger and cache on push to main, so that PRs based on main can re-use that cache.

fixes #256

