### PR TITLE
glibc - qsort fix

### DIFF
--- a/src/glibc/stdlib/qsort.c
+++ b/src/glibc/stdlib/qsort.c
@@ -685,6 +685,23 @@ __qsort_internal (void *const pbase, size_t total_elems, size_t size,
     free (buf);
 }
 
+/*
+ * lind-wasm:
+ * In C, it's legal to cast a function pointer to another type (even with fewer
+ * parameters) and call it with the "wrong" number of arguments. glibc's qsort
+ * implementation relies on this trick.
+ *
+ * However, WebAssembly enforces strict function signatures, so this behavior
+ * causes a runtime error under Wasm.
+ *
+ * While wasm-opt can emulate function pointer casting, that approach adds
+ * significant overhead across the entire Wasm binary. Instead, this change
+ * modifies glibc directly to remove qsort’s function pointer trick.
+ *
+ * Therefore, we duplicates the qsort implementation with a function signature that
+ * has one fewer parameter, eliminating the cast and making qsort work correctly
+ * in a Wasm environment.
+ */
 void
 qsort (void *b, size_t n, size_t s, __compar_fn_t cmp)
 {


### PR DESCRIPTION
This PR is splited from PR #164

This PR focuses on spliting out the fix for qsort function in glibc for wasm compatibility

In C, it is legal to cast a function pointer to another type (potentially with fewer parameters) and then invoke it with the “wrong” number of arguments. The qsort implementation in glibc relies on this trick. However, this behavior violates Wasm’s strict function signature rules and results in a runtime error under Wasm. More discussion [here](https://github.com/Lind-Project/lind-wasm/issues/78)

While it’s possible to work around this with wasm-opt’s emulated function pointer casting, that approach introduces significant overhead across the entire Wasm binary. Instead, this PR directly modifies glibc’s source to remove the qsort function pointer trick, avoiding the need for binary rewriting.

The main change is duplicating the qsort implementation with a function signature that has one fewer parameter. This eliminates the function pointer casting and makes qsort work in a Wasm environment.