### PR TITLE
Remove e2e_status file when distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,6 @@ clean:
 .PHONY: distclean
 distclean: clean
 	@echo "removing test outputs & temp files"
-	$(RM) -f results.json report.html
+	$(RM) -f results.json report.html e2e_status
 	$(RM) -r $(LIND_ROOT)/testfiles || true
 	find tests -type f \( -name '*.wasm' -o -name '*.cwasm' -o -name '*.o' \) -delete


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

This PR updates the distclean target to also remove the e2e_status file.