### PR TITLE
fixes for building python

### DIFF
--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -152,6 +152,12 @@ $CC --target=wasm32-wasi-threads -matomics \
 # First, remove the existing sysroot directory to start cleanly
 rm -rf "$SYSROOT"
 
+# manually delete duplicated symbols
+# TODO: we need to eventually figure out why there are
+#       duplicated symbols and how we are supposed to deal
+#       with it. For now, we just delete one of the duplicated object file
+rm $BUILD/nscd/res_hconf.o
+
 # Find all .o files recursively in the source directory, ignoring stamp.o
 object_files=$(find "$BUILD" -type f -name '*.o' \
   ! -name 'stamp.o' \
@@ -179,7 +185,12 @@ filtered_objects=$(
 )
 llvm-ar rcs "$SYSROOT_ARCHIVE" $filtered_objects
 
+# pthread library placeholder
 llvm-ar crs "$GLIBC/sysroot/lib/wasm32-wasi/libpthread.a"
+# math library placeholder
+llvm-ar crs "$GLIBC/sysroot/lib/wasm32-wasi/libm.a"
+# dylink library placeholder
+llvm-ar crs "$GLIBC/sysroot/lib/wasm32-wasi/libdl.a"
 
 # Check if llvm-ar succeeded
 if [ $? -eq 0 ]; then

--- a/src/glibc/misc/Makefile
+++ b/src/glibc/misc/Makefile
@@ -200,6 +200,7 @@ routines := \
   ttyslot \
   ualarm \
   unwind-link \
+  unwind_def \
   usleep \
   ustat \
   utimes \

--- a/src/glibc/misc/unwind_def.c
+++ b/src/glibc/misc/unwind_def.c
@@ -1,0 +1,19 @@
+// lind-wasm: define these symbol as placeholder
+
+#include <unwind.h>
+
+_Unwind_Reason_Code _Unwind_Backtrace (_Unwind_Trace_Fn fn, void * arg) {
+    return 0;
+}
+
+_Unwind_Ptr _Unwind_GetIP (struct _Unwind_Context * ctx) {
+    return 0;
+}
+
+_Unwind_Word _Unwind_GetGR (struct _Unwind_Context * ctx, int arg) {
+    return 0;
+}
+
+_Unwind_Word _Unwind_GetCFA (struct _Unwind_Context * ctx) {
+    return 0;
+}

--- a/src/glibc/sysdeps/i386/fpu/e_sqrt.c
+++ b/src/glibc/sysdeps/i386/fpu/e_sqrt.c
@@ -5,22 +5,23 @@
 double __ieee754_sqrt(double x) {
     // First, check for negative input, which is domain error in standard sqrt
     if (x < 0) {
-        feraiseexcept(FE_INVALID); // Raise the invalid floating-point exception
+        // feraiseexcept(FE_INVALID); // Raise the invalid floating-point exception
         return nan(""); // Return NaN as per IEEE standard
     }
 
+    // lind-wasm: disable floating-point environment settings
     // Save the current floating-point environment
-    fenv_t env;
-    fegetenv(&env);
+    // fenv_t env;
+    // fegetenv(&env);
 
     // Set the rounding mode to the nearest (similar to setting control word in assembly)
-    fesetround(FE_TONEAREST);
+    // fesetround(FE_TONEAREST);
 
     // Compute the square root
     double result = sqrt(x);
 
     // Restore the floating-point environment
-    fesetenv(&env);
+    // fesetenv(&env);
 
     return result;
 }

--- a/src/glibc/sysdeps/i386/fpu/s_expm1.c
+++ b/src/glibc/sysdeps/i386/fpu/s_expm1.c
@@ -30,3 +30,4 @@ double __expm1(double x) {
     }
 }
 
+weak_alias (__expm1, expm1)

--- a/src/glibc/sysdeps/ieee754/dbl-64/w_fmod.c
+++ b/src/glibc/sysdeps/ieee754/dbl-64/w_fmod.c
@@ -1,1 +1,0 @@
-/* Not needed.  */

