### PR TITLE
Add zizmor installation and run to lint.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,8 @@ on:
       - main
   pull_request:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -40,3 +41,10 @@ jobs:
               -A warnings \
               -A clippy::not_unsafe_ptr_arg_deref \
               -A clippy::absurd_extreme_comparisons
+      - name: Install Zizmor via Cargo
+        run: cargo install zizmor
+
+      - name: Run Zizmor
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: zizmor -v .github/workflows #Running with -v to show all passes, will halt if any fail


### PR DESCRIPTION
### PURPOSE
Enable and validate Zizmor security/linting checks for GitHub Actions workflows as part of our lint job.
This PR updates lint.yml to:

1. Install Zizmor via Cargo
2. Scope the scan to .github/workflows for efficiency
3. Pass ${{ github.token }} to enable online audits (impostor-commit, ref-confusion, known-vulnerable-actions, stale-action-refs)
4. Retain failure-on-findings behavior for CI enforcement

### ISSUES
- Prepares groundwork for adding forbidden-uses rules in future

### NOTES FOR REVIEWERS

- Verified locally with a fine-grained PAT (read-only permissions) to confirm all online audits run
- Attached verbose Zizmor output showing all audit executions, including those previously skipped
- Only forbidden-uses remains skipped, pending configuration file addition
- No findings reported in current workflows.  CI will fail automatically if issues are detected later
- The linter was run (attached below) with all changes already made, so it was tested on itself as well

ATTACHMENTS

[zizmor_verbose_test_results.log](https://github.com/user-attachments/files/21763970/zizmor_verbose_test_results.log) : full debug output from local run with fine-grained personal token used to emulate results