### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,8 +25,9 @@ jobs:
           persist-credentials: false
 
       - name: Format
-        run: cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
-        run: cargo fmt --check --all --manifest-path src/lind-boot/Cargo.toml
+        run: |
+          cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
+          cargo fmt --check --all --manifest-path src/lind-boot/Cargo.toml
 
       # Using rust nightly, invalidates cache every day
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
The Format step in lint.yml contained two `run:` keys, so lint test won't be executed in CI.

This PR updates the step to run `cargo fmt --check` for both src/wasmtime and src/lind-boot manifests.