### PR TITLE
File system calls threei

### DIFF
--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -1,13 +1,20 @@
+// use parking_lot::RwLock;
+// use std::sync::atomic::{AtomicI32, AtomicU64};
+// use std::sync::Arc;
 use libc::c_void;
+// Updated imports - using path_conversion for filesystem operations
 use typemap::datatype_conversion::*;
+use sysdefs::data::fs_struct::{StatData, FSData};
 use typemap::path_conversion::*;
 use sysdefs::constants::err_const::{syscall_error, Errno, get_errno, handle_errno};
 use sysdefs::constants::fs_const::{STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO, O_CLOEXEC, MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, MAP_SHARED, PROT_EXEC, PROT_NONE, PROT_READ, PROT_WRITE, PAGESHIFT, PAGESIZE};
 use sysdefs::constants::lind_platform_const::{FDKIND_KERNEL, MAXFD};
 use sysdefs::constants::sys_const::{DEFAULT_UID, DEFAULT_GID};
 use typemap::cage_helpers::*;
-use cage::{round_up_page, get_cage, HEAP_ENTRY_INDEX, MemoryBackingType, VmmapOps};
+use cage::{round_up_page, get_cage, HEAP_ENTRY_INDEX, MemoryBackingType, VmmapOps, check_addr};
 use fdtables;
+use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Helper function for close_syscall
 /// 
@@ -74,14 +81,14 @@ pub fn open_syscall(
         && sc_unusedarg(arg5, arg5_cageid)
         && sc_unusedarg(arg6, arg6_cageid))
     {
-        return syscall_error(Errno::EFAULT, "open", "Invalide Cage ID");
+        return syscall_error(Errno::EFAULT, "open_syscall", "Invalide Cage ID");
     }
 
     // Get the kernel fd first
     let kernel_fd = unsafe { libc::open(path.as_ptr(), oflag, mode) };
 
     if kernel_fd < 0 {
-        return handle_errno(get_errno(), "open");
+        return handle_errno(get_errno(), "open_syscall");
     }
 
     // Check if `O_CLOEXEC` has been est
@@ -96,7 +103,7 @@ pub fn open_syscall(
         0,
     ) {
         Ok(virtual_fd) => virtual_fd as i32,
-        Err(_) => syscall_error(Errno::EMFILE, "open", "Too many files opened"),
+        Err(_) => syscall_error(Errno::EMFILE, "open_syscall", "Too many files opened"),
     }
 }
 
