### PR TITLE
vmmap: Expose range accessibility check

### DIFF
--- a/src/cage/src/cage.rs
+++ b/src/cage/src/cage.rs
@@ -227,7 +227,7 @@ mod tests {
             vmmap: RwLock::new(crate::memory::vmmap::Vmmap::new()),
         };
 
-        add_cage(2, tet_cage);
+        add_cage(2, test_cage);
 
         let result = get_cage(2);
         assert_eq!(

--- a/src/cage/src/memory/memory.rs
+++ b/src/cage/src/memory/memory.rs
@@ -253,9 +253,10 @@ pub fn translate_vmmap_addr(cage: &Cage, arg: u64) -> Result<u64, Errno> {
 ///
 /// # Returns
 /// * `Ok(true)` - If the entire range is mapped and readable
+/// * `Err(Errno::EINVAL)` - If the cage does not exist
 /// * `Err(Errno::EFAULT)` - If any part of the range is unmapped or not readable
 pub fn check_addr_read(cageid: u64, addr: u64, length: usize) -> Result<bool, Errno> {
-    let cage = get_cage(cageid).unwrap();
+    let cage = get_cage(cageid).ok_or(Errno::EINVAL)?;
     let mut vmmap = cage.vmmap.write();
 
     if vmmap.check_addr_read(addr, length) {
@@ -277,9 +278,10 @@ pub fn check_addr_read(cageid: u64, addr: u64, length: usize) -> Result<bool, Er
 ///
 /// # Returns
 /// * `Ok(true)` - If the entire range is mapped and writable
+/// * `Err(Errno::EINVAL)` - If the cage does not exist
 /// * `Err(Errno::EFAULT)` - If any part of the range is unmapped or not writable
 pub fn check_addr_write(cageid: u64, addr: u64, length: usize) -> Result<bool, Errno> {
-    let cage = get_cage(cageid).unwrap();
+    let cage = get_cage(cageid).ok_or(Errno::EINVAL)?;
     let mut vmmap = cage.vmmap.write();
 
     if vmmap.check_addr_write(addr, length) {
@@ -301,9 +303,10 @@ pub fn check_addr_write(cageid: u64, addr: u64, length: usize) -> Result<bool, E
 ///
 /// # Returns
 /// * `Ok(true)` - If the entire range is mapped with both read and write permissions
+/// * `Err(Errno::EINVAL)` - If the cage does not exist
 /// * `Err(Errno::EFAULT)` - If any part of the range is unmapped or lacks read/write permissions
 pub fn check_addr_rw(cageid: u64, addr: u64, length: usize) -> Result<bool, Errno> {
-    let cage = get_cage(cageid).unwrap();
+    let cage = get_cage(cageid).ok_or(Errno::EINVAL)?;
     let mut vmmap = cage.vmmap.write();
 
     if vmmap.check_addr_rw(addr, length) {

--- a/src/cage/src/memory/vmmap.rs
+++ b/src/cage/src/memory/vmmap.rs
@@ -370,6 +370,28 @@ impl Vmmap {
     // - Any gaps in the address space
     fn debug() {}
 
+    /// Calculates the page number and number of pages for a given address and length.
+    ///
+    /// This helper function converts a byte address range into page numbers,
+    /// handling overflow safely with checked arithmetic.
+    ///
+    /// # Arguments
+    /// * `addr` - Virtual memory address (in bytes)
+    /// * `length` - Length of the memory region in bytes
+    ///
+    /// # Returns
+    /// * `Some((page_num, npages))` - The starting page number and number of pages
+    /// * `None` - If the calculation would overflow
+    fn calculate_page_range(&self, addr: u64, length: usize) -> Option<(u32, u32)> {
+        let page_num = (addr >> PAGESHIFT) as u32;
+        let end_addr = addr
+            .checked_add(length as u64)?
+            .checked_add(PAGESIZE as u64 - 1)?;
+        let end_page = (end_addr >> PAGESHIFT) as u32;
+        let npages = end_page.checked_sub(page_num)?;
+        Some((page_num, npages))
+    }
+
     /// Checks if a given address range is readable
     ///
     /// This helper function checks whether a memory range starting at the given address
@@ -381,12 +403,17 @@ impl Vmmap {
     /// * `length` - Length of the memory region in bytes
     ///
     /// # Returns
-    /// * `true` - If the entire range is mapped and readable
-    /// * `false` - If any part of the range is unmapped or not readable
+    /// * `true` - If the entire range is mapped and readable, or if length is 0
+    /// * `false` - If any part of the range is unmapped, not readable, or if overflow occurs
     pub fn check_addr_read(&mut self, addr: u64, length: usize) -> bool {
-        let page_num = (addr >> PAGESHIFT) as u32;
-        let end_page = ((addr + length as u64 + PAGESIZE as u64 - 1) >> PAGESHIFT) as u32;
-        let npages = end_page - page_num;
+        // Zero-length check is trivially true
+        if length == 0 {
+            return true;
+        }
+
+        let Some((page_num, npages)) = self.calculate_page_range(addr, length) else {
+            return false; // Overflow occurred
+        };
 
         self.check_addr_mapping(page_num, npages, PROT_READ)
             .is_some()
@@ -403,12 +430,17 @@ impl Vmmap {
     /// * `length` - Length of the memory region in bytes
     ///
     /// # Returns
-    /// * `true` - If the entire range is mapped and writable
-    /// * `false` - If any part of the range is unmapped or not writable
+    /// * `true` - If the entire range is mapped and writable, or if length is 0
+    /// * `false` - If any part of the range is unmapped, not writable, or if overflow occurs
     pub fn check_addr_write(&mut self, addr: u64, length: usize) -> bool {
-        let page_num = (addr >> PAGESHIFT) as u32;
-        let end_page = ((addr + length as u64 + PAGESIZE as u64 - 1) >> PAGESHIFT) as u32;
-        let npages = end_page - page_num;
+        // Zero-length check is trivially true
+        if length == 0 {
+            return true;
+        }
+
+        let Some((page_num, npages)) = self.calculate_page_range(addr, length) else {
+            return false; // Overflow occurred
+        };
 
         self.check_addr_mapping(page_num, npages, PROT_WRITE)
             .is_some()
@@ -425,12 +457,17 @@ impl Vmmap {
     /// * `length` - Length of the memory region in bytes
     ///
     /// # Returns
-    /// * `true` - If the entire range is mapped with both read and write permissions
-    /// * `false` - If any part of the range is unmapped or lacks read/write permissions
+    /// * `true` - If the entire range is mapped with both read and write permissions, or if length is 0
+    /// * `false` - If any part of the range is unmapped, lacks read/write permissions, or if overflow occurs
     pub fn check_addr_rw(&mut self, addr: u64, length: usize) -> bool {
-        let page_num = (addr >> PAGESHIFT) as u32;
-        let end_page = ((addr + length as u64 + PAGESIZE as u64 - 1) >> PAGESHIFT) as u32;
-        let npages = end_page - page_num;
+        // Zero-length check is trivially true
+        if length == 0 {
+            return true;
+        }
+
+        let Some((page_num, npages)) = self.calculate_page_range(addr, length) else {
+            return false; // Overflow occurred
+        };
 
         self.check_addr_mapping(page_num, npages, PROT_READ | PROT_WRITE)
             .is_some()
@@ -2118,5 +2155,288 @@ mod tests {
             space.is_none(),
             "Should return None when no space available"
         );
+    }
+
+    /// Test: check_addr_read returns true for readable region
+    /// Expected: Should return true when the entire range has PROT_READ
+    #[test]
+    fn test_check_addr_read_success() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a readable region at pages 10-19 (addresses 0x10000-0x19FFF for 4KB pages)
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_READ,
+                PROT_READ,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        // Check read access within the region (address in bytes: page 10 = 10 << 12 = 40960)
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize; // 5 pages
+        assert!(
+            vmmap.check_addr_read(addr, length),
+            "Should return true for readable region"
+        );
+    }
+
+    /// Test: check_addr_read returns false for non-readable region
+    /// Expected: Should return false when region has PROT_NONE
+    /// Note: check_addr_mapping enforces PROT_READ for any protection that exists,
+    /// so we need to use PROT_NONE to test the failure case
+    #[test]
+    fn test_check_addr_read_failure_no_read_prot() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a region with no permissions (PROT_NONE)
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_NONE,
+                PROT_NONE,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            !vmmap.check_addr_read(addr, length),
+            "Should return false for PROT_NONE region"
+        );
+    }
+
+    /// Test: check_addr_write returns true for writable region
+    /// Expected: Should return true when the entire range has PROT_WRITE
+    #[test]
+    fn test_check_addr_write_success() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a writable region
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_WRITE | PROT_READ,
+                PROT_WRITE | PROT_READ,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            vmmap.check_addr_write(addr, length),
+            "Should return true for writable region"
+        );
+    }
+
+    /// Test: check_addr_write returns false for read-only region
+    /// Expected: Should return false when region lacks PROT_WRITE
+    #[test]
+    fn test_check_addr_write_failure_no_write_prot() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a read-only region
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_READ,
+                PROT_READ,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            !vmmap.check_addr_write(addr, length),
+            "Should return false for non-writable region"
+        );
+    }
+
+    /// Test: check_addr_rw returns true for read-write region
+    /// Expected: Should return true when the entire range has both PROT_READ and PROT_WRITE
+    #[test]
+    fn test_check_addr_rw_success() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a read-write region
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_READ | PROT_WRITE,
+                PROT_READ | PROT_WRITE,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            vmmap.check_addr_rw(addr, length),
+            "Should return true for read-write region"
+        );
+    }
+
+    /// Test: check_addr_rw returns false for read-only region
+    /// Expected: Should return false when region lacks PROT_WRITE
+    #[test]
+    fn test_check_addr_rw_failure_read_only() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a read-only region
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_READ,
+                PROT_READ,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            !vmmap.check_addr_rw(addr, length),
+            "Should return false for read-only region"
+        );
+    }
+
+    /// Test: check_addr_read returns false for unmapped region
+    /// Expected: Should return false when address is not mapped
+    #[test]
+    fn test_check_addr_read_unmapped_region() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Don't add any entries - region is unmapped
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        assert!(
+            !vmmap.check_addr_read(addr, length),
+            "Should return false for unmapped region"
+        );
+    }
+
+    /// Test: Zero-length check returns true
+    /// Expected: Zero-length access should always succeed
+    #[test]
+    fn test_check_addr_zero_length() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Even with no mappings, zero-length should succeed
+        let addr = (10 << PAGESHIFT) as u64;
+        assert!(
+            vmmap.check_addr_read(addr, 0),
+            "Zero-length read check should return true"
+        );
+        assert!(
+            vmmap.check_addr_write(addr, 0),
+            "Zero-length write check should return true"
+        );
+        assert!(
+            vmmap.check_addr_rw(addr, 0),
+            "Zero-length rw check should return true"
+        );
+    }
+
+    /// Test: check_addr_read handles partial region coverage
+    /// Expected: Should return false when request spans beyond mapped region
+    #[test]
+    fn test_check_addr_read_partial_coverage() {
+        let mut vmmap = Vmmap::new();
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        // Add a small readable region at pages 10-14
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                5,
+                PROT_READ,
+                PROT_READ,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        // Try to read 10 pages starting from page 10 (spans into unmapped area)
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (10 << PAGESHIFT) as usize;
+        assert!(
+            !vmmap.check_addr_read(addr, length),
+            "Should return false when request spans beyond mapped region"
+        );
+    }
+
+    /// Test: calculate_page_range helper function
+    /// Expected: Should correctly calculate page numbers from addresses
+    #[test]
+    fn test_calculate_page_range() {
+        let vmmap = Vmmap::new();
+
+        // Test basic calculation: 1 page
+        let result = vmmap.calculate_page_range(0, PAGESIZE as usize);
+        assert_eq!(result, Some((0, 1)), "Single page at start");
+
+        // Test calculation spanning multiple pages
+        let addr = (10 << PAGESHIFT) as u64;
+        let length = (5 << PAGESHIFT) as usize;
+        let result = vmmap.calculate_page_range(addr, length);
+        assert_eq!(result, Some((10, 5)), "5 pages starting at page 10");
+
+        // Test with non-page-aligned length (should round up)
+        let result = vmmap.calculate_page_range(0, 1);
+        assert_eq!(result, Some((0, 1)), "1 byte should still be 1 page");
     }
 }

--- a/src/threei/src/threei.rs
+++ b/src/threei/src/threei.rs
@@ -10,11 +10,8 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
 use sysdefs::constants::lind_platform_const;
-<<<<<<< HEAD
 use sysdefs::constants::{PROT_READ, PROT_WRITE}; // Used in `copy_data_between_cages`
-=======
 use typemap::datatype_conversion::sc_convert_uaddr_to_host;
->>>>>>> cb22b63f0 (Add helper functions for vmmap range accessibility check)
 
 use crate::handler_table::{
     _check_cage_handler_exist, _get_handler, _rm_cage_from_handler, _rm_grate_from_handler,


### PR DESCRIPTION
This PR solves Issue #516 by adding centralized helper functions in vmmap to check range accessibility (read, write, and read-write). These helpers replace scattered permission checks across the codebase and provide a single, consistent API.