### PR TITLE
fixed pthread attribute stackaddr

### DIFF
--- a/src/glibc/csu/__init_tls.c
+++ b/src/glibc/csu/__init_tls.c
@@ -99,7 +99,7 @@ static inline struct stack_bounds get_stack_bounds()
 	struct stack_bounds bounds;
 
 	if (&__stack_high) {
-		bounds.base = &__stack_high;
+		bounds.base = &__stack_low;
 		bounds.size = &__stack_high - &__stack_low;
 	} else {
 		unsigned char *sp;


### PR DESCRIPTION
`stackaddr` in pthread attribute is supposed to point to the lowest address of the stack. In `__init_tls.c`, this attribute is assigned to `stack_high` for some reason. Fix the code by assigning `stack_low` instead.