### PR TITLE
Improve timeout handling for poll/select

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
               -A clippy::not_unsafe_ptr_arg_deref \
               -A clippy::absurd_extreme_comparisons
       - name: Install Zizmor via Cargo
-        run: cargo install zizmor --version 1.18.0
+        run: cargo install zizmor --version 1.15.2
 
       - name: Run Zizmor
         env:


### PR DESCRIPTION
This PR ports over the change from - https://github.com/Lind-Project/lind-wasm/pull/342

Previously, we ignored the chunk timeout of 100ms from timeout_setup_ms(). We now keep track of this value and pass it to the libc call into select/poll. Passing the full timeout would cause the thread to sleep uncontrollably in the kernel. 

By re-entering the user-space every 100ms, we ensure we periodically checks for signals.