### PR TITLE
changing buffering behavior of stdout

### DIFF
--- a/src/glibc/stdio-common/printf_buffer_to_file.c
+++ b/src/glibc/stdio-common/printf_buffer_to_file.c
@@ -121,7 +121,7 @@ __printf_buffer_to_file_done (struct __printf_buffer_to_file *buf)
 
   /* Flush stdout buffer immediately if it is refered to a terminal,
      without waiting for it to fill or for the program to exit */
-  if (!isatty(stdout)) {
+  if (!isatty(fileno(stdout))) {
     fflush(stdout);
   }
 


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Force a flush of the `stdout` buffer, ensuring that any buffered output is immediately written to the terminal without waiting for the buffer to fill or for the program to exit.

This resolves issue #526, which caused test failures due to output mismatches when executed in Lind.

Results:

```
printing getgid:
1000
printing getuid:
1000
printing getegid:
1000
printing geteuid:
1000
```