### PR TITLE
Add condition to prevent running on draft PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,12 @@ permissions: {}
 
 jobs:
   docker:
+    # If the workflow was triggered by anything other than a pull_request event 
+    # (e.g., push, workflow_dispatch, schedule, pull_request_target), 
+    # github.event_name != 'pull_request' is true.
+    # github.event.pull_request is only populated on pull_request events. 
+    # It is true when the PR is not a draft (i.e., “Ready for review”).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: End-to-end testing
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,12 @@ permissions: {}
 
 jobs:
   lint:
+    # If the workflow was triggered by anything other than a pull_request event 
+    # (e.g., push, workflow_dispatch, schedule, pull_request_target), 
+    # github.event_name != 'pull_request' is true.
+    # github.event.pull_request is only populated on pull_request events. 
+    # It is true when the PR is not a draft (i.e., “Ready for review”).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions: {}
 


### PR DESCRIPTION
### PURPOSE

Prevent unnecessary runs of the e2e testing workflow on draft PRs to conserve CI resources and prevent spam sent out without cause.
This PR updates `.github/workflows/e2e.yml`  and `.github/lint.yml` to add a conditional check that skips the job when a draft PR is created.

### ISSUES
-  Avoids burning compute time on unnecessary e2e and lint tests
- reduces queue times for PRs ready for testing and review

### NOTES FOR REVIEWERS
- Draft PRs will still trigger the workflow, but should be marked as 'skipped' 
- No changes to the build steps or test setups, just an exception to avoid extra runs

Shows results as 'skipped' from a draft PR
<img width="734" height="140" alt="image" src="https://github.com/user-attachments/assets/9799f500-da87-4cef-bcde-05a8b7ca1c41" />
