### PR TITLE
Refactor: unify LindCtx initialization with optional cageid

### DIFF
--- a/src/wasmtime/src/commands/run.rs
+++ b/src/wasmtime/src/commands/run.rs
@@ -1116,52 +1116,26 @@ impl RunCommand {
             };
             let module = module.unwrap_core();
 
-            // if cageid is set, that means this function is called by execute_with_lind (exec-ed wasm instance)
-            if let Some(cageid) = cageid {
-                store.data_mut().lind_fork_ctx = Some(LindCtx::new_with_cageid(
-                    module.clone(),
-                    linker.clone(),
-                    lind_manager,
-                    self.clone(),
-                    cageid,
-                    |host| host.lind_fork_ctx.as_mut().unwrap(),
-                    |host| host.fork(),
-                    |run_command, path, args, cageid, lind_manager, envs| {
-                        // entry point of exec call. Fork self and replace the argument, environment variables and
-                        // execution path and starts execution
-                        let mut new_run_command = run_command.clone();
-                        new_run_command.module_and_args = vec![OsString::from(path)];
-                        if let Some(envs) = envs {
-                            new_run_command.run.vars = envs.clone();
-                        }
-                        for arg in args.iter().skip(1) {
-                            new_run_command.module_and_args.push(OsString::from(arg));
-                        }
-                        new_run_command.execute_with_lind(lind_manager.clone(), cageid)
-                    },
-                )?);
-            // if cageid is not set, then this function is called by the first wasm instance
-            } else {
-                store.data_mut().lind_fork_ctx = Some(LindCtx::new(
-                    module.clone(),
-                    linker.clone(),
-                    lind_manager,
-                    self.clone(),
-                    |host| host.lind_fork_ctx.as_mut().unwrap(),
-                    |host| host.fork(),
-                    |run_command, path, args, cageid, lind_manager, envs| {
-                        let mut new_run_command = run_command.clone();
-                        new_run_command.module_and_args = vec![OsString::from(path)];
-                        if let Some(envs) = envs {
-                            new_run_command.run.vars = envs.clone();
-                        }
-                        for arg in args.iter().skip(1) {
-                            new_run_command.module_and_args.push(OsString::from(arg));
-                        }
-                        new_run_command.execute_with_lind(lind_manager.clone(), cageid)
-                    },
-                )?);
-            }
+            store.data_mut().lind_fork_ctx = Some(LindCtx::new(
+                module.clone(),
+                linker.clone(),
+                lind_manager,
+                self.clone(),
+                cageid,
+                |host| host.lind_fork_ctx.as_mut().unwrap(),
+                |host| host.fork(),
+                |run_command, path, args, cageid, lind_manager, envs| {
+                    let mut new_run_command = run_command.clone();
+                    new_run_command.module_and_args = vec![OsString::from(path)];
+                    if let Some(envs) = envs {
+                        new_run_command.run.vars = envs.clone();
+                    }
+                    for arg in args.iter().skip(1) {
+                        new_run_command.module_and_args.push(OsString::from(arg));
+                    }
+                    new_run_command.execute_with_lind(lind_manager.clone(), cageid)
+                },
+            )?);
         }
 
         // must create wasi_threads context here, because pre_instance requires all


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

This change is purely structural and was made to improve readability and reviewability, especially in the lind-boot PR where the initialization logic is combined with other necessary logics.

Previously, the caller had to decide between `new()` and `new_with_cageid()`, resulting in duplicated call-site logic. By moving this distinction into `LindCtx::new()` through `Option<cageid>`, the call sites become easier to follow and reason about during code review.
