### PR TITLE
pin version of zizmor to 1.15.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
               -A clippy::not_unsafe_ptr_arg_deref \
               -A clippy::absurd_extreme_comparisons
       - name: Install Zizmor via Cargo
-        run: cargo install zizmor
+        run: cargo install zizmor --version 1.15.2
 
       - name: Run Zizmor
         env:


### PR DESCRIPTION
Version of zizmor was failing CI because one of its dependencies had been yanked.  Pinned version to working installation and filed issue with zizmor regarding dependency.  Will unpin when my issue is resolved.