### PR TITLE
Add a check to not run comment on forked PRs, only branched ones

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,8 @@ jobs:
           retention-days: 7
       
       - name: Post PR comment
-        if: github.event_name == 'pull_request'
+        # Run only on branch PRs, not on fork PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
### PURPOSE
Stops the e2e action from trying to make a comment on a PR when the source of the request is from a fork

### ISSUES
`GITHUB_TOKEN` is used to make the comment, and it is scoped such that it is inaccessible from a fork, so a check is put in place to restrict comment attempts from a fork.

### NOTE TO REVIEWERS
The fix doesn't change the comment for regular PRs