### PR TITLE
build: replacement for lindtool.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ sysroot:
 
 .PHONY: wasmtime
 wasmtime:
+	# Build wasmtime with `--release` flag for faster runtime (e.g. for tests)
 	cargo build --manifest-path src/wasmtime/Cargo.toml --release
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+
+.PHONY: all
+all:
+	@echo "Run targets individually!"
+
+.PHONY: sysroot
+sysroot:
+	./scripts/make_glibc_and_sysroot.sh
+
+.PHONY: wasmtime
+wasmtime:
+	cargo build --manifest-path src/wasmtime/Cargo.toml --release
+
+.PHONY: test
+test:
+	# NOTE: `grep` workaround required for lack of meaningful exit code in wasmtestreport.py
+	LIND_WASM_BASE=. LIND_FS_ROOT=src/RawPOSIX/tmp \
+	./scripts/wasmtestreport.py && \
+	cat results.json && \
+	! grep '"number_of_failures": [^0]' results.json

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -60,7 +60,6 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain nightly-2025-06-01
 ENV PATH="/root/.cargo/bin:${PATH}"
 COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs Makefile .
-# Build wasmtime with `--release` flag for faster tests
 RUN make wasmtime
 
 

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -61,9 +61,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
 ENV PATH="/root/.cargo/bin:${PATH}"
 COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs .
 # Build wasmtime with `--release` flag for faster tests
-# NOTE: `ln` workaround required for hard-coded paths in test tools (lind_config.sh)
-RUN cargo build --manifest-path src/wasmtime/Cargo.toml --release && \
-    (cd src/wasmtime/target && mkdir -p debug && ln -sf ../release/wasmtime debug)
+RUN cargo build --manifest-path src/wasmtime/Cargo.toml --release
 
 
 # Build glibc and generate sysroot

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -59,12 +59,14 @@ FROM base as build-wasmtime
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain nightly-2025-06-01
 ENV PATH="/root/.cargo/bin:${PATH}"
+# NOTE: Using 'make' risks cache invalidation on unrelated Makefile changes
 COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs Makefile .
 RUN make wasmtime
 
 
 # Build glibc and generate sysroot
 FROM base AS build-glibc
