### PR TITLE
tests: removed mmap_shared test from skip_test_cases list

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -32,7 +32,6 @@ memory_tests/deterministic/mmap-nagative2.c
 memory_tests/deterministic/mmap.c
 memory_tests/deterministic/mmap_complicated.c
 memory_tests/deterministic/mmap_file.c
-memory_tests/deterministic/mmap_shared.c
 memory_tests/deterministic/mmaptest.c
 memory_tests/deterministic/sbrk.c
 memory_tests/deterministic/shmtest.c


### PR DESCRIPTION
removal of `mmap_shared` test from the `skip_test_cases.txt` list, following the earlier commit that resolves the issue and allows the test to pass when executed natively with the `wasmtimereport.py` script.

<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