--- a/src/glibc/sysdeps/ieee754/ldbl-96/s_fma.c
+++ b/src/glibc/sysdeps/ieee754/ldbl-96/s_fma.c
@@ -51,8 +51,9 @@ __fma (double x, double y, double z)
     }
 
   fenv_t env;
-  feholdexcept (&env);
-  fesetround (FE_TONEAREST);
+  // lind-wasm: disable floating point environment settings
+  // feholdexcept (&env);
+  // fesetround (FE_TONEAREST);
 
   /* Multiplication m1 + m2 = x * y using Dekker's algorithm.  */
 #define C ((1ULL << (LDBL_MANT_DIG + 1) / 2) + 1)
@@ -75,27 +76,27 @@ __fma (double x, double y, double z)
   /* Ensure the arithmetic is not scheduled after feclearexcept call.  */
   math_force_eval (m2);
   math_force_eval (a2);
-  feclearexcept (FE_INEXACT);
+  // feclearexcept (FE_INEXACT);
 
   /* If the result is an exact zero, ensure it has the correct sign.  */
   if (a1 == 0 && m2 == 0)
     {
-      feupdateenv (&env);
+      // feupdateenv (&env);
       /* Ensure that round-to-nearest value of z + m1 is not reused.  */
       z = math_opt_barrier (z);
       return z + m1;
     }
 
-  fesetround (FE_TOWARDZERO);
+  // fesetround (FE_TOWARDZERO);
   /* Perform m2 + a2 addition with round to odd.  */
   a2 = a2 + m2;
 
   /* Add that to a1 again using rounding to odd.  */
   union ieee854_long_double u;
   u.d = a1 + a2;
-  if ((u.ieee.mantissa1 & 1) == 0 && u.ieee.exponent != 0x7fff)
-    u.ieee.mantissa1 |= fetestexcept (FE_INEXACT) != 0;
-  feupdateenv (&env);
+  // if ((u.ieee.mantissa1 & 1) == 0 && u.ieee.exponent != 0x7fff)
+  //   u.ieee.mantissa1 |= fetestexcept (FE_INEXACT) != 0;
+  // feupdateenv (&env);
 
   /* Add finally round to double precision.  */
   return u.d;

--- a/src/glibc/sysdeps/unix/sysv/linux/epoll_create.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/epoll_create.c
@@ -28,4 +28,13 @@ epoll_create (int size)
 {
    return MAKE_LEGACY_SYSCALL(EPOLL_CREATE_SYSCALL, "syscall|epoll_create", (uint64_t) size, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
 }
+
+// to do: support flag argument
+int
+epoll_create1 (int size)
+{
+   return MAKE_LEGACY_SYSCALL(EPOLL_CREATE_SYSCALL, "syscall|epoll_create", (uint64_t) 1, NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
+}
+
 libc_hidden_def (epoll_create)
+libc_hidden_def (epoll_create1)

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_yield.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_yield.c
@@ -4,3 +4,4 @@ int __GI___sched_yield (void)
 }
 
 weak_alias(__GI___sched_yield, __sched_yield)
+weak_alias(__sched_yield, sched_yield)

--- a/src/glibc/target/include/bits/struct_stat.h
+++ b/src/glibc/target/include/bits/struct_stat.h
@@ -55,6 +55,20 @@ struct stat
     struct timespec st_ctim;		/* Time of last status change.  */
   };
 
+/* lind-wasm addition */
+#ifndef st_atime
+    #define st_atime st_atim.tv_sec
+#endif
+
+#ifndef st_mtime
+    #define st_mtime st_mtim.tv_sec
+#endif
+
+#ifndef st_ctime
+    #define st_ctime st_ctim.tv_sec
+#endif
+/* lind-wasm addition ends */
+
 #ifdef __USE_LARGEFILE64
 /* Note stat64 has the same shape as stat for x86-64.  */
 struct stat64


### PR DESCRIPTION
Some fixes to make python 3.14 working
list:
1. remove duplicated `res_hconf.o` object file
2. create empty `libm.a` and `libdl.a` placeholder archive files
3. create placeholder symbols for some glibc Unwind symbols
4. disable floating point environment settings in math functions
5. create entry for `epoll_create1`, does not actually implement `epoll_create1` though
6. fix stat struct