### PR TITLE
Fix lind_compile to ensure lindfs root has been created before each copy

### DIFF
--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -217,7 +217,7 @@ esac
 CLANG_BIN="clang"  # must be on PATH
 WASM_OPT_BIN="${REPO_ROOT}/tools/binaryen/bin/wasm-opt"
 LINDBOOT_BIN="${REPO_ROOT}/build/lind-boot"
-LINDFS_ROOT="${REPO_ROOT}/lindfs"
+LINDFS_ROOT="${REPO_ROOT}/lindfs/"
 if [[ ! -x "${LINDBOOT_BIN}" ]]; then
   echo "ERROR: lind-boot missing: ${LINDBOOT_BIN}" >&2
   exit 127 # Note: This is the traditional "command not found" exit code, can be changed as needed
@@ -325,6 +325,7 @@ do_optimize() {
 }
 
 cp_to_lindfs() {
+  mkdir -p "${LINDFS_ROOT}"
   cp "${OUT_WASM}" "${LINDFS_ROOT}"
 }
 


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Previous version will cause .wasm binaries become executables but named as `lindfsroot`, if lindfs_root not create.

Fix lind_compile to ensure lindfs root has been created before each copy