### PR TITLE
add crt1.o to gitignore

### DIFF
--- a/src/glibc/.gitignore
+++ b/src/glibc/.gitignore
@@ -47,3 +47,4 @@ core
 
 /sysroot
 
+crt1.o


### PR DESCRIPTION
crt1.o often appears in git changes, which is annoying. let's add it to gitignore