@@ -109,12 +116,12 @@ pub fn open_syscall(
 /// ## Arguments:
 ///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
 ///     - cageid: current cage identifier.
-///     - vfd_arg: the virtual file descriptor from the RawPOSIX environment.
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment.
 ///     - buf_arg: pointer to a buffer where the read data will be stored (user's perspective).
 ///     - count_arg: the maximum number of bytes to read from the file descriptor.
 pub fn read_syscall(
     cageid: u64,
-    vfd_arg: u64,
+    virtual_fd: u64,
     vfd_cageid: u64,
     buf_arg: u64,
     buf_cageid: u64,
@@ -128,7 +135,7 @@ pub fn read_syscall(
     arg6_cageid: u64,
 ) -> i32 {
     // Convert the virtual fd to the underlying kernel file descriptor.
-    let kernel_fd = convert_fd_to_host(vfd_arg, vfd_cageid, cageid);
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
     if kernel_fd == -1 {
         return syscall_error(Errno::EFAULT, "read", "Invalid Cage ID");
     } else if kernel_fd == -9 {
@@ -172,11 +179,11 @@ pub fn read_syscall(
 /// ## Arguments:
 ///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
 ///     - cageid: current cage identifier.
-///     - vfd_arg: the virtual file descriptor from the RawPOSIX environment to be closed.
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment to be closed.
 ///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused.
 pub fn close_syscall(
     cageid: u64,
-    vfd_arg: u64,
+    virtual_fd: u64,
     vfd_cageid: u64, 
     arg2: u64,
     arg2_cageid: u64,
@@ -189,15 +196,14 @@ pub fn close_syscall(
     arg6: u64,
     arg6_cageid: u64,
 ) -> i32 {
-    if !(sc_unusedarg(arg2, arg2_cageid)
-         && sc_unusedarg(arg3, arg3_cageid)
+    if !(sc_unusedarg(arg3, arg3_cageid)
          && sc_unusedarg(arg4, arg4_cageid)
          && sc_unusedarg(arg5, arg5_cageid)
          && sc_unusedarg(arg6, arg6_cageid)) {
         return syscall_error(Errno::EFAULT, "close", "Invalid Cage ID");
     }
 
-    match fdtables::close_virtualfd(cageid, vfd_arg) {
+    match fdtables::close_virtualfd(cageid, virtual_fd) {
         Ok(()) => 0,
         Err(e) => {
             if e == Errno::EBADFD as u64 {
@@ -209,6 +215,119 @@ pub fn close_syscall(
             }
         }
     }
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/futex.2.html
+///
+/// The Linux `futex()` syscall provides a mechanism for fast user-space locking. It allows a process or thread
+/// to wait for or wake another process or thread on a shared memory location without invoking heavy kernel-side
+/// synchronization primitives unless contention arises. This implementation wraps the futex syscall, allowing
+/// direct invocation with the relevant arguments passed from the current cage context.
+///
+/// Input:
+///     - cageid: current cageid
+///     - uaddr_arg: pointer to the futex word in user memory
+///     - futex_op_arg: operation code indicating futex command type
+///     - val_arg: value expected at uaddr or the number of threads to wake
+///     - val2_arg: timeout or other auxiliary parameter depending on operation
+///     - uaddr2_arg: second address used for requeueing operations
+///     - val3_arg: additional value for some futex operations
+///
+/// Return:
+///     - On success: 0 or number of woken threads depending on futex operation
+///     - On failure: a negative errno value indicating the syscall error
+pub fn futex_syscall(
+    cageid: u64,
+    uaddr_arg: u64,
+    uaddr_cageid: u64,
+    futex_op_arg: u64,
+    futex_op_cageid: u64,
+    val_arg: u64,
+    val_cageid: u64,
+    val2_arg: u64,
+    val2_cageid: u64,
+    uaddr2_arg: u64,
+    uaddr2_cageid: u64,
+    val3_arg: u64,
+    val3_cageid: u64,
+) -> i32{
+    let uaddr = sc_convert_uaddr_to_host(uaddr_arg, uaddr_cageid, cageid);
+    let futex_op = sc_convert_sysarg_to_u32(futex_op_arg, futex_op_cageid, cageid);
+    let val = sc_convert_sysarg_to_u32(val_arg, val_cageid, cageid);
+    let val2 = sc_convert_sysarg_to_u32(val2_arg, val2_cageid, cageid);
+    let uaddr2 = sc_convert_sysarg_to_u32(uaddr2_arg, uaddr2_cageid, cageid);
+    let val3 = sc_convert_sysarg_to_u32(val3_arg, val3_cageid, cageid);
+
+    let ret = unsafe { syscall(SYS_futex, uaddr, futex_op, val, val2, uaddr2, val3)  as i32 };
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "futex");
+    }
+    ret
+}
+
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/write.2.html
+///
+/// Linux `write()` syscall attempts to write `count` bytes from the buffer pointed to by `buf` to the file associated
+/// with the open file descriptor, `fd`. RawPOSIX first converts virtual fd to kernel fd due to the `fdtable` subsystem, second
+/// translates the `buf_arg` pointer to actual system pointer
+///
+/// Input:
+///     - cageid: current cageid
+///     - virtual_fd: virtual file descriptor, needs to be translated kernel fd for future kernel operation
+///     - buf_arg: pointer points to a buffer that stores the data
+///     - count_arg: length of the buffer
+///
+/// Output:
+///     - Upon successful completion of this call, we return the number of bytes written. This number will never be greater
+///         than `count`. The value returned may be less than `count` if the write_syscall() was interrupted by a signal, or
+///         if the file is a pipe or FIFO or special file and has fewer than `count` bytes immediately available for writing.
+pub fn write_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    buf_arg: u64,
+    buf_cageid: u64,
+    count_arg: u64,
+    count_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "write", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "write", "Bad File Descriptor");
+    }
+
+    let buf = sc_convert_buf(buf_arg, buf_cageid, cageid);
+    let count = sc_convert_sysarg_to_usize(count_arg, count_cageid, cageid);
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "write", "Invalide Cage ID");
+    }
+
+    // Early return
+    if count == 0 {
+        return 0;
+    }
+
+    let ret = unsafe { libc::write(kernel_fd, buf as *const c_void, count) as i32 };
+
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "write");
+    }
+    return ret;
 }
 
 /// Reference to Linux: https://man7.org/linux/man-pages/man2/mkdir.2.html
@@ -251,7 +370,7 @@ pub fn mkdir_syscall(
         && sc_unusedarg(arg5, arg5_cageid)
         && sc_unusedarg(arg6, arg6_cageid))
     {
-        return syscall_error(Errno::EFAULT, "mkdir", "Invalide Cage ID");
+        return syscall_error(Errno::EFAULT, "mkdir_syscall", "Invalide Cage ID");
     }
 
     let ret = unsafe { libc::mkdir(path.as_ptr(), mode) };
@@ -969,8 +1088,13 @@ pub fn fcntl_syscall(
                 Err(_e) => return syscall_error(Errno::EBADF, "fcntl", "Bad File Descriptor"),
             }
         }
-        // todo: F_GETOWN and F_SETOWN commands are not implemented yet
+        // Return (as the function result) the process ID or process
+        // group ID currently receiving SIGIO and SIGURG signals for
+        // events on file descriptor fd.
         (F_GETOWN, ..) => DEFAULT_GID as i32,
+        // Set the process ID or process group ID that will receive
+        // SIGIO and SIGURG signals for events on the file descriptor
+        // fd.
         (F_SETOWN, arg) if arg >= 0 => 0,
         _ => {
             // Get fdtable entry
@@ -986,4 +1110,1164 @@ pub fn fcntl_syscall(
             ret
         }
     }
