### PR TITLE
fix pthread

### DIFF
--- a/src/glibc/nptl/pthread_create.c
+++ b/src/glibc/nptl/pthread_create.c
@@ -471,7 +471,7 @@ start_thread (void *arg)
      the saved signal mask), so that is a false positive.  */
   DIAG_IGNORE_NEEDS_COMMENT (11, "-Wstringop-overflow=");
 #endif
-  not_first_call = setjmp ((struct __jmp_buf_tag *) &unwind_buf.cancel_jmp_buf);
+  not_first_call = setjmp ((struct __jmp_buf_tag *) unwind_buf.cancel_jmp_buf);
   DIAG_POP_NEEDS_COMMENT;
 
   /* No previous handlers.  NB: This must be done after setjmp since the

--- a/src/glibc/sysdeps/x86/bits/setjmp.h
+++ b/src/glibc/sysdeps/x86/bits/setjmp.h
@@ -27,13 +27,13 @@
 
 #ifndef _ASM
 
-# if __WORDSIZE == 64
+// # if __WORDSIZE == 64
 typedef long int __jmp_buf[8];
-# elif defined  __x86_64__
-__extension__ typedef long long int __jmp_buf[8];
-# else
-typedef int __jmp_buf[6];
-# endif
+// # elif defined  __x86_64__
+// __extension__ typedef long long int __jmp_buf[8];
+// # else
+// typedef int __jmp_buf[6];
+// # endif
 
 #endif
 

--- a/src/glibc/target/include/x86_64-linux-gnu/bits/setjmp.h
+++ b/src/glibc/target/include/x86_64-linux-gnu/bits/setjmp.h
@@ -27,13 +27,13 @@
 
 #ifndef _ASM
 
-# if __WORDSIZE == 64
+// # if __WORDSIZE == 64
 typedef long int __jmp_buf[8];
-# elif defined  __x86_64__
-__extension__ typedef long long int __jmp_buf[8];
-# else
-typedef int __jmp_buf[6];
-# endif
+// # elif defined  __x86_64__
+// __extension__ typedef long long int __jmp_buf[8];
+// # else
+// typedef int __jmp_buf[6];
+// # endif
 
 #endif
 


### PR DESCRIPTION
This PR addresses issues in the pthread implementation that were preventing thread-related tests from running.

The first issue was pretty trival: there is a `MAKE_SYSCALL` invocation in the `pthread_join` routine was not replacing the syscall number correctly. This has been fixed.

The second issue is more complex and still under consideration. In the `pthread_create` routine, an `unwind_buf` is used to simulate a `try-catch` block in C via setjmp. Since glibc is compiled as a 32-bit target, `unwind_buf` is only 4-byte aligned.
However, wasmtime’s setjmp implementation stores a 64-bit hash directly into the user-provided buffer. On a 64-bit host, dereferencing this as a u64 requires 8-byte alignment. This mismatch can lead to alignment issues.

The draft solution is to enforce 8-byte alignment on `unwind_buf` via an attribute. This resolves the pthread issue and allows tests to run again, but it may not be the ideal long-term solution.

I am considering an alternative approach that modifies the setjmp implementation itself to avoid relying on stricter alignment in user-provided buffers.