### PR TITLE
Update stat time struct for wasm

### DIFF
--- a/src/glibc/target/include/bits/struct_stat.h
+++ b/src/glibc/target/include/bits/struct_stat.h
@@ -55,6 +55,21 @@ struct stat
     struct timespec st_ctim;		/* Time of last status change.  */
   };
 
+
+    /* lind-wasm: define stat times for wasi */
+    #ifndef st_atime
+        #define st_atime st_atim.tv_sec
+    #endif
+
+    #ifndef st_mtime
+        #define st_mtime st_mtim.tv_sec
+    #endif
+
+    #ifndef st_ctime
+        #define st_ctime st_ctim.tv_sec
+    #endif
+    /* lind-wasm ends */
+
 #ifdef __USE_LARGEFILE64
 /* Note stat64 has the same shape as stat for x86-64.  */
 struct stat64


### PR DESCRIPTION
This PR defines st_atime etc so they fit standard linux definitions for Wasm compiles.