+# NOTE: Using 'make' risks cache invalidation on unrelated Makefile changes
 COPY --parents scripts/make_glibc_and_sysroot.sh src/glibc Makefile .
 RUN make sysroot
 

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -43,6 +43,16 @@ RUN apt-get update && \
         sed \
     && rm -rf /var/lib/apt/lists/*
 
+# Install clang
+ARG LLVM="llvmorg-16.0.4"
+ARG CLANG="clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04"
+# NOTE: We `curl | tar` in spite of Docker best practices to save cache layers
+RUN curl -sL https://github.com/llvm/llvm-project/releases/download/${LLVM}/${CLANG}.tar.xz | \
+       tar -xvJ
+COPY src/glibc/wasi /${CLANG}/lib/clang/16/lib/wasi
+ENV PATH="/${CLANG}/bin:${PATH}"
+
+
 # Install rust and build wasmtime
 FROM base as build-wasmtime
 # NOTE: pinning known-to-work nightly-2025-06-01 (see #242)
@@ -55,21 +65,20 @@ COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs .
 RUN cargo build --manifest-path src/wasmtime/Cargo.toml --release && \
     (cd src/wasmtime/target && mkdir -p debug && ln -sf ../release/wasmtime debug)
 
-# Install clang, build glibc and generate sysroot
+
+# Build glibc and generate sysroot
 FROM base AS build-glibc
-# NOTE: We `curl | tar` in spite of Docker best practices to save cache layers
-RUN curl -sL https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.4/clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04.tar.xz | \
-       tar -xvJ
 COPY --parents scripts/make_glibc_and_sysroot.sh src/glibc .
 RUN ./scripts/make_glibc_and_sysroot.sh
+
 
 # Build Docker image that includes the full lind-wasm toolchain
 # NOTE: Lind-wasm source code is not included
 FROM base AS release
 COPY --from=build-wasmtime --parents  src/wasmtime/target .
-COPY --from=build-glibc --parents \
-    clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04 src/glibc/sysroot .
+COPY --from=build-glibc --parents src/glibc/sysroot .
 COPY --parents scripts tests tools skip_test_cases.txt .
+
 
 # Run all tests, print results, and exit with 1, if any test fails; 0 otherwise
 FROM base AS test
@@ -79,7 +88,6 @@ COPY --parents scripts tests tools skip_test_cases.txt .
 # NOTE: `grep` workaround required for lack of meaningful exit code in wasmtestreport.py
 RUN --mount=from=build-wasmtime,source=src/wasmtime/target,destination=src/wasmtime/target \
     --mount=from=build-glibc,source=src/glibc/sysroot,destination=src/glibc/sysroot \
-    --mount=from=build-glibc,source=clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04,destination=clang+llvm-16.0.4-x86_64-linux-gnu-ubuntu-22.04 \
     LIND_WASM_BASE=/  LIND_FS_ROOT=/src/RawPOSIX/tmp ./scripts/wasmtestreport.py && \
     cat results.json && \
     ! grep '"number_of_failures": [^0]' results.json

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -59,15 +59,15 @@ FROM base as build-wasmtime
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain nightly-2025-06-01
 ENV PATH="/root/.cargo/bin:${PATH}"
-COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs .
+COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs Makefile .
 # Build wasmtime with `--release` flag for faster tests
-RUN cargo build --manifest-path src/wasmtime/Cargo.toml --release
+RUN make wasmtime
 
 
 # Build glibc and generate sysroot
 FROM base AS build-glibc
-COPY --parents scripts/make_glibc_and_sysroot.sh src/glibc .
-RUN ./scripts/make_glibc_and_sysroot.sh
+COPY --parents scripts/make_glibc_and_sysroot.sh src/glibc Makefile .
+RUN make sysroot
 
 
 # Build Docker image that includes the full lind-wasm toolchain
@@ -80,12 +80,9 @@ COPY --parents scripts tests tools skip_test_cases.txt .
 
 # Run all tests, print results, and exit with 1, if any test fails; 0 otherwise
 FROM base AS test
-COPY --parents scripts tests tools skip_test_cases.txt .
+COPY --parents scripts tests tools skip_test_cases.txt Makefile .
 # NOTE: Build artifacts from prior stages are only mounted, to save COPY time
 # and cache layers. This means they are not preserved in the resulting image.
-# NOTE: `grep` workaround required for lack of meaningful exit code in wasmtestreport.py
 RUN --mount=from=build-wasmtime,source=src/wasmtime/target,destination=src/wasmtime/target \
     --mount=from=build-glibc,source=src/glibc/sysroot,destination=src/glibc/sysroot \
-    LIND_WASM_BASE=/  LIND_FS_ROOT=/src/RawPOSIX/tmp ./scripts/wasmtestreport.py && \
-    cat results.json && \
-    ! grep '"number_of_failures": [^0]' results.json
+    make test

--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -ue
+
+# Cross-compile passed .c file to .wasm and .cwasm files
+#
+# Important notes:
+# - call from source code repository root directory
+# - expects `clang` on $PATH
+# - expects `wasm-opt` at its included location
+# - expects `wasmtime` its release build location
+#
+# Usage:
+#
+#   ./scripts/lind_compile /path/to/lind-program.c
+
+# Expects exactly one arg, ending with '.c'
+if [[ "$#" -ne 1 || "${1: -2}" != ".c" ]]; then
+    echo "usage: $0 </path/to/*.c file>"
+    exit 1
+fi
+
+path_c="$1"
+path_wasm="${1%.c}.wasm"
+path_cwasm="${1%.c}.cwasm"
+
+clang --sysroot=${PWD}/src/glibc/sysroot \
+    -pthread --target=wasm32-unknown-wasi \
+    -Wl,--import-memory,--export-memory,--max-memory=67108864,--export="__stack_pointer",--export=__stack_low \
+    "$path_c" -g -O0 -o "$path_wasm"
+
+tools/binaryen/bin/wasm-opt --epoch-injection --asyncify -O2 --debuginfo "$path_wasm" -o "$path_wasm"
+
+src/wasmtime/target/release/wasmtime compile "$path_wasm" -o "$path_cwasm"

--- a/scripts/lind_run
+++ b/scripts/lind_run
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ue
+
+# Run passed optionally pre-compiled wasm file in wasmtime
+#
+# Important notes:
+# - call from source code repository root directory
+# - expects `clang` on $PATH
+# - expects `wasmtime` its release build location
+#
+# Usage:
+#   ./scripts/lind_run /path/to/lind-program.[c]wasm
+
+src/wasmtime/target/release/wasmtime run --allow-precompiled --wasi threads=y --wasi preview2=n  "$@"

--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -70,8 +70,6 @@ SYS_INCLUDE="-nostdinc -isystem $CLANG/lib/clang/16/include -isystem /usr/i686-l
 DEFINES="-D_LIBC_REENTRANT -include $BUILD/libc-modules.h -DMODULE_NAME=libc"
 EXTRA_DEFINES="-include ../include/libc-symbols.h -DPIC -DTOP_NAMESPACE=glibc"
 
-# Copy clang wasi libs
-cp -r $GLIBC/wasi $CLANG/lib/clang/16/lib
 
 # Build glibc
 rm -rf $BUILD

--- a/scripts/wasmtestreport.py
+++ b/scripts/wasmtestreport.py
@@ -133,7 +133,7 @@ def add_test_result(result, file_path, status, error_type, output):
 # Function: compile_c_to_wasm
 #
 # Purpose:
-#   Given a path to a .c file, calls the lindtool script to compile it into wasm.
+#   Given a path to a .c file, calls `lind_compile` to compile it into wasm.
 #
 # Variables:
 # - Input: source_file - path to the .c file.
@@ -145,15 +145,15 @@ def add_test_result(result, file_path, status, error_type, output):
 #   Catches and returns exceptions as error strings
 #
 # Note:
-#   Dependancy on the script "./lindtool.sh compile_test".
+#   Dependancy on the script `lind_compile`.
 # ----------------------------------------------------------------------
 def compile_c_to_wasm(source_file):
     source_file = Path(source_file).resolve()
     testcase = str(source_file.with_suffix(''))
-    compile_cmd = [os.path.join(LIND_TOOL_PATH, "lindtool.sh"), "compile_test", testcase]
+    compile_cmd = [os.path.join(LIND_TOOL_PATH, "lind_compile"), source_file]
     if DEBUG_MODE:
         print("Running command:", compile_cmd)
-        if os.path.isfile(os.path.join(LIND_TOOL_PATH, "lindtool.sh")):
+        if os.path.isfile(os.path.join(LIND_TOOL_PATH, "lind_compile")):
             print("File exists and is a regular file!")
         else:
             print("File not found or it's a directory!")
@@ -164,7 +164,7 @@ def compile_c_to_wasm(source_file):
         if result.returncode != 0:
             return (None, result.stdout + "\n" + result.stderr)
         else:
-            wasm_file = Path(testcase + ".wasm")
+            wasm_file = Path(testcase + ".cwasm")
             return (wasm_file, "")
     except Exception as e:
         return (None, f"Exception during compilation: {str(e)}")
@@ -188,16 +188,15 @@ def compile_c_to_wasm(source_file):
 #   Catches TimeoutExpired and other Exceptions.
 #
 # Note:
-#   Dependancy on the script "./lindtool.sh run"
+#   Dependancy on the script "lind_run"
 #   Since the script outputs the command being run, we ignore 
 #   the first line in stdout by the script which is the command itself
 # ----------------------------------------------------------------------
 def run_compiled_wasm(wasm_file, timeout_sec=DEFAULT_TIMEOUT):
-    testcase = str(wasm_file.with_suffix(''))
-    run_cmd = [os.path.join(LIND_TOOL_PATH, "lindtool.sh"), "run", testcase]
+    run_cmd = [os.path.join(LIND_TOOL_PATH, "lind_run"), wasm_file]
     if DEBUG_MODE:
         print("Running command:", run_cmd)
-        if os.path.isfile(os.path.join(LIND_TOOL_PATH, "lindtool.sh")):
+        if os.path.isfile(os.path.join(LIND_TOOL_PATH, "lind_run")):
             print("File exists and is a regular file!")
         else:
             print("File not found or it's a directory!")
@@ -212,7 +211,7 @@ def run_compiled_wasm(wasm_file, timeout_sec=DEFAULT_TIMEOUT):
         filtered_lines = lines[1:]
         filtered_output = "\n".join(filtered_lines)
 
-        return (proc.returncode, filtered_output)
+        return (proc.returncode, full_output)
 
     except subprocess.TimeoutExpired as e:
         return ("timeout", f"Timed Out (timeout: {timeout_sec}s)")


### PR DESCRIPTION
Add **shell scripts** and **Makefile** to replace lindtool.sh (see #269) and use in wasmtestreport.py and Dockerfile.e2e:

* Replacements
  - `lindtool.sh compile_test` → `scripts/lind_compile`
  - `... run` → `scripts/lind_run`
  - `... compile_wasmtime` → `make wasmtime`
  - `... compile_src` + `... make_glibc` → `make sysroot`
* Does not add replacement for `... rawposix` because of [#230](https://github.com/Lind-Project/lind-wasm/issues/230)
* Replacement for `... debug` may be added in follow-up PR, if needed
* Adds new `make test` target, and slightly restructures Dockerfile.e2e
* Please review commit by commit and see commit messages for details!
* IMPORTANT NOTE: default usage of wasmtestreport.py is backwards incompatible (see  commit message 88da8e17f31695a44f8f8451464a76528ee6fa90)