### PR TITLE
fix migration - glibc/wasmtime - libc fatal debug

### DIFF
--- a/src/glibc/malloc/malloc.c
+++ b/src/glibc/malloc/malloc.c
@@ -5766,15 +5766,28 @@ libc_hidden_def (__libc_mallopt)
 
 extern char **__libc_argv attribute_hidden;
 
+#ifdef WASM_DEBUG_MALLOC_ERR
+// TODO: malloc_printerr is currently unable to print messages to the console correctly.
+// This is a temporary workaround to ensure that error messages are printed.
+void __imported__malloc_printerr(const char *str) __attribute__((
+  __import_module__("debug"),
+  __import_name__("malloc_printerr")
+));
+#endif
+
 static void
 malloc_printerr (const char *str)
 {
+#ifdef WASM_DEBUG_MALLOC_ERR
+  __imported__malloc_printerr(str);
+  __builtin_unreachable ();
+#else
 #if IS_IN (libc)
   __libc_message ("%s\n", str);
 #else
   __libc_fatal (str);
 #endif
-  __builtin_unreachable ();
+#endif
 }
 
 #if IS_IN (libc)


### PR DESCRIPTION
This PR is splited from PR #164 

This PR focuses on spliting out the temporary debug solution for glibc fatal. Previously, when glibc crushes, there is no debug information getting printed out, which is pretty inconvenient. The reason behind it is that the `libc_assert_fail` and `malloc_printerr` function in glibc is not working correctly. This PR provides an temporary solution to have the error message directly passed to wasmtime to print the error