### PR TITLE
fix unwind symbols

### DIFF
--- a/src/glibc/misc/Makefile
+++ b/src/glibc/misc/Makefile
@@ -200,6 +200,7 @@ routines := \
   ttyslot \
   ualarm \
   unwind-link \
+  unwind_def \
   usleep \
   ustat \
   utimes \

--- a/src/glibc/misc/unwind_def.c
+++ b/src/glibc/misc/unwind_def.c
@@ -1,0 +1,19 @@
+// lind-wasm: define these symbol as placeholder
+
+#include <unwind.h>
+
+_Unwind_Reason_Code _Unwind_Backtrace (_Unwind_Trace_Fn fn, void * arg) {
+    return 0;
+}
+
+_Unwind_Ptr _Unwind_GetIP (struct _Unwind_Context * ctx) {
+    return 0;
+}
+
+_Unwind_Word _Unwind_GetGR (struct _Unwind_Context * ctx, int arg) {
+    return 0;
+}
+
+_Unwind_Word _Unwind_GetCFA (struct _Unwind_Context * ctx) {
+    return 0;
+}


### PR DESCRIPTION
define a couple of placeholder symbols for unwind related functions for python compatibility

There is a lot of undefined symbols in glibc probably due to they were defined in assembly file before (and was then deleted). Define a placeholder symbol for them to at least make things compile for now