### PR TITLE
ci: clean PR caches on close

### DIFF
--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -8,6 +8,10 @@ permissions:
   actions: write
   contents: read
 
+concurrency:
+  group: pr-cache-cleanup
+  cancel-in-progress: false
+
 jobs:
   purge:
     runs-on: ubuntu-latest
@@ -20,13 +24,24 @@ jobs:
             const repo  = context.repo.repo;
             const pr    = context.payload.pull_request.number;
 
-            for (const ref of [`refs/pull/${pr}/merge`, `refs/pull/${pr}/head`]) {
-              try {
-                core.info(`Deleting caches for ${ref}`);
-                await github.request('DELETE /repos/{owner}/{repo}/actions/caches', {
-                  owner, repo, ref
-                });
-              } catch (e) {
-                core.warning(`No caches for ${ref} or deletion failed: ${e.message}`);
+            const refs = [`refs/pull/${pr}/merge`, `refs/pull/${pr}/head`];
+
+            for (const ref of refs) {
+              const { data } = await github.request(
+                'GET /repos/{owner}/{repo}/actions/caches',
+                { owner, repo, ref, per_page: 100 }
+              );
+
+              if (data.total_count === 0) {
+                core.info(`No caches for ${ref}`);
+                continue;
+              }
+
+              for (const cache of data.actions_caches) {
+                core.info(`Deleting cache id ${cache.id} (key: ${cache.key})`);
+                await github.request(
+                  'DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}',
+                  { owner, repo, cache_id: cache.id }
+                );
               }
             }

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -1,0 +1,32 @@
+name: PR cache cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches scoped to this PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const pr    = context.payload.pull_request.number;
+
+            for (const ref of [`refs/pull/${pr}/merge`, `refs/pull/${pr}/head`]) {
+              try {
+                core.info(`Deleting caches for ${ref}`);
+                await github.request('DELETE /repos/{owner}/{repo}/actions/caches', {
+                  owner, repo, ref
+                });
+              } catch (e) {
+                core.warning(`No caches for ${ref} or deletion failed: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
Fixes #266, deletes all PR-scoped caches (refs/pull/<n>/head|merge) automatically when a PR is closed/merged to conserve cache quota, keeps caches on main for reuse. No changes to existing build/test workflows.
