### PR TITLE
413 changes to html report have altered pr comment output

### DIFF
--- a/scripts/render_e2e_templates.py
+++ b/scripts/render_e2e_templates.py
@@ -9,25 +9,58 @@ def extract_body(html_text:str) -> str:
     m = re.search(r"(?is)<\s*body\b>[^>]*>(.*?)</\s*body\s*>",html_text, flags=re.I)
     return m.group(1) if m else html_text
 
-def wrap_h3_tables_as_details(html: str) -> str:    
+def strip_top_h1(html: str) -> str:
+    # Remove the first <h1>…</h1> so it doesn't render as a blob in the PR comment.
+    return re.sub(r'(?is)<\s*h1\b[^>]*>.*?</\s*h1\s*>', '', html, count=1)
+
+def wrap_sections_as_details(html: str) -> str:
+    
+    #Wrap each <div class="test-section">…</div> as:
+    #  <details><summary>{h2 text}</summary>…(section content without the h2)…</details>
+    
+    pattern = re.compile(
+        r"""
+        <div
+            [^>]*
+            class="[^"]*\btest-section\b[^"]*"
+            [^>]*>
+            \s*
+            (?:<h2[^>]*>(?P<title>.*?)</h2>)?
+            (?P<body>.*?)
+        </div>
+        """,
+        re.IGNORECASE | re.DOTALL | re.VERBOSE,
+    )
+
+    def _wrap(m):
+        title = (m.group("title") or "Section").strip()
+        body = m.group("body")
+        return f"<details>\n  <summary>{title}</summary>\n{body}\n</details>"
+
+    return pattern.sub(_wrap, html)
+
+def wrap_h3_tables_as_details(html: str):    
     import re
     pattern = re.compile(r'(\s*<h3[^>]*>.*?</h3>\s*)(<table\b.*?>.*?</table>)',
                          re.DOTALL | re.IGNORECASE)
     def _wrap(m):
         h3 = m.group(1).strip()
         table = m.group(2)
-        return f'  <summary>{h3}</summary>\n <details>\n {table}\n</details>'
+        return f' <summary>{h3}</summary>\n <details>\n {table}\n</details>'
     return pattern.sub(_wrap, html)
 
 def main():
     report_path = os.environ["REPORT_PATH"]
     
     tpl_dir = "scripts/templates"
-    out_dir = os.environ.get("OUT_DIR", ".")   # ← changed from "test-reports"
+    out_dir = os.environ.get("OUT_DIR", ".")
     os.makedirs(out_dir, exist_ok=True)
     
     body_html = extract_body(read(report_path))
-    body_html = wrap_h3_tables_as_details(body_html)
+    body_html = strip_top_h1(body_html)
+    
+    _wrapped = wrap_sections_as_details(body_html)
+    body_html = _wrapped if _wrapped != body_html else wrap_h3_tables_as_details(body_html)
 
     env = Environment(
         loader=FileSystemLoader(tpl_dir),

--- a/scripts/templates/e2e_comment.md.j2
+++ b/scripts/templates/e2e_comment.md.j2
@@ -1,8 +1,8 @@
 <!-- Report Generator -->
-## End-to_End Test Report
+## End-to-End Test Report
 
 <details>
-  <summary><strong>HTML preview</strong></summary>
+  <summary><strong>Test Preview</strong></summary>
 
 
 


### PR DESCRIPTION
### PURPOSE 
Corrects the formatting of the PR comment to match the new report structure

### ISSUES
Old comment was designed for different HTML structure,  so the details menus were in the wrong places

### NOTES TO REVIEWERS

The only things altered in this are the template file and python script to generate the comments.