### PR TITLE
Improvements to lind_compile

### DIFF
--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -37,7 +37,7 @@ usage: $(basename "$0") [OPTIONS] <source>
     --precompile-only   : .wasm -> .cwasm
 
   Common options:
-    --print-cmd, --verbose  print the underlying commands that are executed
+    -v, --print-cmd, --verbose  print the underlying commands that are executed
     -h, --help              show this help
 
   Examples:
@@ -84,7 +84,7 @@ while [[ "$#" -gt 0 ]]; do
     --precompile-only)
       set_mode "precompile-only"
       ;;
-    --print-cmd|--verbose)
+    -v|--print-cmd|--verbose)
       PRINT_CMDS="true"
       ;;
     -h|--help)


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Fixes #573

1) Adds --compile-only, --opt-only, --precompile-only modes to scripts/lind_compile so each stage can be run independently.

2) Adds --print-cmd / --verbose to print the underlying commands for easier debugging.

3) Keeps default behavior unchanged when no flags are provided.
