### PR TITLE
Remove flock.c from skip test cases

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -1,4 +1,3 @@
-file_tests/deterministic/flock.c
 file_tests/deterministic/popen.c
 file_tests/deterministic/creat_access.c
 file_tests/non-deterministic/sc-writev.c


### PR DESCRIPTION
This test case should pass but somehow was readded to skip list.
