### PR TITLE
Initialize cageid field in libc first in crt

### DIFF
--- a/src/glibc/lind_syscall/crt1/crt1.c
+++ b/src/glibc/lind_syscall/crt1/crt1.c
@@ -203,11 +203,11 @@ int __unused_function_pointer() {
 void *___dummy_reference __attribute__((used)) = __unused_function_pointer;
 
 int _start() {
+    __lind_init_addr_translation(); // iniatilize cageids before anything else executes
     __libc_setup_tls();
     __wasi_init_tp();
     __wasi_initialize_environ();
     __ctype_init(); //lind-wasm: init ctypes for isalpha etc.
-    __lind_init_addr_translation();
     #ifdef LIND_DEBUG
     	__lind_debug_import();
     #endif


### PR DESCRIPTION
closes #617 

fixes https://github.com/Lind-Project/lind-wasm-apps/issues/31

We were initializing the cageid field in libc too late in the crt start function which was causing applications to call syscalls from mysterious cage 0. 

This fixes the bash bug and hopefully closes the issue.
