### PR TITLE
Add cron schedule for 1st of each month, 8AM UTC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Test and release on Docker Hub
 
 on:
   workflow_dispatch:
+  schedule:
+  - cron: "0 8 1 * *"
 
 permissions: {}
 


### PR DESCRIPTION
### Summary

This PR adds a scheduled workflow trigger so the Docker Hub test and release job runs automatically on a monthly interval.

### Details

The workflow now includes a cron schedule that executes at 08:00 UTC on the first day of each month. This schedule is added alongside the existing manual dispatch trigger and does not change any job logic or execution steps. All build, test, and release behavior remains unchanged.

### Motivation

Automating a monthly run ensures that releases continue to be validated and published on a predictable cadence without relying on manual invocation.

### Changes

Added schedule block with cron: "0 8 1 * *" in the workflow header.

No other modifications were made.