### PR TITLE
Update timeout in test report

### DIFF
--- a/scripts/wasmtestreport.py
+++ b/scripts/wasmtestreport.py
@@ -31,7 +31,7 @@ formatter = logging.Formatter("[%(levelname)s] %(message)s")
 ch.setFormatter(formatter)
 logger.addHandler(ch)
 
-DEFAULT_TIMEOUT = 5 # in seconds
+DEFAULT_TIMEOUT = 10 # in seconds
 
 JSON_OUTPUT = "results.json"
 HTML_OUTPUT = "report.html"


### PR DESCRIPTION
### PURPOSE
Updates the default timeout in wasmtestreport.py from 5s to 10s

### NOTES FOR REVIEWERS
No code was altered save for the default timeout in wasmtestreport.py