### PR TITLE
fixed syscall glibc function signature

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/i386/syscall.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/syscall.c
@@ -1,4 +1,8 @@
-long syscall(void) {
-    long result = 0;
-    return result;
+#include <lind_debug.h>
+
+long int
+syscall (long int callno, ...)
+{
+    lind_debug_panic("syscall function invoked but not supported!");
+    return -1;
 }


### PR DESCRIPTION
fix issue https://github.com/Lind-Project/lind-wasm/issues/637

fixed `syscall` function signature and direct to `lind_debug_panic`