### PR TITLE
glibc - workaround for getpwuid functions

### DIFF
--- a/src/glibc/nscd/getpwuid_r.c
+++ b/src/glibc/nscd/getpwuid_r.c
@@ -27,4 +27,27 @@
 /* We are nscd, so we don't want to be talking to ourselves.  */
 #undef	USE_NSCD
 
-#include <nss/getXXbyYY_r.c>
+// TODO: normal getpwuid routine is not working correctly for some reason
+// currently hardcoded the value but we should fix this in the future
+// #include <nss/getXXbyYY_r.c>
+
+int
+__getpwuid_r (uid_t uid, struct passwd *resbuf, char *buffer,
+   size_t buflen, struct passwd **result)
+{
+   if(uid != 1000) return -1;
+
+   resbuf->pw_name = "lind";
+   resbuf->pw_passwd = "";
+   resbuf->pw_uid = 1000;
+   resbuf->pw_gid = 1000;
+   resbuf->pw_gecos = "lind";
+   resbuf->pw_dir = "/home";
+   resbuf->pw_shell = "/bin/sh";
+
+   result = &resbuf;
+
+   return 0;
+}
+
+weak_alias (__getpwuid_r, getpwuid_r)

--- a/src/glibc/nss/getpwuid.c
+++ b/src/glibc/nss/getpwuid.c
@@ -16,7 +16,7 @@
    <https://www.gnu.org/licenses/>.  */
 
 #include <pwd.h>
-
+#include <stdlib.h>
 
 #define LOOKUP_TYPE	struct passwd
 #define FUNCTION_NAME	getpwuid
@@ -25,4 +25,22 @@
 #define ADD_VARIABLES	uid
 #define BUFLEN		NSS_BUFLEN_PASSWD
 
-#include "../nss/getXXbyYY.c"
+// TODO: normal getpwuid routine is not working correctly for some reason
+// currently hardcoded the value but we should fix this in the future
+// #include "../nss/getXXbyYY.c"
+
+struct passwd *
+getpwuid (uid_t uid)
+{
+   if(uid != 1000) return NULL;
+
+   struct passwd *res = malloc(sizeof(struct passwd));
+   res->pw_name = "lind";
+   res->pw_passwd = "";
+   res->pw_uid = 1000;
+   res->pw_gid = 1000;
+   res->pw_gecos = "lind";
+   res->pw_dir = "/home";
+   res->pw_shell = "/bin/sh";
+   return res;
+}

--- a/src/glibc/nss/getpwuid_r.c
+++ b/src/glibc/nss/getpwuid_r.c
@@ -25,4 +25,25 @@
 #define ADD_VARIABLES	uid
 #define BUFLEN		NSS_BUFLEN_PASSWD
 
-#include <nss/getXXbyYY_r.c>
+// TODO: normal getpwuid routine is not working correctly for some reason
+// currently hardcoded the value but we should fix this in the future
+// #include <nss/getXXbyYY_r.c>
+
+int
+getpwuid_r (uid_t uid, struct passwd *resbuf, char *buffer,
+   size_t buflen, struct passwd **result)
+{
+   if(uid != 1000) return -1;
+
+   resbuf->pw_name = "lind";
+   resbuf->pw_passwd = "";
+   resbuf->pw_uid = 1000;
+   resbuf->pw_gid = 1000;
+   resbuf->pw_gecos = "lind";
+   resbuf->pw_dir = "/home";
+   resbuf->pw_shell = "/bin/sh";
+
+   result = &resbuf;
+
+   return 0;
+}


### PR DESCRIPTION
This PR is splited from PR #164

This PR focuses on spliting out the fix for getpwuid functions

`getpwuid` in glibc is used for retrieveing some system information. This function does not work for some reason. Here is a temporary workaround to make some applications happy