### PR TITLE
ci: fix docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
+          # Persist GitHub token in '.git/' dir to be used by `mkdocs gh-deploy`
+          # below. This is the default, but spelled out for extra awareness.
+          # MAKE SURE TO NOT LEAK THE .git DIR!!
+          persist-credentials: true
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]


### PR DESCRIPTION
Re-enable 'persist-credentials' security footgun, required by `mkdocs gh-deplopy`.

fixes #264
