### PR TITLE
Disable nscd for libc build to fix conflicts with resolv

### DIFF
--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -78,6 +78,7 @@ cd $BUILD
   --disable-werror \
   --disable-hidden-plt \
   --disable-profile \
+  --disable-nscd \
   --with-headers=/usr/i686-linux-gnu/include \
   --prefix=$GLIBC/target \
   --host=i686-linux-gnu \


### PR DESCRIPTION
nscd is a caching daemon for DNS/user/group lookups; it’s optional, and should be disabled in nonstandard libc builds. It's causing conflicts with resolv which will handle DNS lookups.

Disabling it for our builds here to help fix: #591 in a cleaner way