### PR TITLE
rawposix - signal interruption for select and poll

### DIFF
--- a/src/RawPOSIX/src/interface/misc.rs
+++ b/src/RawPOSIX/src/interface/misc.rs
@@ -304,3 +304,44 @@ pub struct AdvisoryLock {
     advisory_lock: RustRfc<Mutex<i32>>,
     advisory_condvar: Condvar,
 }
+
+pub fn timeout_setup(rposix_timeout: Option<Duration>) -> (Duration, libc::timeval) {
+    let end_time = match rposix_timeout {
+        Some(duration) => duration,
+        None => Duration::MAX,
+    };
+
+    let mut timeout;
+    if end_time > Duration::from_millis(100) {
+        timeout = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 1000000, // 100ms
+        };
+    } else {
+        timeout = libc::timeval {
+            tv_sec: 0,
+            tv_usec: end_time.subsec_micros() as i64,
+        };
+    }
+
+    (end_time, timeout)
+}
+
+pub fn timeout_setup_ms(timeout_ms: i32) -> (Duration, i32) {
+    let end_time = {
+        if timeout_ms >= 0 {
+            Duration::from_millis(timeout_ms as u64)
+        } else {
+            Duration::MAX
+        }
+    };
+
+    let mut timeout;
+    if end_time > Duration::from_millis(100) {
+        timeout = 100;
+    } else {
+        timeout = timeout_ms;
+    }
+
+    (end_time, timeout)
+}


### PR DESCRIPTION
This PR is splited from PR #164

This PR focuses on spliting out the signal interruption implementation for select and poll

The signal interruption for select and poll works by invoking system select and poll syscall with fixed timeout (100ms) to be able to periodically check for signal. It wakes up every 100ms once system select/poll is timed out, it then checks if it reached user timeout and signals.