+}
+
+pub fn clock_gettime_syscall(
+    cageid: u64,
+    clockid_arg: u64,
+    clockid_cageid: u64,
+    tp_arg: u64,
+    tp_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let clockid = sc_convert_sysarg_to_u32(clockid_arg, clockid_cageid, cageid);
+    // let tp = sc_convert_sysarg_to_usize(tp_arg, tp_cageid, cageid);
+    let tp = sc_convert_addr_to_host(tp_arg, tp_cageid, cageid);
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "clock_gettime", "Invalide Cage ID");
+    }
+
+    let ret = unsafe { syscall(SYS_clock_gettime, clockid, tp) as i32 };
+
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "clock_gettime");
+    }
+
+    ret
+}
+
+
+pub fn dup_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    arg2: u64,
+    arg2_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    if !(sc_unusedarg(arg2, arg2_cageid)
+        && sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "dup", "Invalide Cage ID");
+    }
+
+    if virtual_fd < 0 {
+        return syscall_error(Errno::EBADF, "dup", "Bad File Descriptor");
+    }
+    let wrappedvfd = fdtables::translate_virtual_fd(cageid, virtual_fd as u64);
+    if wrappedvfd.is_err() {
+        return syscall_error(Errno::EBADF, "dup", "Bad File Descriptor");
+    }
+    let vfd = wrappedvfd.unwrap();
+    let ret_kernelfd = unsafe { libc::dup(vfd.underfd as i32) };
+    let ret_virtualfd =
+        fdtables::get_unused_virtual_fd(cageid, vfd.fdkind, ret_kernelfd as u64, false, 0).unwrap();
+    return ret_virtualfd as i32;
+}
+
+pub fn dup2_syscall(
+    cageid: u64,
+    old_virtualfd: u64,
+    old_vfd_cageid: u64,
+    new_virtualfd: u64,
+    new_vfd_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "dup2", "Invalide Cage ID");
+    }
+
+    if old_virtualfd < 0 || new_virtualfd < 0 {
+        return syscall_error(Errno::EBADF, "dup2", "Bad File Descriptor");
+    }
+
+    match fdtables::translate_virtual_fd(cageid, old_virtualfd) {
+        Ok(old_vfd) => {
+            let new_kernelfd = unsafe { libc::dup(old_vfd.underfd as i32) };
+            // Map new kernel fd with provided kernel fd
+            let _ret_kernelfd = unsafe { libc::dup2(old_vfd.underfd as i32, new_kernelfd) };
+            let _ = fdtables::get_specific_virtual_fd(
+                cageid,
+                new_virtualfd,
+                old_vfd.fdkind,
+                new_kernelfd as u64,
+                false,
+                old_vfd.perfdinfo,
+            )
+            .unwrap();
+            return new_virtualfd as i32;
+        }
+        Err(_e) => {
+            return syscall_error(Errno::EBADF, "dup2", "Bad File Descriptor");
+        }
+    }
+}
+
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/fchdir.2.html
+///
+/// Linux `fchdir()` syscall changes the current working directory of the calling process to the
+/// directory referred to by the open file descriptor `fd`. Since we implement a file descriptor
+/// management subsystem (called `fdtables`), we first translate the virtual file descriptor to the
+/// corresponding kernel file descriptor before invoking the kernel's `libc::fchdir()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment referring to a directory
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn fchdir_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    arg2: u64,
+    arg2_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "fchdir", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "fchdir", "Bad File Descriptor");
+    }
+
+    if !(sc_unusedarg(arg2, arg2_cageid)
+        && sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "fchdir", "Invalid Cage ID");
+    }
+
+    let ret = unsafe { libc::fchdir(kernel_fd) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "fchdir");
+    }
+
+    // Update the cage's current working directory
+    // We need to get the current working directory from the kernel to update the cage
+    let mut cwd_buf = [0u8; 1024];
+    let cwd_ptr = unsafe { libc::getcwd(cwd_buf.as_mut_ptr() as *mut i8, cwd_buf.len()) };
+    if !cwd_ptr.is_null() {
+        if let Some(cage) = get_cage(cageid) {
+            let mut cwd = cage.cwd.write();
+            *cwd = Arc::new(PathBuf::from(
+                unsafe { std::ffi::CStr::from_ptr(cwd_ptr) }.to_string_lossy().as_ref()
+            ));
+        }
+    }
+
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/writev.2.html
+///
+/// Linux `writev()` syscall performs scatter-gather output by writing data from multiple buffers
+/// to a file descriptor in a single operation. Since we implement a file descriptor management
+/// subsystem (called `fdtables`), we first translate the virtual file descriptor to the corresponding
+/// kernel file descriptor, then translate the iovec array pointer from cage virtual memory to host
+/// memory before invoking the kernel's `libc::writev()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - iov_arg: pointer to an array of iovec structures describing the buffers (user's perspective)
+///     - iovcnt_arg: number of iovec structures in the array
+///     - arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn writev_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    iov_arg: u64,
+    iov_cageid: u64,
+    iovcnt_arg: u64,
+    iovcnt_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "writev", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "writev", "Bad File Descriptor");
+    }
+
+    let iovcnt = sc_convert_sysarg_to_i32(iovcnt_arg, iovcnt_cageid, cageid);
+    if iovcnt < 0 {
+        return syscall_error(Errno::EINVAL, "writev", "Invalid iovcnt");
+    }
+
+    let iov_ptr = sc_convert_buf(iov_arg, iov_cageid, cageid);
+    if iov_ptr.is_null() {
+        return syscall_error(Errno::EFAULT, "writev", "iovec is null");
+    }
+
+    if !(sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "writev", "Invalid Cage ID");
+    }
+
+    let ret = unsafe {
+        libc::writev(
+            kernel_fd,
+            iov_ptr as *const libc::iovec,
+            iovcnt,
+        ) as i32
+    };
+    if ret < 0 {
+        return handle_errno(get_errno(), "writev");
+    }
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/fstat.2.html
+///
+/// Linux `fstat()` syscall retrieves information about the file referred to by the open file descriptor `fd`.
+/// Since we implement a file descriptor management subsystem (called `fdtables`), we first translate the virtual
+/// file descriptor to the corresponding kernel file descriptor, then call the kernel's `libc::fstat()` function.
+/// The returned stat structure is converted to our ABI-stable StatData format and copied to the user's buffer.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - stat_arg: pointer to a stat structure where the file information will be stored (user's perspective)
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn fstat_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    stat_arg: u64,
+    stat_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "fstat", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "fstat", "Bad File Descriptor");
+    }
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "fstat", "Invalid Cage ID");
+    }
+
+    // 1) Call host fstat into a local host variable
+    let mut host_stat: libc::stat = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::fstat(kernel_fd, &mut host_stat as *mut libc::stat) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "fstat");
+    }
+
+    // 2) Convert to ABI-stable StatData and copy into guest buffer
+    let translated: StatData = StatData {
+        st_dev: host_stat.st_dev as u64,
+        st_ino: host_stat.st_ino as usize,
+        st_mode: host_stat.st_mode as u32,
+        st_nlink: host_stat.st_nlink as u32,
+        st_uid: host_stat.st_uid as u32,
+        st_gid: host_stat.st_gid as u32,
+        st_rdev: host_stat.st_rdev as u64,
+        st_size: host_stat.st_size as usize,
+        st_blksize: host_stat.st_blksize as i32,
+        st_blocks: host_stat.st_blocks as u32,
+        // The StatData comment notes we don't currently populate time bits
+        st_atim: (0, 0),
+        st_mtim: (0, 0),
+        st_ctim: (0, 0),
+    };
+
+    // Validate guest buffer range and writability
+    let needed_size = std::mem::size_of::<StatData>();
+    if check_addr(stat_cageid, stat_arg, needed_size, PROT_WRITE).is_err() {
+        return syscall_error(Errno::EFAULT, "fstat", "stat buffer not writable or too small");
+    }
+
+    let dest_ptr = sc_convert_addr_to_host(stat_arg, stat_cageid, cageid) as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &translated as *const StatData as *const u8,
+            dest_ptr,
+            needed_size,
+        );
+    }
+
+    0
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/stat.2.html
+///
+/// Linux `stat()` syscall returns information about a file, using the file path instead of a file descriptor.
+/// This is similar to fstat but takes a pathname instead of a file descriptor.
+///
+/// ## Arguments:
+///     - cageid: current cage
+///     - path_arg: pointer to the pathname string (user's perspective)
+///     - stat_arg: pointer to a stat structure where the file information will be stored (user's perspective)
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn stat_syscall(
+    cageid: u64,
+    path_arg: u64,
+    path_cageid: u64,
+    stat_arg: u64,
+    stat_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // Convert path from guest memory to host string
+    let path_str = sc_convert_path_to_host(path_arg, path_cageid, cageid);
+    if path_str.is_empty() {
+        return syscall_error(Errno::EFAULT, "stat", "Invalid path");
+    }
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "stat", "Invalid Cage ID");
+    }
+
+    // 1) Call host stat into a local host variable
+    let mut host_stat: libc::stat = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::stat(path_str.as_ptr(), &mut host_stat as *mut libc::stat) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "stat");
+    }
+
+    // 2) Convert to ABI-stable StatData and copy into guest buffer
+    let translated: StatData = StatData {
+        st_dev: host_stat.st_dev as u64,
+        st_ino: host_stat.st_ino as usize,
+        st_mode: host_stat.st_mode as u32,
+        st_nlink: host_stat.st_nlink as u32,
+        st_uid: host_stat.st_uid as u32,
+        st_gid: host_stat.st_gid as u32,
+        st_rdev: host_stat.st_rdev as u64,
+        st_size: host_stat.st_size as usize,
+        st_blksize: host_stat.st_blksize as i32,
+        st_blocks: host_stat.st_blocks as u32,
+        // The StatData comment notes we don't currently populate time bits
+        st_atim: (0, 0),
+        st_mtim: (0, 0),
+        st_ctim: (0, 0),
+    };
+
+    // Validate guest buffer range and writability
+    let needed_size = std::mem::size_of::<StatData>();
+    if check_addr(stat_cageid, stat_arg, needed_size, PROT_WRITE).is_err() {
+        return syscall_error(Errno::EFAULT, "stat", "stat buffer not writable or too small");
+    }
+
+    let dest_ptr = sc_convert_addr_to_host(stat_arg, stat_cageid, cageid) as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &translated as *const StatData as *const u8,
+            dest_ptr,
+            needed_size,
+        );
+    }
+
+    0
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/ftruncate.2.html
+///
+/// Linux `ftruncate()` syscall truncates the file referred to by the file descriptor `fd` to be at most
+/// `length` bytes in size. Since we implement a file descriptor management subsystem (called `fdtables`),
+/// we first translate the virtual file descriptor to the corresponding kernel file descriptor, then convert
+/// the length argument from u64 to i64 type before invoking the kernel's `libc::ftruncate()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - length_arg: the desired length in bytes for the file truncation
+///     - arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn ftruncate_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    length_arg: u64,
+    length_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "ftruncate", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "ftruncate", "Bad File Descriptor");
+    }
+
+    let length = sc_convert_sysarg_to_i64(length_arg, length_cageid, cageid);
+
+    // Validate that length is not negative
+    if length < 0 {
+        return syscall_error(Errno::EINVAL, "ftruncate", "length cannot be negative");
+    }
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "ftruncate", "Invalid Cage ID");
+    }
+
+    let ret = unsafe { libc::ftruncate(kernel_fd, length) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "ftruncate");
+    }
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/fstatfs.2.html
+///
+/// Linux `fstatfs()` syscall returns information about a mounted filesystem referred to by the open file
+/// descriptor `fd`. Since we implement a file descriptor management subsystem (called `fdtables`), we first
+/// translate the virtual file descriptor to the corresponding kernel file descriptor, then call the kernel's
+/// `libc::fstatfs()` function. The returned statfs structure is converted to our ABI-stable FSData format
+/// and copied to the user's buffer.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - statfs_arg: pointer to a statfs structure where the filesystem information will be stored (user's perspective)
+///     - arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn fstatfs_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    statfs_arg: u64,
+    statfs_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "fstatfs", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "fstatfs", "Bad File Descriptor");
+    }
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "fstatfs", "Invalid Cage ID");
+    }
+
+    // 1) Call host fstatfs into a local host variable
+    let mut host_statfs: libc::statfs = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::fstatfs(kernel_fd, &mut host_statfs as *mut libc::statfs) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "fstatfs");
+    }
+
+    // 2) Convert to ABI-stable FSData
+    let translated: FSData = {
+        // Safely pack fsid_t (two i32s) into u64
+        let fsid_packed: u64 = unsafe { std::mem::transmute::<libc::fsid_t, u64>(host_statfs.f_fsid) };
+        FSData {
+            f_type: host_statfs.f_type as u64,
+            f_bsize: host_statfs.f_bsize as u64,
+            f_blocks: host_statfs.f_blocks as u64,
+            f_bfree: host_statfs.f_bfree as u64,
+            f_bavail: host_statfs.f_bavail as u64,
+            f_files: host_statfs.f_files as u64,
+            // Linux exposes f_ffree; map it to our ABI's f_ffiles field
+            f_ffiles: host_statfs.f_ffree as u64,
+            f_fsid: fsid_packed,
+            f_namelen: host_statfs.f_namelen as u64,
+            f_frsize: host_statfs.f_frsize as u64,
+            f_spare: [0u8; 32],
+        }
+    };
+
+    // 3) Validate guest buffer range and writability, then copy
+    let needed_size = std::mem::size_of::<FSData>();
+    if check_addr(statfs_cageid, statfs_arg, needed_size, PROT_WRITE).is_err() {
+        return syscall_error(Errno::EFAULT, "fstatfs", "statfs buffer not writable or too small");
+    }
+
+    let dest_ptr = sc_convert_addr_to_host(statfs_arg, statfs_cageid, cageid) as *mut u8;
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            &translated as *const FSData as *const u8,
+            dest_ptr,
+            needed_size,
+        );
+    }
+
+    0
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/getdents64.2.html
+///
+/// Linux `getdents()` syscall reads several directory entries from the directory referred to by the open file
+/// descriptor `fd` into the buffer pointed to by `dirp`. Since we implement a file descriptor management
+/// subsystem (called `fdtables`), we first translate the virtual file descriptor to the corresponding kernel
+/// file descriptor, then call the kernel's `getdents64` syscall directly to retrieve directory entries.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment referring to a directory
+///     - dirp_arg: pointer to a buffer where the directory entries will be stored (user's perspective)
+///     - count_arg: size of the buffer pointed to by dirp
+///     - arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn getdents_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    dirp_arg: u64,
+    dirp_cageid: u64,
+    count_arg: u64,
+    count_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "getdents", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "getdents", "Bad File Descriptor");
+    }
+
+    let dirp = sc_convert_buf(dirp_arg, dirp_cageid, cageid);
+    if dirp.is_null() {
+        return syscall_error(Errno::EFAULT, "getdents", "buffer is null");
+    }
+    let count = sc_convert_sysarg_to_usize(count_arg, count_cageid, cageid);
+
+    if !(sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "getdents", "Invalid Cage ID");
+    }
+
+    let ret = unsafe {
+        libc::syscall(libc::SYS_getdents64 as libc::c_long, kernel_fd, dirp, count) as i64
+    };
+    if ret < 0 {
+        return handle_errno(get_errno(), "getdents");
+    }
+    // Check if the result is too large to fit in i32
+    if ret > i32::MAX as i64 {
+        return i32::MAX;
+    }
+
+    ret as i32
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/lseek.2.html
+///
+/// Linux `lseek()` syscall repositions the file offset of the open file description associated with the file
+/// descriptor `fd` to the argument `offset` according to the directive `whence`. Since we implement a file
+/// descriptor management subsystem (called `fdtables`), we first translate the virtual file descriptor to the
+/// corresponding kernel file descriptor, then convert the offset and whence parameters from cage memory before
+/// invoking the kernel's `libc::lseek()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - offset_arg: the new offset according to the directive whence
+///     - whence_arg: how to interpret the offset (SEEK_SET, SEEK_CUR, or SEEK_END)
+///     - arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn lseek_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    offset_arg: u64,
+    offset_cageid: u64,
+    whence_arg: u64,
+    whence_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "lseek", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "lseek", "Bad File Descriptor");
+    }
+
+    let offset = sc_convert_sysarg_to_i64(offset_arg, offset_cageid, cageid);
+    let whence = sc_convert_sysarg_to_i32(whence_arg, whence_cageid, cageid);
+
+    match whence {
+        libc::SEEK_SET | libc::SEEK_CUR | libc::SEEK_END => {},
+        _ => return syscall_error(Errno::EINVAL, "lseek", "invalid whence parameter"),
+    }
+
+    if !(sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "lseek", "Invalid Cage ID");
+    }
+
+    let ret = unsafe { libc::lseek(kernel_fd, offset, whence) };
+    if ret < 0 {
+        return handle_errno(get_errno(), "lseek");
+    }
+
+    // Check if the result is too large to fit in i32
+    if ret > i32::MAX as i64 {
+        return syscall_error(Errno::EOVERFLOW, "lseek", "result too large");
+    }
+    ret as i32
+}
+
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/pread.2.html
+///
+/// Linux `pread()` syscall reads up to `count` bytes from the file descriptor `fd` at the
+/// given `offset` without changing the file offset. Since we implement a file descriptor management
+/// subsystem (called `fdtables`), we first translate the virtual file descriptor to the corresponding
+/// kernel file descriptor, then convert the buffer and offset from cage memory before invoking the
+/// kernel's `libc::pread()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - buf_arg: pointer to a buffer where the read data will be stored (user's perspective)
+///     - count_arg: the maximum number of bytes to read from the file descriptor
+///     - offset_arg: file offset at which the input/output operation takes place
+///     - arg5, arg6: additional arguments which are expected to be unused
+pub fn pread_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    buf_arg: u64,
+    buf_cageid: u64,
+    count_arg: u64,
+    count_cageid: u64,
+    offset_arg: u64,
+    offset_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "pread", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "pread", "Bad File Descriptor");
+    }
+
+    let buf = sc_convert_buf(buf_arg, buf_cageid, cageid);
+    if buf.is_null() {
+        return syscall_error(Errno::EFAULT, "pread", "Buffer is null");
+    }
+
+    let count = sc_convert_sysarg_to_usize(count_arg, count_cageid, cageid);
+    let offset = sc_convert_sysarg_to_i64(offset_arg, offset_cageid, cageid);
+
+    if !(sc_unusedarg(arg5, arg5_cageid) && sc_unusedarg(arg6, arg6_cageid)) {
+        return syscall_error(Errno::EFAULT, "pread", "Invalid Cage ID");
+    }
+
+    if count == 0 {
+        return 0;
+    }
+
+    let ret = unsafe { libc::pread(kernel_fd, buf as *mut c_void, count, offset) as i32 };
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "pread");
+    }
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/pwrite.2.html
+///
+/// Linux `pwrite()` syscall writes up to `count` bytes from the buffer pointed to by `buf` to the file
+/// associated with the open file descriptor, `fd`, starting at the given `offset` without changing the
+/// file offset. Since we implement a file descriptor management subsystem (called `fdtables`), we first
+/// translate the virtual file descriptor to the corresponding kernel file descriptor, then convert the
+/// buffer, count, and offset from cage memory before invoking the kernel's `libc::pwrite()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - buf_arg: pointer to a buffer that stores the data to be written (user's perspective)
+///     - count_arg: the maximum number of bytes to write to the file descriptor
+///     - offset_arg: file offset at which the input/output operation takes place
+///     - arg5, arg6: additional arguments which are expected to be unused
+pub fn pwrite_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    buf_arg: u64,
+    buf_cageid: u64,
+    count_arg: u64,
+    count_cageid: u64,
+    offset_arg: u64,
+    offset_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "pwrite", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "pwrite", "Bad File Descriptor");
+    }
+
+    let buf = sc_convert_buf(buf_arg, buf_cageid, cageid);
+    let count = sc_convert_sysarg_to_usize(count_arg, count_cageid, cageid);
+    let offset = sc_convert_sysarg_to_i64(offset_arg, offset_cageid, cageid);
+
+    if !(sc_unusedarg(arg5, arg5_cageid) && sc_unusedarg(arg6, arg6_cageid)) {
+        return syscall_error(Errno::EFAULT, "pwrite", "Invalid Cage ID");
+    }
+
+    if count == 0 {
+        return 0;
+    }
+
+    let ret = unsafe { libc::pwrite(kernel_fd, buf as *const c_void, count, offset) as i32 };
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "pwrite");
+    }
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/chdir.2.html
+///
+/// Linux `chdir()` syscall changes the current working directory of the calling process to the directory
+/// specified by path. Since path seen by user is different from actual path on host, we need to convert
+/// the path first. RawPOSIX also updates the cage's current working directory in the cage structure after
+/// successfully changing the directory, ensuring cage isolation is maintained.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - path_arg: pointer to a pathname naming the directory (user's perspective)
+///     - path_cageid: cage identifier for the path argument
+///     - arg2, arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+///
+/// Return:
+///     - return zero on success. On error, -1 is returned and errno is set to indicate the error.
+pub fn chdir_syscall(
+    cageid: u64,
+    path_arg: u64,
+    path_cageid: u64,
+    arg2: u64,
+    arg2_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // Type conversion
+    let path = sc_convert_path_to_host(path_arg, path_cageid, cageid);
+    
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg2, arg2_cageid)
+        && sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "chdir_syscall", "Invalid Cage ID");
+    }
+
+    // Call the kernel chdir function
+    let ret = unsafe { libc::chdir(path.as_ptr()) };
+    
+    // Error handling
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "chdir");
+    }
+
+    // Update the cage's current working directory
+    if let Some(cage) = get_cage(cageid) {
+        let mut cwd = cage.cwd.write();
+        *cwd = Arc::new(PathBuf::from(path.to_string_lossy().as_ref()));
+    }
+
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/rmdir.2.html
+///
+/// Linux `rmdir()` syscall removes a directory, which must be empty. Since path seen by user is different
+/// from actual path on host, we need to convert the path first. RawPOSIX doesn't have any other operations,
+/// so all operations will be handled by host. RawPOSIX does error handling for this syscall.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - path_arg: pointer to a pathname naming the directory to be removed (user's perspective)
+///     - path_cageid: cage identifier for the path argument
+///     - arg2, arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+///
+/// Return:
+///     - return zero on success. On error, -1 is returned and errno is set to indicate the error.
+pub fn rmdir_syscall(
+    cageid: u64,
+    path_arg: u64,
+    path_cageid: u64,
+    arg2: u64,
+    arg2_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // Type conversion
+    let path = sc_convert_path_to_host(path_arg, path_cageid, cageid);
+    
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg2, arg2_cageid)
+        && sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "rmdir_syscall", "Invalid Cage ID");
+    }
+
+    // Call the kernel rmdir function
+    let ret = unsafe { libc::rmdir(path.as_ptr()) };
+    
+    // Error handling
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "rmdir");
+    }
+
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/chmod.2.html
+///
+/// Linux `chmod()` syscall changes the permissions of a file. Since path seen by user is different from
+/// actual path on host, we need to convert the path first. The mode argument specifies the permissions
+/// to be assigned to the file and is passed directly to the kernel after type conversion.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - path_arg: pointer to a pathname naming the file (user's perspective)
+///     - path_cageid: cage identifier for the path argument
+///     - mode_arg: the new file permissions (user's perspective)
+///     - mode_cageid: cage identifier for the mode argument
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+///
+/// Return:
+///     - return zero on success. On error, -1 is returned and errno is set to indicate the error.
+pub fn chmod_syscall(
+    cageid: u64,
+    path_arg: u64,
+    path_cageid: u64,
+    mode_arg: u64,
+    mode_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // Type conversion
+    let path = sc_convert_path_to_host(path_arg, path_cageid, cageid);
+    let mode = sc_convert_sysarg_to_u32(mode_arg, mode_cageid, cageid);
+    
+    // would sometimes check, sometimes be a no-op depending on the compiler settings
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "chmod_syscall", "Invalid Cage ID");
+    }
+
+    // Call the kernel chmod function
+    let ret = unsafe { libc::chmod(path.as_ptr(), mode) };
+    
+    // Error handling
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "chmod");
+    }
+
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/fchmod.2.html
+///
+/// Linux `fchmod()` syscall changes the permissions of an open file referred to by file descriptor `fd`.
+/// Since we implement a file descriptor management subsystem (called `fdtables`), we first translate the
+/// virtual file descriptor to the corresponding kernel file descriptor, then convert the mode from cage
+/// memory before invoking the kernel's `libc::fchmod()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - virtual_fd: the virtual file descriptor from the RawPOSIX environment
+///     - mode_arg: the new file permissions to be applied to the file
+///     - mode_cageid: cage identifier for the mode argument
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn fchmod_syscall(
+    cageid: u64,
+    virtual_fd: u64,
+    vfd_cageid: u64,
+    mode_arg: u64,
+    mode_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let kernel_fd = convert_fd_to_host(virtual_fd, vfd_cageid, cageid);
+    if kernel_fd == -1 {
+        return syscall_error(Errno::EFAULT, "fchmod", "Invalid Cage ID");
+    } else if kernel_fd == -9 {
+        return syscall_error(Errno::EBADF, "fchmod", "Bad File Descriptor");
+    }
+
+    let mode = sc_convert_sysarg_to_u32(mode_arg, mode_cageid, cageid);
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "fchmod", "Invalid Cage ID");
+    }
+
+    let ret = unsafe { libc::fchmod(kernel_fd, mode) };
+    if ret < 0 {
+        let errno = get_errno();
+        return handle_errno(errno, "fchmod");
+    }
+    ret
+}
+
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/getcwd.2.html
+///
+/// Linux `getcwd()` syscall returns an absolute pathname that is the current working directory of the calling process.
+/// The pathname is returned as a null-terminated string in the buffer pointed to by `buf`. Since path seen by user
+/// is different from actual path on host, we need to convert the buffer pointer from cage memory to host memory
+/// before invoking the kernel's `libc::getcwd()` function.
+///
+/// Input:
+///     This call will have one cageid indicating the current cage, and several regular arguments similar to Linux:
+///     - cageid: current cage identifier
+///     - buf_arg: pointer to a buffer where the current working directory path will be stored (user's perspective)
+///     - size_arg: the size of the buffer in bytes
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+///
+/// Return:
+///     - On success, returns a pointer to the buffer containing the current working directory path
+///     - On error, returns NULL and errno is set to indicate the error
+pub fn getcwd_syscall(
+    cageid: u64,
+    buf_arg: u64,
+    buf_cageid: u64,
+    size_arg: u64,
+    size_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    let buf = sc_convert_buf(buf_arg, buf_cageid, cageid);
+    if buf.is_null() {
+        return syscall_error(Errno::EFAULT, "getcwd", "Buffer is null");
+    }
+
+    let size = sc_convert_sysarg_to_usize(size_arg, size_cageid, cageid);
+    if size == 0 {
+        return syscall_error(Errno::EINVAL, "getcwd", "Size cannot be zero");
+    }
+
+    if !(sc_unusedarg(arg3, arg3_cageid)
+        && sc_unusedarg(arg4, arg4_cageid)
+        && sc_unusedarg(arg5, arg5_cageid)
+        && sc_unusedarg(arg6, arg6_cageid))
+    {
+        return syscall_error(Errno::EFAULT, "getcwd", "Invalid Cage ID");
+    }
+
+    let ret = unsafe { libc::getcwd(buf as *mut i8, size) };
+    if ret.is_null() {
+        let errno = get_errno();
+        return handle_errno(errno, "getcwd");
+    }
+
+    // getcwd returns the buffer pointer on success, but we need to return the buffer address
+    // in the user's perspective (cage memory address)
+    buf_arg as i32
+}
+
+/// Truncate a file to a specified length
+/// 
+/// # Arguments
+///     - cageid: current cage identifier
+///     - path_arg: pointer to the pathname of the file to truncate
+///     - path_cageid: cage identifier for the path argument
+///     - length_arg: the new length to truncate the file to
+///     - length_cageid: cage identifier for the length argument
+///     - arg3, arg4, arg5, arg6: additional arguments which are expected to be unused
+pub fn truncate_syscall(
+    cageid: u64,
+    path_arg: u64,
+    path_cageid: u64,
+    length_arg: u64,
+    length_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
+) -> i32 {
+    // Validate unused arguments
+    if !(sc_unusedarg(arg3, arg3_cageid)
+         && sc_unusedarg(arg4, arg4_cageid)
+         && sc_unusedarg(arg5, arg5_cageid)
+         && sc_unusedarg(arg6, arg6_cageid)) {
+        return syscall_error(Errno::EFAULT, "truncate", "Invalid Cage ID");
+    }
+
+    // Type conversion
+    let path = sc_convert_path_to_host(path_arg, path_cageid, cageid);
+    if path.is_empty() {
+        return syscall_error(Errno::EFAULT, "truncate", "Invalid path");
+    }
+    
+    let length = sc_convert_sysarg_to_i64(length_arg, length_cageid, cageid);
+
+    // Call libc truncate
+    let ret = unsafe { libc::truncate(path.as_ptr() as *const i8, length) };
+    
+    if ret == -1 {
+        let errno = get_errno();
+        return handle_errno(errno, "truncate");
+    }
+
+    0
 }

