### PR TITLE
Add bounds check for virtfd

### DIFF
--- a/src/fdtables/src/dashmaparrayglobal.rs
+++ b/src/fdtables/src/dashmaparrayglobal.rs
@@ -352,7 +352,12 @@ lazy_static! {
 
 #[doc = include_str!("../docs/close_virtualfd.md")]
 pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
-
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+    
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
 
     // derefing this so I don't hold a lock and deadlock close handlers

--- a/src/fdtables/src/dashmapvecglobal.rs
+++ b/src/fdtables/src/dashmapvecglobal.rs
@@ -350,7 +350,12 @@ lazy_static! {
 
 #[doc = include_str!("../docs/close_virtualfd.md")]
 pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
-
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+    
     assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
 
     // cloning this so I don't hold a lock and deadlock close handlers

--- a/src/fdtables/src/muthashmaxglobal.rs
+++ b/src/fdtables/src/muthashmaxglobal.rs
@@ -458,6 +458,12 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
 // remaining.
 #[doc = include_str!("../docs/close_virtualfd.md")]
 pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+    
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {

--- a/src/fdtables/src/vanillaglobal.rs
+++ b/src/fdtables/src/vanillaglobal.rs
@@ -422,6 +422,12 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
 // remaining.
 #[doc = include_str!("../docs/close_virtualfd.md")]
 pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
+    // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    if virtfd >= FD_PER_PROCESS_MAX {
+        return Err(threei::Errno::EBADFD as u64);
+    }
+    
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {


### PR DESCRIPTION
This change adds a range check in close_virtualfd to ensure that the provided virtfd is less than FD_PER_PROCESS_MAX.
If the value is out of bounds, the function now returns EBADFD immediately.