### PR TITLE
Fix: close_syscall panics on negative fd

### DIFF
--- a/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
+++ b/src/RawPOSIX/src/safeposix/syscalls/fs_calls.rs
@@ -905,6 +905,8 @@ impl Cage {
     /// ## Returns:
     ///     Return 0 when success; -1 along with errno when fail.
     pub fn close_syscall(&self, virtual_fd: i32) -> i32 {
+        // We only check for negative fd's here since fdtables uses u64.
+        // Upper-bound checks are handled by the close_virtualfd function.
         if virtual_fd < 0 {
             return syscall_error(Errno::EBADF, "close", "Bad File Descriptor");
         }


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

`close_syscall` panics when a negative file descriptor is passed. This occurs because there is no bound check for fd's being negative. A common case where this occurs is when `open(...)` fails. 

This PR adds a simple check for this. 

```
int fd = open("/path/doesnt/exist", O_RDONLY);    // fd = -1
...
close(fd);    // POSIX behaviour: return -1, errno set to EBADF. 
```

Current lind behaviour:
```
thread 'main' panicked at crates/rawposix/src/fdtables/dashmapvecglobal.rs:379:15:
index out of bounds: the len is 1024 but the index is 18446744073709551614
```