### PR TITLE
tests: refactor grate unit tests to be self-validating

### DIFF
--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -250,7 +250,7 @@ if [[ "${PRINT_ARGS}" == "true" && ( "${MODE}" == "full" || "${MODE}" == "compil
     -O0
   )
   if [[ "${COMPILE_GRATE}" == "true" ]]; then
-    debug_default_clang_flags+=(--export-pass-fptr-to-wt)
+    debug_default_clang_flags+=(-Wl,--export=pass_fptr_to_wt)
   fi
   if [[ "${NO_DEFAULT_CLANG_FLAGS}" == "true" ]]; then
     debug_default_clang_flags=()
@@ -279,7 +279,7 @@ if [[ "${PRINT_ARGS}" == "true" && ( "${MODE}" == "full" || "${MODE}" == "compil
     -O0
   )
   if [[ "${COMPILE_GRATE}" == "true" ]]; then
-    debug_default_clang_flags+=(--export-pass-fptr-to-wt)
+    debug_default_clang_flags+=(-Wl,--export=pass_fptr_to_wt)
   fi
   if [[ "${NO_DEFAULT_CLANG_FLAGS}" == "true" ]]; then
     debug_default_clang_flags=()
@@ -309,7 +309,7 @@ do_compile() {
   )
 
   if [[ "${COMPILE_GRATE}" == "true" ]]; then
-    default_clang_flags+=(--export-pass-fptr-to-wt)
+    default_clang_flags+=(-Wl,--export=pass_fptr_to_wt)
   fi
 
   if [[ "${NO_DEFAULT_CLANG_FLAGS}" == "true" ]]; then

--- a/tests/grate-tests/concurrent-request/geteuid.c
+++ b/tests/grate-tests/concurrent-request/geteuid.c
@@ -1,14 +1,16 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {
     int ret;
-  for (int i = 0; i < 1000000; i++) {
-    ret = geteuid();
-    if (ret == -1) {
-      printf("[Cage | geteuid] geteuid failed with ret=%d\n", ret);
+    for (int i = 0; i < 1000000; i++) {
+        ret = geteuid();
+        if (ret != 10) {
+            fprintf(stderr, "[Cage | geteuid] FAIL: iteration %d, expected 10, got %d\n", i, ret);
+            exit(EXIT_FAILURE);
+        }
     }
-  }
-    printf("[Cage | geteuid] geteuid ret = %d\n", ret);
+    printf("[Cage | geteuid] PASS: 1000000 calls returned %d\n", ret);
     return 0;
 }

--- a/tests/grate-tests/concurrent-request/geteuid_grate.c
+++ b/tests/grate-tests/concurrent-request/geteuid_grate.c
@@ -65,9 +65,18 @@ int main(int argc, char *argv[]) {
   }
 
   int status;
+  int failed = 0;
   while (wait(&status) > 0) {
-    printf("[Grate|geteuid] terminated, status: %d\n", status);
+    if (status != 0) {
+      fprintf(stderr, "[Grate|geteuid] FAIL: child exited with status %d\n", status);
+      failed = 1;
+    }
   }
 
+  if (failed) {
+    fprintf(stderr, "[Grate|geteuid] FAIL\n");
+    return EXIT_FAILURE;
+  }
+  printf("[Grate|geteuid] PASS\n");
   return 0;
 }

--- a/tests/grate-tests/multi-register.c
+++ b/tests/grate-tests/multi-register.c
@@ -1,10 +1,18 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {
     int ret_euid = geteuid();
     int ret_uid = getuid();
-    printf("[Cage | multi-register] geteuid ret = %d\n", ret_euid);
-    printf("[Cage | multi-register] getuid ret = %d\n", ret_uid);
+    if (ret_euid != 10) {
+        fprintf(stderr, "[Cage | multi-register] FAIL: geteuid expected 10, got %d\n", ret_euid);
+        exit(EXIT_FAILURE);
+    }
+    if (ret_uid != 20) {
+        fprintf(stderr, "[Cage | multi-register] FAIL: getuid expected 20, got %d\n", ret_uid);
+        exit(EXIT_FAILURE);
+    }
+    printf("[Cage | multi-register] PASS: geteuid=%d, getuid=%d\n", ret_euid, ret_uid);
     return 0;
 }

--- a/tests/grate-tests/multi-register_grate.c
+++ b/tests/grate-tests/multi-register_grate.c
@@ -102,9 +102,18 @@ int main(int argc, char *argv[]) {
   }
 
   int status;
+  int failed = 0;
   while (wait(&status) > 0) {
-    printf("[Grate|geteuid] terminated, status: %d\n", status);
+    if (status != 0) {
+      fprintf(stderr, "[Grate|multi-register] FAIL: child exited with status %d\n", status);
+      failed = 1;
+    }
   }
 
+  if (failed) {
+    fprintf(stderr, "[Grate|multi-register] FAIL\n");
+    return EXIT_FAILURE;
+  }
+  printf("[Grate|multi-register] PASS\n");
   return 0;
 }

--- a/tests/grate-tests/simple-tests/geteuid.c
+++ b/tests/grate-tests/simple-tests/geteuid.c
@@ -1,8 +1,13 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {
     int ret = geteuid();
-    printf("[Cage | geteuid] geteuid ret = %d\n", ret);
+    if (ret != 10) {
+        fprintf(stderr, "[Cage | geteuid] FAIL: expected 10, got %d\n", ret);
+        exit(EXIT_FAILURE);
+    }
+    printf("[Cage | geteuid] PASS: geteuid ret = %d\n", ret);
     return 0;
 }

--- a/tests/grate-tests/simple-tests/geteuid_grate.c
+++ b/tests/grate-tests/simple-tests/geteuid_grate.c
@@ -83,9 +83,18 @@ int main(int argc, char *argv[]) {
   }
 
   int status;
+  int failed = 0;
   while (wait(&status) > 0) {
-    printf("[Grate|geteuid] terminated, status: %d\n", status);
+    if (status != 0) {
+      fprintf(stderr, "[Grate|geteuid] FAIL: child exited with status %d\n", status);
+      failed = 1;
+    }
   }
 
+  if (failed) {
+    fprintf(stderr, "[Grate|geteuid] FAIL\n");
+    return EXIT_FAILURE;
+  }
+  printf("[Grate|geteuid] PASS\n");
   return 0;
 }


### PR DESCRIPTION
Closes #729

- Cage files now validate return values internally and exit(EXIT_FAILURE) on mismatch
- Grate files now check child exit status and propagate failures
- Fixed --compile-grate flag in lind_compile 
- Naming convention enforced: cage .c, grate _grate.c