### PR TITLE
Update skip_test_cases.txt to remove passing tests

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -1,17 +1,9 @@
 file_tests/deterministic/popen.c
 file_tests/deterministic/creat_access.c
-file_tests/non-deterministic/sc-writev.c
 memory_tests/deterministic/mmaptest.c
 memory_tests/fail/mmap-negative2.c
 networking_tests/deterministic/uds-nb-select.c
-networking_tests/non-deterministic/serverclient.c
-networking_tests/non-deterministic/shutdown.c
-networking_tests/non-deterministic/socketepoll.c
-networking_tests/non-deterministic/socketselect.c
 networking_tests/deterministic/uds-serverclient.c
-networking_tests/non-deterministic/uds-socketselect.c
-process_tests/non-deterministic/fork.c
-process_tests/non-deterministic/template.c
 process_tests/deterministic/tls_test.c
 signal_tests/deterministic/sigpipe.c
 signal_tests/deterministic/signal_SIGCHLD.c


### PR DESCRIPTION
These tests are already passing but were left in this skip list with their old non-det paths, removing for clarity.
