### PR TITLE
257 ci enable dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+
+version: 2
+updates:
+- package-ecosystem: "" # See documentation for possible values
+  directory: "/" # Location of package manifests
+  schedule:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,29 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
+# Dependabot configuration for keeping GitHub Actions in '.github/workflows' up to date.
+# 
+# Schedule: Weekly, Wednesday 12:00 New York time
+#
+# labels: these labels will be applied to any PR made by dependabot
+#
+# Commit Message: 
+# This will create an automatic commit message for each commit.
+#
+# Example Message:
+# deps(gha): bump actions from v1.1.1 to v1.1.2
+#
 
 version: 2
 updates:
-- package-ecosystem: "" # See documentation for possible values
-  directory: "/" # Location of package manifests
+- package-ecosystem: "github-actions" # See documentation for possible values
+  directory: "/.github/workflows" # Scanning for workflows only
   schedule:
     interval: "weekly"
+    day: "wednesday"
+    time: "12:00"
+    timezone: "America/New_York"
+  labels:
+      - "dependabot"
+      - "gha"
+      - "automated"
+  commit-message:
+    prefix: "deps(gha)"
+    include: "scope"


### PR DESCRIPTION
### PURPOSE
Enable automated dependency updates for GitHub Actions workflows using Dependabot.
This PR adds a `.github/dependabot.yml` configuration file to ensure workflows remain current and secure.
1. Schedule weekly checks (Wednesdays at 12:00 New York time) for all workflows under `.github/workflows`
2. Apply `dependabot`, `gha`, and `automated` labels to PRs for easy identification and filtering
3. Use a standardised commit message format ( `deps(cha):...`) for consistent changelog and history
4. Ensure configuration is scoped specifically to GitHub Actions to avoid unnecessary scans of other ecosystems


### ISSUES
- Helps maintain up-to-date and secure GitHub Actions without manual intervention
- REduces risk of using outdated or vulnerable workflow actions

### NOTES FOR REVIEWERS
- Dependabot was enable in the repostitory settings (Cannot add via PR, it's a UI action)
- Configuration tested for YAML validity against Dependabot spec
- Schedule and timezone chosen for project location, can be altered
- No functional changes to workflow behaviour, only automation step for dependency updates