### PR TITLE
fix migration - wasmtime - asyncify & signal interruption

### DIFF
--- a/src/wasmtime/crates/lind-common/Cargo.toml
+++ b/src/wasmtime/crates/lind-common/Cargo.toml
@@ -16,3 +16,4 @@ wasmtime = { workspace = true, features = ['threads'] }
 wasmtime-environ = { workspace = true }
 rawposix = { path = "../rawposix" }
 wasmtime-lind-multi-process = { path = "../lind-multi-process" }
+sysdefs = { path = "../sysdefs" }

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -13,7 +13,7 @@ use crate::{
 use alloc::sync::Arc;
 use core::ptr::NonNull;
 use rawposix::safeposix::dispatcher::lind_syscall_api;
-use sysdefs::constants::fs_const::{
+use sysdefs::constants::{
     MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PAGESHIFT, PROT_READ, PROT_WRITE,
 };
 use wasmparser::WasmFeatures;

--- a/src/wasmtime/crates/wasmtime/src/runtime/store.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/store.rs
@@ -338,8 +338,13 @@ pub struct StoreOpaque {
     host_globals: Vec<StoreBox<VMHostGlobalContext>>,
 
     asyncify_state: AsyncifyState,
+    // signal asyncify data, holds the sequence of the parameters for signal handler
     signal_asyncify_data: Vec<SignalAsyncifyData>,
     signal_asyncify_counter: u64,
+    // syscall asyncify data, holds the sequence of syscall return value
+    syscall_asyncify_data: Vec<i32>,
+    syscall_asyncify_counter: u64,
+
     // stack top
     stack_top: u64,
     // stack bottom
@@ -548,6 +553,8 @@ impl<T> Store<T> {
                 asyncify_state: super::AsyncifyState::Normal,
                 signal_asyncify_data: Vec::new(),
                 signal_asyncify_counter: 0,
+                syscall_asyncify_data: Vec::new(),
+                syscall_asyncify_counter: 0,
                 #[cfg(feature = "component-model")]
                 num_component_instances: 0,
                 signal_handler: None,
@@ -660,6 +667,8 @@ impl<T> Store<T> {
             asyncify_state: super::AsyncifyState::Normal,
             signal_asyncify_data: Vec::new(),
             signal_asyncify_counter: 0,
+            syscall_asyncify_data: Vec::new(),
+            syscall_asyncify_counter: 0,
             #[cfg(feature = "component-model")]
             num_component_instances: 0,
             signal_handler: None,
@@ -1426,6 +1435,39 @@ impl<'a, T> StoreContextMut<'a, T> {
     pub fn set_signal_asyncify_data(&mut self, data: Vec<SignalAsyncifyData>) {
         self.0.signal_asyncify_data = data;
         self.0.signal_asyncify_counter = 0;
+    }
+
+    // append the syscall retval information
+    pub fn append_syscall_asyncify_data(&mut self, retval: i32) {
+        self.0.syscall_asyncify_data.push(retval);
+    }
+
+    // pop the syscall retval information
+    pub fn pop_syscall_asyncify_data(&mut self) {
+        self.0.syscall_asyncify_data.pop();
+    }
+
+    // get the current syscall retval information
+    pub fn get_current_syscall_rewind_data(&mut self) -> Option<i32> {
+        let data = self
+            .0
+            .syscall_asyncify_data
+            .get(self.0.syscall_asyncify_counter as usize)
+            .cloned();
+        let length = self.0.syscall_asyncify_data.len();
+        if self.0.syscall_asyncify_counter == (length - 1) as u64 {
+            self.0.syscall_asyncify_counter = 0;
+        } else {
+            self.0.syscall_asyncify_counter += 1;
+        }
+        data
+    }
+
+    // set the syscall retval information
+    // used by fork to copy asyncify information
+    pub fn set_syscall_asyncify_data(&mut self, data: Vec<i32>) {
+        self.0.syscall_asyncify_data = data;
+        self.0.syscall_asyncify_counter = 0;
     }
 
     /// get stack top
@@ -2980,6 +3022,10 @@ impl<T> StoreInner<T> {
     // get the signal asyncify information
     pub fn get_signal_asyncify_data(&mut self) -> Vec<SignalAsyncifyData> {
         self.signal_asyncify_data.clone()
+    }
+
+    pub fn get_syscall_asyncify_data(&mut self) -> Vec<i32> {
+        self.syscall_asyncify_data.clone()
     }
 
     pub fn is_thread(&self) -> bool {


### PR DESCRIPTION
This PR is splited from PR #164 

This PR focuses on spliting out the signal interruption implementation on wasmtime part. Added logic to have Asyncify supporting signal interruption on syscall