### PR TITLE
Add disable_signals feature for debugging

### DIFF
--- a/docs/contribute/debug-programs.md
+++ b/docs/contribute/debug-programs.md
@@ -64,4 +64,21 @@ gdb --args ../wasmtime/target/debug/wasmtime run -D debug-info -O opt-level=0 ma
 
 ## Other Debugging Techniques
 
-Coming soon
+### Disabling Signals for Debugging
+
+The `signal-disable` feature added in this PR allows `lind-wasm` to run binaries without inserting Wasmtime epoch signals, which is useful for debugging purposes. When this feature is enabled, the signal handler is not set, and any unexpected signals (e.g., timeouts or faults) will cause the program to crash directly in RawPOSIX, making issues easier to trace.
+
+> ⚠️ **Warning:** This feature is intended for debugging only and should not be used in production environments.
+
+To use this feature, compile `lind-wasm` with the `signal-disable` feature enabled. Here’s how to do it:
+
+**Building with the Feature:**
+
+From the root of the repository, navigate to `src/wasmtime` and build with the `signal-disable` feature:
+
+```bash
+cd src/wasmtime
+
+# Build lind-wasm with the signal-disable feature
+cargo build --features signal-disable
+```

--- a/src/RawPOSIX/Cargo.toml
+++ b/src/RawPOSIX/Cargo.toml
@@ -38,6 +38,9 @@ criterion = { version = "0.3", features = ["html_reports"]}
 tempfile = "3.2.0"
 grcov="0.8.19" # code coverage
 
+[features]
+disable_signals = []
+
 [[bin]]
 name = "lind_fs_utils"
 path = "src/tools/fs_utils.rs"

--- a/src/RawPOSIX/src/interface/signal.rs
+++ b/src/RawPOSIX/src/interface/signal.rs
@@ -72,7 +72,6 @@ fn get_epoch_state(cageid: u64, thread_id: u64) -> u64 {
         // SAFETY: see comment at `signal_epoch_trigger`
         unsafe { *epoch }
     }
-
 }
 
 // check the specified thread with specified cage is in "killed" state

