### PR TITLE
rawposix: allow ioctl(TIOCGWINSZ) passthrough

### DIFF
--- a/src/sysdefs/src/constants/fs_const.rs
+++ b/src/sysdefs/src/constants/fs_const.rs
@@ -80,6 +80,7 @@ pub const F_NOTIFY: i32 = 1026;
 //Commands for IOCTL
 pub const FIONBIO: u32 = 21537;
 pub const FIOASYNC: u32 = 21586;
+pub const TIOCGWINSZ: u32 = 21523;
 
 //File types for open/stat etc.
 // Source: include/linux/stat.h


### PR DESCRIPTION
Allow TIOCGWINSZ (21523) in RawPOSIX ioctl handling to prevent lind_debug_panic.  
Normalized requests are forwarded to the host kernel.  

Files changed:
- src/rawposix/src/fs_calls.rs
- src/sysdefs/src/constants/fs_const.rs

Fixes #662