### PR TITLE
Remove `sc_convert_uaddr_to_host` usage for address conversions in rawposix and 3i

### DIFF
--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -279,21 +279,21 @@ pub fn futex_syscall(
     futex_op_cageid: u64,
     val_arg: u64,
     val_cageid: u64,
-    val2_arg: u64,
-    val2_cageid: u64,
+    timeout_arg: u64,
+    timeout_cageid: u64,
     uaddr2_arg: u64,
     uaddr2_cageid: u64,
     val3_arg: u64,
     val3_cageid: u64,
 ) -> i32 {
-    let uaddr = sc_convert_uaddr_to_host(uaddr_arg, uaddr_cageid, cageid);
+    let uaddr = uaddr_arg;
     let futex_op = sc_convert_sysarg_to_u32(futex_op_arg, futex_op_cageid, cageid);
     let val = sc_convert_sysarg_to_u32(val_arg, val_cageid, cageid);
-    let val2 = sc_convert_uaddr_to_host(val2_arg, val2_cageid, cageid);
-    let uaddr2 = sc_convert_uaddr_to_host(uaddr2_arg, uaddr2_cageid, cageid);
+    let timeout = timeout_arg;
+    let uaddr2 = uaddr2_arg;
     let val3 = sc_convert_sysarg_to_u32(val3_arg, val3_cageid, cageid);
 
-    let ret = unsafe { syscall(SYS_futex, uaddr, futex_op, val, val2, uaddr2, val3) as i32 };
+    let ret = unsafe { syscall(SYS_futex, uaddr, futex_op, val, timeout, uaddr2, val3) as i32 };
     if ret < 0 {
         let errno = get_errno();
         return handle_errno(errno, "futex");
@@ -4217,7 +4217,7 @@ pub fn getrandom_syscall(
     arg6: u64,
     arg6_cageid: u64,
 ) -> i32 {
-    let buf = sc_convert_uaddr_to_host(buf_arg, buf_arg_cageid, cageid);
+    let buf = buf_arg;
     let buflen = sc_convert_sysarg_to_u32(buflen_arg, buflen_arg_cageid, cageid);
     let flags = sc_convert_sysarg_to_u32(flags_arg, flags_arg_cageid, cageid);
 

--- a/src/threei/src/threei.rs
+++ b/src/threei/src/threei.rs
@@ -11,7 +11,6 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, RwLock};
 use sysdefs::constants::lind_platform_const;
 use sysdefs::constants::{PROT_READ, PROT_WRITE}; // Used in `copy_data_between_cages`
-use typemap::datatype_conversion::sc_convert_uaddr_to_host;
 
 use crate::handler_table::{
     _check_cage_handler_exist, _get_handler, _rm_cage_from_handler, _rm_grate_from_handler,
@@ -870,7 +869,7 @@ pub fn copy_data_between_cages(
             }
             // Try to compute actual string length within limit
             let max_scan = len as usize;
-            let host_src_try = sc_convert_uaddr_to_host(srcaddr, srccage, thiscage);
+            let host_src_try = srcaddr;
             if host_src_try == 0 {
                 eprintln!("[3i|copy] host_src null");
                 return threei_const::ELINDAPIABORTED;
@@ -903,8 +902,8 @@ pub fn copy_data_between_cages(
     }
 
     // Translate user virtual addrs to host pointers
-    let host_src_addr = sc_convert_uaddr_to_host(srcaddr, srccage, thiscage);
-    let host_dest_addr = sc_convert_uaddr_to_host(destaddr, destcage, thiscage);
+    let host_src_addr = srcaddr;
+    let host_dest_addr = destaddr;
     if host_src_addr == 0 || host_dest_addr == 0 {
         // src addr or dest addr is null
         eprintln!("[3i|copy] host addr translate failed");


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

The `futex_syscall`, `getrandom_syscall`, and `copy_data_between_cages` still use the `sc_convert_uaddr_to_host` function, which is not necessary with the address translations changes. The use of this helper function has been removed from other functions that used them, this PR cleans up the remaining occurrences. 