--- a/src/RawPOSIX/src/interface/signal.rs
+++ b/src/RawPOSIX/src/interface/signal.rs
@@ -57,7 +57,7 @@ pub fn epoch_kill_all(cageid: u64) {
 fn get_epoch_state(cageid: u64, thread_id: u64) -> u64 {
         #[cfg(feature = "disable_signals")]
     {
-        return 1;
+        return 1; // if were disabling signals this function is unescessary so we avoid a potential null ptr dereference
     }
 
     #[cfg(not(feature = "disable_signals"))]

--- a/src/RawPOSIX/src/interface/signal.rs
+++ b/src/RawPOSIX/src/interface/signal.rs
@@ -55,7 +55,7 @@ pub fn epoch_kill_all(cageid: u64) {
 // get the current epoch state of the thread
 // thread safety: this function will only be invoked by main thread of the cage
 fn get_epoch_state(cageid: u64, thread_id: u64) -> u64 {
-        #[cfg(feature = "disable_signals")]
+    #[cfg(feature = "disable_signals")]
     {
         return 1; // if were disabling signals this function is unescessary so we avoid a potential null ptr dereference
     }

--- a/src/RawPOSIX/src/interface/signal.rs
+++ b/src/RawPOSIX/src/interface/signal.rs
@@ -280,12 +280,12 @@ pub fn lind_thread_exit(cageid: u64, thread_id: u64) -> bool {
 
             // we also need to migrate the epoch state to the new thread
             #[cfg(not(feature = "disable_signals"))]
-            let state = get_epoch_state(cageid, thread_id); 
+            let state = get_epoch_state(cageid, thread_id);
 
             #[cfg(feature = "disable_signals")]
             // If the disable_signals feature is enabled, checking the epoch state will yield a null pointer.
             // To avoid this, we bypass the call to get_epoch_state and set state to 1 directly.
-            let state = 1; 
+            let state = 1;
 
             let new_thread_epoch_handler = entry.value().write();
             let new_thread_epoch = *new_thread_epoch_handler;

--- a/src/wasmtime/Cargo.toml
+++ b/src/wasmtime/Cargo.toml
@@ -58,7 +58,7 @@ wasmtime-lind-multi-process = { path = "crates/lind-multi-process", optional = f
 wasmtime-lind-common = { path = "crates/lind-common" }
 wasmtime-lind-utils = { path = "crates/lind-utils" }
 wasmtime-wasi-http = { workspace = true, optional = true }
-rawposix = { workspace = true }
+rawposix = { workspace = true, optional = false, features = ["disable_signals"]}
 fdtables = { workspace = true }
 sysdefs = { workspace = true }
 clap = { workspace = true }
@@ -387,7 +387,7 @@ default = [
   "clap/default",
 ]
 
-disable_signals = ["wasmtime-lind-multi-process/disable_signals"]
+disable_signals = ["wasmtime-lind-multi-process/disable_signals", "rawposix/disable_signals"]
 
 # ========================================
 # Off-by-default features

--- a/src/wasmtime/Cargo.toml
+++ b/src/wasmtime/Cargo.toml
@@ -54,7 +54,7 @@ wasi-common = { workspace = true, default-features = true, features = ["exit"], 
 wasmtime-wasi = { workspace = true, default-features = true, optional = true }
 wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
-wasmtime-lind-multi-process = { path = "crates/lind-multi-process" }
+wasmtime-lind-multi-process = { path = "crates/lind-multi-process", optional = false, features = ["disable_signals"]}
 wasmtime-lind-common = { path = "crates/lind-common" }
 wasmtime-lind-utils = { path = "crates/lind-utils" }
 wasmtime-wasi-http = { workspace = true, optional = true }
@@ -387,7 +387,7 @@ default = [
   "clap/default",
 ]
 
-disable_signals = []
+disable_signals = ["wasmtime-lind-multi-process/disable_signals"]
 
 # ========================================
 # Off-by-default features

--- a/src/wasmtime/Cargo.toml
+++ b/src/wasmtime/Cargo.toml
@@ -387,6 +387,8 @@ default = [
   "clap/default",
 ]
 
+disable_signals = []
+
 # ========================================
 # Off-by-default features
 #

--- a/src/wasmtime/crates/lind-multi-process/Cargo.toml
+++ b/src/wasmtime/crates/lind-multi-process/Cargo.toml
@@ -18,3 +18,7 @@ wasmtime-environ = { workspace = true }
 wasmtime-lind-utils = { path = "../lind-utils" }
 rawposix = { path = "../rawposix" }
 sysdefs = { path = "../sysdefs" }
+cfg-if = { workspace = true }
+
+[features]
+disable_signals = []

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -423,7 +423,6 @@ impl<
                         )
                         .unwrap();
 
-
                     cfg_if! {
                         // The disable_signals feature allows Wasmtime to run Lind binaries without inserting an epoch.
                         // It sets the signal pointer to 0, so any signals will trigger a fault in RawPOSIX.

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use cfg_if::cfg_if;
+
 use anyhow::{anyhow, Result};
 use rawposix::safeposix::dispatcher::lind_syscall_api;
 use wasmtime_lind_utils::lind_syscall_numbers::{EXEC_SYSCALL, EXIT_SYSCALL, FORK_SYSCALL};
@@ -421,13 +423,25 @@ impl<
                         )
                         .unwrap();
 
-                    // retrieve the epoch global
-                    let lind_epoch = instance
-                        .get_export(&mut store, "epoch")
-                        .and_then(|export| export.into_global())
-                        .expect("Failed to find shared_global");
-                    // retrieve the handler (underlying pointer) for the epoch global
-                    let pointer = lind_epoch.get_handler(&mut store);
+
+                    cfg_if! {
+                        // The disable_signals feature allows Wasmtime to run Lind binaries without inserting an epoch.
+                        // It sets the signal pointer to 0, so any signals will trigger a fault in RawPOSIX.
+                        // This is intended for debugging only and should not be used in production.
+                        if #[cfg(feature = "disable_signals")] {
+                            let pointer = 0;
+                        } else {
+                            // retrieve the epoch global
+                            let lind_epoch = instance
+                                .get_export(&mut store, "epoch")
+                                .and_then(|export| export.into_global())
+                                .expect("Failed to find epoch global export!");
+
+                            // retrieve the handler (underlying pointer) for the epoch global
+                            let pointer = lind_epoch.get_handler(&mut store);
+                        }
+                    }
+
                     // initialize the signal for the main thread of forked cage
                     rawposix::interface::lind_signal_init(
                         child_cageid,
@@ -697,13 +711,24 @@ impl<
                         .unwrap();
                     let _ = stack_pointer_setter.call(&mut store, (stack_addr - offset) as i32);
 
-                    // retrieve the epoch global
-                    let lind_epoch = instance
-                        .get_export(&mut store, "epoch")
-                        .and_then(|export| export.into_global())
-                        .expect("Failed to find shared_global");
-                    // retrieve the handler (underlying pointer) for the epoch global
-                    let pointer = lind_epoch.get_handler(&mut store);
+                    cfg_if! {
+                        // The disable_signals feature allows Wasmtime to run Lind binaries without inserting an epoch.
+                        // It sets the signal pointer to 0, so any signals will trigger a fault in RawPOSIX.
+                        // This is intended for debugging only and should not be used in production.
+                        if #[cfg(feature = "disable_signals")] {
+                            let pointer = 0;
+                        } else {
+                            // retrieve the epoch global
+                            let lind_epoch = instance
+                                .get_export(&mut store, "epoch")
+                                .and_then(|export| export.into_global())
+                                .expect("Failed to find epoch global export!");
+
+                            // retrieve the handler (underlying pointer) for the epoch global
+                            let pointer = lind_epoch.get_handler(&mut store);
+                        }
+                    }
+
                     // initialize the signal for the thread of the cage
                     rawposix::interface::lind_signal_init(
                         child_cageid as u64,

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -428,7 +428,7 @@ impl<
                         // It sets the signal pointer to 0, so any signals will trigger a fault in RawPOSIX.
                         // This is intended for debugging only and should not be used in production.
                         if #[cfg(feature = "disable_signals")] {
-                            let pointer = 0;
+                            let pointer: *mut u64 = &mut 0;
                         } else {
                             // retrieve the epoch global
                             let lind_epoch = instance
@@ -715,7 +715,7 @@ impl<
                         // It sets the signal pointer to 0, so any signals will trigger a fault in RawPOSIX.
                         // This is intended for debugging only and should not be used in production.
                         if #[cfg(feature = "disable_signals")] {
-                            let pointer = 0;
+                            let pointer: *mut u64 = &mut 0;
                         } else {
                             // retrieve the epoch global
                             let lind_epoch = instance


### PR DESCRIPTION
This PR adds a compile feature to disable the signal epoch checks for debugging programs without signals. This helps for debugging and performance comparisons.
