### PR TITLE
ci: add GHA workflow to create lind-wasm image and push to Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ permissions: {}
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Test and release on Docker Hub
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          username: securesystemslab
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@18ce135bb5112fa8ce4ed6c17ab05699d7f3a5e0 # v3.11.0
+
+      # Build 'test' stage (default) to run tests
+      - name: Test
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          platforms: linux/amd64
+          cache-from: type=gha
+          file: scripts/Dockerfile.e2e
+
+      # Build 'release' stage and push to Dockerhub
+      - name: Release and push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          target: release
+          push: true
+          platforms: linux/amd64
+          cache-from: type=gha
+          file: scripts/Dockerfile.e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,16 @@ jobs:
           cache-from: type=gha
           file: scripts/Dockerfile.e2e
 
+      # Create release tag: securesystemslab/lind-wasm:<short commit id>
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: |
+            securesystemslab/lind-wasm
+          tags: |
+            type=sha
+
       # Build 'release' stage and push to Dockerhub
       - name: Release and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
@@ -35,3 +45,4 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           file: scripts/Dockerfile.e2e
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,9 @@ jobs:
           cache-from: type=gha
           file: scripts/Dockerfile.e2e
 
-      # Create release tag: securesystemslab/lind-wasm:<short commit id>
+      # Configure Docker release tags:
+      # - securesystemslab/lind-wasm:sha-<short commit id>
+      # - securesystemslab/lind-wasm:latest
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -35,6 +37,8 @@ jobs:
             securesystemslab/lind-wasm
           tags: |
             type=sha
+          flavor: |
+            latest=true
 
       # Build 'release' stage and push to Dockerhub
       - name: Release and push

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -27,7 +27,7 @@
 # - gcc skipped in favor of clang
 # - libc6-dev-i386-cross required for wasi cross-compilation with clang
 # - build-essential, ca-certificates, curl, libxml2 needed by rust and clang
-FROM ubuntu:latest AS base
+FROM ubuntu:22.04 AS base
 RUN apt-get update && \
     apt-get install -y --no-install-recommends -qq \
         binutils \

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -1,26 +1,24 @@
 # syntax=docker/dockerfile:1.7-labs
 # NOTE: use non-stable syntax for convenient --parents option in COPY command
 
-# Dockerfile for lind-wasm end-to-end testing
+# Multi-stage Dockerfile for lind-wasm end-to-end testing and image creation
 #
-# - Install build dependencies
-# - Build wasmtime, glibc and sysroot for clang cross-compilation
-# - Run tests using wasmtestreport.py
+# - Installs build dependencies
+# - Builds wasmtime, glibc and sysroot for clang cross-compilation
+# - A. Runs end-to-end tests (default)
+# - B. Creates Docker image with lind-wasm toolchain
 #
-# Usage:
-#   docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e .
+# NOTE: The 'test' stage (A) runs end-to-end tests on `docker build`, and is
+# optimized for Docker build time and caching. It is not meant for `docker
+# run`. Use the 'release' stage (B) to create an image that includes the full
+# lind-wasm toolchain, e.g. to run demos, tests, experiments, etc.
 #
-# Caveat:
-#   This Dockerfile is meant for end-to-end testing via `docker build`.
-#   It employs several optimizations for targeted cache invalidation
-#   and minimal cache size:
-#   - scoped COPYs
-#   - independent build stages
-#   - minimal number of layers
-#   - minimal layer sizes
-#   As part of this not all build artifacts are copied into the final image,
-#   and thus not available on `docker run`.
-#   TLDR: The resulting docker image is not meant for distribution.
+# Usage A (test):
+#     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e .
+#
+# Usage B (create and run image):
+#     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e --target release .
+#     docker run --platform=linux/amd64 -it release /bin/bash
 
 # Install build dependencies
 # NOTE: We install dependencies for multiple stages at once, to save RUN time
@@ -64,6 +62,14 @@ RUN curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0
        tar -xvJ
 COPY --parents scripts/make_glibc_and_sysroot.sh src/glibc .
 RUN ./scripts/make_glibc_and_sysroot.sh
+
+# Build Docker image that includes the full lind-wasm toolchain
+# NOTE: Lind-wasm source code is not included
+FROM base AS release
+COPY --from=build-wasmtime --parents  src/wasmtime/target .
+COPY --from=build-glibc --parents \
+    clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04 src/glibc/sysroot .
+COPY --parents scripts tests tools skip_test_cases.txt .
 
 # Run all tests, print results, and exit with 1, if any test fails; 0 otherwise
 FROM base AS test


### PR DESCRIPTION
~blocks on #270~ 
closes #252 (note: GHA currently runs on workflow_dispatch; not weekly)

 * Adds alternative 'release' stage to Dockerfile.e2e, which produces a Docker image that does include the full toolchain, e.g. to run demos, tests, experiments, etc.
 * add GHA to create image and push to Docker Hub

see commits for details