### PR TITLE
build: add lint/format/docs targets to Makefile (Fixes #280)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,17 +46,14 @@ docs-serve:
 
 .PHONY: clean
 clean:
-	@echo "Removing glibc artifacts"
+	@echo "glibc artifacts"
 	$(RM) -r src/glibc/build src/glibc/sysroot src/glibc/target
-
 	@echo "cargo clean (wasmtime)"
 	cargo clean --manifest-path src/wasmtime/Cargo.toml
 
-	@echo "Deleting test outputs"
+.PHONY: distclean
+distclean: clean
+	@echo "removing test outputs & temp files"
 	$(RM) -f results.json report.html
 	$(RM) -r src/RawPOSIX/tmp/testfiles || true
-
-	@echo "Purging compiled test artifacts"
 	find tests -type f \( -name '*.wasm' -o -name '*.cwasm' -o -name '*.o' \) -delete
-
-	@echo "Clean done."

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,7 @@ lint:
 .PHONY: format
 format:
 	cargo fmt --all --manifest-path src/wasmtime/Cargo.toml
-
-.PHONY: docs-publish
-docs-publish:
-	mkdocs gh-deploy --force 
+ 
 
 .PHONY: docs-serve
 docs-serve:

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,27 @@ test:
 	./scripts/wasmtestreport.py && \
 	cat results.json && \
 	! grep '"number_of_failures": [^0]' results.json
+
+.PHONY: lint
+lint:
+	cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
+	cargo clippy \
+	    --manifest-path src/wasmtime/Cargo.toml \
+	    --all-features \
+	    --keep-going \
+	    -- \
+	    -A warnings \
+	    -A clippy::not_unsafe_ptr_arg_deref \
+	    -A clippy::absurd_extreme_comparisons
+
+.PHONY: format
+format:
+	cargo fmt --all --manifest-path src/wasmtime/Cargo.toml
+
+.PHONY: docs-publish
+docs-publish:
+	mkdocs gh-deploy --force 
+
+.PHONY: docs-serve
+docs-serve:
+	mkdocs serve

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 
-.PHONY: all
-all:
-	@echo "Run targets individually!"
-
-.PHONY: build
+.PHONY: build 
 build: sysroot wasmtime
 	@echo "Build complete"
+
+.PHONY: all
+all: build
 
 .PHONY: sysroot
 sysroot:
@@ -47,17 +46,17 @@ docs-serve:
 
 .PHONY: clean
 clean:
-	@echo "▶ Removing glibc artefacts"
+	@echo "Removing glibc artifacts"
 	$(RM) -r src/glibc/build src/glibc/sysroot src/glibc/target
 
-	@echo "▶ cargo clean (wasmtime)"
+	@echo "cargo clean (wasmtime)"
 	cargo clean --manifest-path src/wasmtime/Cargo.toml
 
-	@echo "▶ Deleting test outputs"
+	@echo "Deleting test outputs"
 	$(RM) -f results.json report.html
 	$(RM) -r src/RawPOSIX/tmp/testfiles || true
 
-	@echo "▶ Purging compiled test artefacts"
+	@echo "Purging compiled test artifacts"
 	find tests -type f \( -name '*.wasm' -o -name '*.cwasm' -o -name '*.o' \) -delete
 
 	@echo "Clean done."

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@
 all:
 	@echo "Run targets individually!"
 
+.PHONY: build
+build: sysroot wasmtime
+	@echo "Build complete"
+
 .PHONY: sysroot
 sysroot:
 	./scripts/make_glibc_and_sysroot.sh
@@ -40,3 +44,20 @@ format:
 .PHONY: docs-serve
 docs-serve:
 	mkdocs serve
+
+.PHONY: clean
+clean:
+	@echo "▶ Removing glibc artefacts"
+	$(RM) -r src/glibc/build src/glibc/sysroot src/glibc/target
+
+	@echo "▶ cargo clean (wasmtime)"
+	cargo clean --manifest-path src/wasmtime/Cargo.toml
+
+	@echo "▶ Deleting test outputs"
+	$(RM) -f results.json report.html
+	$(RM) -r src/RawPOSIX/tmp/testfiles || true
+
+	@echo "▶ Purging compiled test artefacts"
+	find tests -type f \( -name '*.wasm' -o -name '*.cwasm' -o -name '*.o' \) -delete
+
+	@echo "Clean done."


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Closes #280, adds lint/format/docs targets to Makefile.

