### PR TITLE
lind_run: re-exec with sudo when not running as root

### DIFF
--- a/scripts/lind_run
+++ b/scripts/lind_run
@@ -36,6 +36,7 @@ if [[ ! -x "${WASMTIME_BIN}" ]]; then
   echo "ERROR: wasmtime missing: ${WASMTIME_BIN}" >&2
   exit 127 # Note: This is the traditional "command not found" exit code, can be changed as needed
 fi
+[[ -x "${WASMTIME_BIN}" ]] || { echo "error: wasmtime not found at ${WASMTIME_BIN}" >&2; exit 2; }
 
 # Check if we need to re-exec with sudo
 if [[ $EUID -ne 0 ]]; then


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Purpose
After introducing `chroot` for filesystem isolation, wasmtime requires sudo to run the cage system. A non-root user running `lind_run` will require sudo.

#685 