### PR TITLE
fix migration - glibc/rawposix - writev/iovec fix

### DIFF
--- a/src/glibc/misc/bits/types/struct_iovec.h
+++ b/src/glibc/misc/bits/types/struct_iovec.h
@@ -26,7 +26,9 @@
 struct iovec
   {
     void *iov_base;	/* Pointer to data.  */
+    int __padding1;
     size_t iov_len;	/* Length of data.  */
+    int __padding2;
   };
 
 #endif

--- a/src/glibc/sysdeps/unix/sysv/linux/writev.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/writev.c
@@ -24,6 +24,13 @@
 ssize_t
 __writev (int fd, const struct iovec *iov, int iovcnt)
 {
+  // clean up padding field of each iovec
+  for(size_t i = 0; i < iovcnt; ++i)
+  {
+    struct iovec *cur = iov + i;
+    cur->__padding1 = 0;
+    cur->__padding2 = 0;
+  }
   // Dennis Edit
   return MAKE_SYSCALL(170, "syscall|writev", (uint64_t) fd, (uint64_t)(uintptr_t) iov, (uint64_t) iovcnt, NOTUSED, NOTUSED, NOTUSED);
 }

--- a/src/glibc/target/include/bits/types/struct_iovec.h
+++ b/src/glibc/target/include/bits/types/struct_iovec.h
@@ -26,7 +26,9 @@
 struct iovec
   {
     void *iov_base;	/* Pointer to data.  */
+    int __padding1;
     size_t iov_len;	/* Length of data.  */
+    int __padding2;
   };
 
 #endif


### PR DESCRIPTION
This PR is splited from PR #164 

This PR focuses on spliting out the fix for writev syscall and iovec struct