--- a/src/threei/src/syscall_table.rs
+++ b/src/threei/src/syscall_table.rs
@@ -1,29 +1,39 @@
-use super::threei::Raw_CallFunc;
+use super::threei::RawCallFunc;
+// use rawposix::fs_calls::{
+//     brk_syscall, clock_gettime_syscall, close_syscall, dup2_syscall, dup_syscall, fcntl_syscall,
+//     futex_syscall, lseek_syscall, mkdir_syscall, mmap_syscall, munmap_syscall,
+//     nanosleep_time64_syscall, open_syscall, pipe2_syscall, pipe_syscall, read_syscall,
+//     sbrk_syscall, unlink_syscall, write_syscall,
+// };
 use rawposix::fs_calls::{
-    brk_syscall, clock_gettime_syscall, close_syscall, dup2_syscall, dup_syscall, fcntl_syscall,
-    futex_syscall, lseek_syscall, mkdir_syscall, mmap_syscall, munmap_syscall,
-    nanosleep_time64_syscall, open_syscall, pipe2_syscall, pipe_syscall, read_syscall,
-    sbrk_syscall, unlink_syscall, write_syscall,
+    close_syscall, mkdir_syscall, open_syscall, read_syscall, mmap_syscall, munmap_syscall,
+    brk_syscall, sbrk_syscall, fcntl_syscall, write_syscall, clock_gettime_syscall,
+    fstat_syscall, stat_syscall, lseek_syscall, pread_syscall, pwrite_syscall, writev_syscall,
+    ftruncate_syscall, getdents_syscall, chdir_syscall, fchdir_syscall, rmdir_syscall,
+    chmod_syscall, fchmod_syscall, fstatfs_syscall, getcwd_syscall, truncate_syscall, dup_syscall,
+    dup2_syscall, futex_syscall,
 };
 use rawposix::sys_calls::{
     exec_syscall, exit_syscall, fork_syscall, getpid_syscall, wait_syscall, waitpid_syscall,
 };
 
 /// According to the Linux version
