### PR TITLE
Pin versions for zizmor

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,7 @@ jobs:
           echo "----------------------------------"
 
       - name: Upload HTML report artifact to report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: wasm-e2e-report
           path: ${{ env.REPORT_LOCAL_DIR }}/${{ env.REPORT_LOCAL_FILE }}
@@ -106,7 +106,7 @@ jobs:
       - name: Post PR comment
         # Run only on branch PRs, not on fork PRs
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr-cache-cleanup.yml
+++ b/.github/workflows/pr-cache-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete caches scoped to this PR
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           persist-credentials: false
 


### PR DESCRIPTION
### What Changed
Pinned all GitHub Actions used in this repo from floating tags (e.g. `@v6`, `@v8`) to immutable commit SHAs.

### Purpose
Prevents highjacking floating tags

This is a security hardening step, stops zizmor failing because of it.