### PR TITLE
build: improve local development experience

### DIFF
--- a/docs/contribute/unit-tests.md
+++ b/docs/contribute/unit-tests.md
@@ -21,30 +21,23 @@ cd lind-wasm
 ```
 3. Build Docker Image 
 ```
-docker build -t testing_image -f .devcontainer/Dockerfile --build-arg DEV_MODE=true --platform=linux/amd64 .
+docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e -t dev --target base .
 ```
 4. Run the image 
 ```
-docker run -it testing_image /bin/bash
+# NOTE: this mounts the source code repo into the container
+docker run --platform=linux/amd64 -v $(PWD):/lind -w /lind -it dev /bin/bash
 ```
 5. Build toolchain (glibc and wasmtime)
 ```
-bazel build //:make_glibc //:make_wasmtime
+# this may take a while ...
+make wasmtime sysroot
 ```
 6. Run the test suite 
 ```
-bazel run //:python_tests
+./scripts/wasmtestreport.py
 ```
-(This will run the whole test suite.  Use `scripts/wasmtestreport.py --help` to
-list available arguments and flags)
-Note: Pass test suite arguments using
-```
-bazel run //:python_tests -- <wasmtestreport arguments>
-```
-For example: 
-```
-bazel run //:python_tests -- --timeout 10
-```
+Run `scripts/wasmtestreport.py --help` to list available usage options.
 
 
 
@@ -98,14 +91,14 @@ can be directly compared, i.e. contents of gcc run == contents of lind-wasm
 run, that would be enough
 
 Any failure in compiling or running using gcc or lind-wasm is considered a
-failure. Mismatch in native (gcc) and wasm outputs are also considered a 
+failure. Mismatch in native (gcc) and wasm outputs are also considered a
 failure.
 
 
 ## Example Combined Usage
 
 ```
-bazel run //:python_tests -- \
+./scripts/wasmtestreport.py \
   --generate-html \
   --skip config_tests file_tests \
   --timeout 10 \

--- a/docs/contribute/unit-tests.md
+++ b/docs/contribute/unit-tests.md
@@ -24,8 +24,11 @@ cd lind-wasm
 docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e -t dev --target base .
 ```
 4. Run the image 
-```
-# NOTE: this mounts the source code repo into the container
+```bash
+# Note: The `-v` option mounts your repo into the container. This means, you can
+# live-edit the files in the container using your host editor. And files created
+# or edited in the container, e.g. when running `make`, persist on the host.
+
 docker run --platform=linux/amd64 -v $(PWD):/lind -w /lind -it dev /bin/bash
 ```
 5. Build toolchain (glibc and wasmtime)

--- a/scripts/Dockerfile.e2e
+++ b/scripts/Dockerfile.e2e
@@ -11,14 +11,20 @@
 # NOTE: The 'test' stage (A) runs end-to-end tests on `docker build`, and is
 # optimized for Docker build time and caching. It is not meant for `docker
 # run`. Use the 'release' stage (B) to create an image that includes the full
-# lind-wasm toolchain, e.g. to run demos, tests, experiments, etc.
+# lind-wasm toolchain, e.g. to run demos, tests, experiments, etc. For
+# development you may want to build just the base image (C) and mount the full
+# source tree.
 #
 # Usage A (test):
 #     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e .
 #
 # Usage B (create and run image):
-#     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e --target release .
+#     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e -t release --target release .
 #     docker run --platform=linux/amd64 -it release /bin/bash
+#
+# Usage C (create base image and mount source):
+#     docker build --platform=linux/amd64 -f scripts/Dockerfile.e2e -t dev --target base .
+#     docker run --platform=linux/amd64 -v $(PWD):/lind -w /lind -it dev /bin/bash
 
 # Install build dependencies
 # NOTE: We install dependencies for multiple stages at once, to save RUN time
@@ -52,13 +58,15 @@ RUN curl -sL https://github.com/llvm/llvm-project/releases/download/${LLVM}/${CL
 COPY src/glibc/wasi /${CLANG}/lib/clang/16/lib/wasi
 ENV PATH="/${CLANG}/bin:${PATH}"
 
-
-# Install rust and build wasmtime
-FROM base as build-wasmtime
+# Install rust
 # NOTE: pinning known-to-work nightly-2025-06-01 (see #242)
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --default-toolchain nightly-2025-06-01
 ENV PATH="/root/.cargo/bin:${PATH}"
+
+
+# Build wasmtime
+FROM base as build-wasmtime
 # NOTE: Using 'make' risks cache invalidation on unrelated Makefile changes
 COPY --parents src/wasmtime src/RawPOSIX src/fdtables src/sysdefs Makefile .
 RUN make wasmtime


### PR DESCRIPTION
Update Dockerfile.e2e to improve local development experience. That is, to support the following usage scenario:

- build base image
- run container with local source code repository mounted into container
  - this allows syncing source code changes between host and container
- run `make` on the container sheel to build toolchain (libc/sysroot, wasmtime) from local sources and test with wasmtestreport.py

The PR also adds code comments and updates contributor guidelines to document the usage.

See commit messages for details. 

(Note that the changes in `make_glibc_and_sysroot.sh` seem unrelated but are necessary to use the script on arbitrary paths, e.g. when mounted on `/lind` as suggested in the updated docs.

fixes #253 