-pub const SYSCALL_TABLE: &[(u64, Raw_CallFunc)] = &[
+pub const SYSCALL_TABLE: &[(u64, RawCallFunc)] = &[
     (0, read_syscall),
     (1, write_syscall),
     (2, open_syscall),
     (3, close_syscall),
+    (4, stat_syscall),
+    (5, fstat_syscall),
     (8, lseek_syscall),
     (9, mmap_syscall),
-    (10, open_syscall),
     (11, munmap_syscall),
     (12, brk_syscall),
-    (22, pipe_syscall),
+    (17, pread_syscall),
+    (18, pwrite_syscall),
+    (20, writev_syscall),
     (32, dup_syscall),
-    (33, dup2_syscall),
-    (35, nanosleep_time64_syscall),
+    (41, dup2_syscall),
     (39, getpid_syscall),
     (57, fork_syscall),
     (59, exec_syscall),
@@ -31,10 +41,73 @@ pub const SYSCALL_TABLE: &[(u64, Raw_CallFunc)] = &[
     (61, wait_syscall),
     (61, waitpid_syscall),
     (72, fcntl_syscall),
+    (76, truncate_syscall),
+    (77, ftruncate_syscall),
+    (78, getdents_syscall),
+    (79, getcwd_syscall),
+    (80, chdir_syscall),
+    (81, fchdir_syscall),
     (83, mkdir_syscall),
-    (87, unlink_syscall),
+    (84, rmdir_syscall),
+    (90, chmod_syscall),
+    (91, fchmod_syscall),
+    (138, fstatfs_syscall),
     (202, futex_syscall),
     (228, clock_gettime_syscall),
-    (293, pipe2_syscall),
     (1004, sbrk_syscall),
 ];
+
+// //! rawposix syscall dispatcher table
+// //! Source of truth for syscall numbers: Linux x86_64 syscall table
+// //! https://github.com/torvalds/linux/blob/v6.16-rc1/arch/x86/entry/syscalls/syscall_64.tbl
+// //! Keep these in sync with glibc's lind_syscall_num.h
+// use super::threei::RawCallFunc;
+// use rawposix::fs_calls::{
+//     brk_syscall, clock_gettime_syscall, close_syscall, dup2_syscall, dup_syscall, fcntl_syscall,
+//     futex_syscall, lseek_syscall, mkdir_syscall, mmap_syscall, munmap_syscall,
+//     nanosleep_time64_syscall, open_syscall, pipe2_syscall, pipe_syscall, read_syscall,
+//     sbrk_syscall, unlink_syscall, write_syscall,
+// };
+// use rawposix::sys_calls::{
+//     exec_syscall, exit_syscall, fork_syscall, getpid_syscall, wait_syscall, waitpid_syscall,
+// };
+
+// /// According to the Linux version
+// /// In glibc, waitpid() is actually implemented by calling wait4(), 
+// /// so the Linux kernel itself does not provide a separate syscall 
+// /// number for waitpid.
+// /// In lind-wasm, however, we treat wait and waitpid as distinct 
+// /// syscalls, assigning them arbitrary syscall numbers. These are 
+// /// only resolved later in rawposix, where wait is internally implemented 
+// /// by invoking waitpid with options = 0.
+// /// This design choice may become a future TODO: we could adopt a 
+// /// similar approach in lind-glibc by having wait() directly call 
+// /// waitpid(), and then remove the separate wait implementation from 
+// /// rawposix.
+// pub const SYSCALL_TABLE: &[(u64, RawCallFunc)] = &[
+//     (0, read_syscall),
+//     (1, write_syscall),
+//     (2, open_syscall),
+//     (3, close_syscall),
+//     (8, lseek_syscall),
+//     (9, mmap_syscall),
+//     (11, munmap_syscall),
+//     (12, brk_syscall),
+//     (22, pipe_syscall),
+//     (32, dup_syscall),
+//     (33, dup2_syscall),
+//     (35, nanosleep_time64_syscall),
+//     (39, getpid_syscall),
+//     (57, fork_syscall),
+//     (59, exec_syscall),
+//     (60, exit_syscall),
+//     (61, wait_syscall),
+//     (72, fcntl_syscall),
+//     (83, mkdir_syscall),
+//     (87, unlink_syscall),
+//     (202, futex_syscall),
+//     (228, clock_gettime_syscall),
+//     (293, pipe2_syscall),
+//     (400, waitpid_syscall),
+//     (1004, sbrk_syscall),
+// ];


### PR DESCRIPTION
Implementations for the following syscalls, rebased with threei-integration

1. PREAD
2. PWRITE
3. CHDIR
4. RMDIR
5. CHMOD
6. FCHMOD
7. FCHDIR
8. WRITEV
9. FXSTAT
10. FTRUNCATE
11. FSTATFS
12. GETDENTS
13. LSEEK
14. 