### PR TITLE
Change register_handler and copy_data_between_cages to use make_3i_call routine

### DIFF
--- a/src/glibc/lind_syscall/lind_syscall_num.h
+++ b/src/glibc/lind_syscall/lind_syscall_num.h
@@ -117,5 +117,9 @@
 #define PIPE2_SYSCALL 293
 #define GETRANDOM_SYSCALL 318
 
+/* Lind-specific syscalls (not part of the Linux syscall table) */
+#define REGISTER_HANDLER_SYSCALL 1001
+#define COPY_DATA_BETWEEN_CAGES_SYSCALL 1002
+
 #endif /* _LIND_SYSCALL_NUM_H */
  

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -63,3 +63,22 @@ pub const RAWPOSIX_CAGEID: u64 = 777777;
 ///   call to the corresponding Wasmtime entry function rather than
 ///   treating it as a RawPOSIX syscall or grate calls.
 pub const WASMTIME_CAGEID: u64 = 888888;
+/// Logical target Cage ID representing the **3i control layer itself**.
+///
+/// This constant is a *virtual target identifier* used to route calls
+/// to 3i's own operations rather than to a concrete cage or the
+/// RawPOSIX/Wasmtime layers.
+///
+/// Unlike `RAWPOSIX_CAGEID` and `WASMTIME_CAGEID`, which represent
+/// execution backends, `THREEI_CAGEID` is intended for meta-level
+/// operations that modify or mediate the 3i dispatch system.
+///
+/// ## Usage scenarios
+/// - Used when interposing on 3i-specific management syscalls such as
+///   `register_handler` and `copy_data_between_cages`.
+/// - It will be registered as the `target_cageid` for these syscalls
+///   during `lind-boot` initialization in RawPOSIX.
+/// - At dispatch time, 3i interprets this value as a request to route
+///   the call through its internal control-layer logic rather than
+///   forwarding it to RawPOSIX or Wasmtime.
+pub const THREEI_CAGEID: u64 = 999999;

--- a/src/threei/src/threei_const.rs
+++ b/src/threei/src/threei_const.rs
@@ -32,3 +32,15 @@ pub const GRATE_ERR: i32 = -1;
 ///
 /// The value is expected to be globally unique among all runtimes registered with 3i
 pub const RUNTIME_TYPE_WASMTIME: u64 = 1;
+/// 3i-specific syscall number for `register_handler`.
+///
+/// Match the definition in `glibc/lind_syscall_num.h`.
+/// TODO: When introducing a Rust-side unified syscall number table
+/// (similar to glibc's `syscall_num` constants), move this constant there.
+pub const REGISTER_HANDLER_SYSCALL: u64 = 1001;
+/// 3i-specific syscall number for `copy_data_between_cages`.
+///
+/// Match the definition in `glibc/lind_syscall_num.h`.
+/// TODO: When introducing a Rust-side unified syscall number table
+/// (similar to glibc's `syscall_num` constants), move this constant there.
+pub const COPY_DATA_BETWEEN_CAGES_SYSCALL: u64 = 1002;

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -113,69 +113,6 @@ pub fn add_to_linker<
         },
     )?;
 
-    // Registers grate-specific syscall-like host functions `register-syscall` / `cp-data-syscall` /
-    // `copy_handler_table_to_cage` into the Wasmtime linker. This is part of the 3i (inter-cage
-    // interposition) system, which allows user-level libc code (e.g., glibc) to perform cage-to-grate
-    // syscall routing in a way that *resembles normal syscalls* from the user’s perspective.
-    //
-    // To maintain consistency with traditional syscall patterns, we expose 3i-related functions
-    // using the same mechanism as `lind` syscalls. These functions are declared in glibc headers and
-    // invoked like syscalls. At runtime, they are resolved via Wasmtime’s linker and routed to
-    // closures here. This particular function allows a cage to register a handler function (by index)
-    // for a specific syscall number, targeting a specific grate.
-    //
-    // The same trampoline mechanism used by `lind-syscall` is reused to simplify design and
-    // reduce interface divergence between normal syscalls and 3i interposition calls.
-    //
-    // attach register_handler to wasmtime
-    linker.func_wrap(
-        "lind",
-        "register-syscall",
-        move |targetcage: u64,
-              targetcallnum: u64,
-              handlefunc_flag: u64,
-              this_grate_id: u64,
-              in_grate_fn_ptr_u64: u64|
-              -> i32 {
-            register_handler(
-                in_grate_fn_ptr_u64,
-                targetcage,
-                targetcallnum,
-                threei_const::RUNTIME_TYPE_WASMTIME,
-                handlefunc_flag,
-                this_grate_id,
-                UNUSED_ARG,
-                UNUSED_ID,
-                UNUSED_ARG,
-                UNUSED_ID,
-                UNUSED_ARG,
-                UNUSED_ID,
-                UNUSED_ARG,
-                UNUSED_ID,
-            )
-        },
-    )?;
-
-    // attach copy_data_between_cages to wasmtime
-    linker.func_wrap(
-        "lind",
-        "cp-data-syscall",
-        move |thiscage: u64,
-              targetcage: u64,
-              srcaddr: u64,
-              srccage: u64,
-              destaddr: u64,
-              destcage: u64,
-              len: u64,
-              copytype: u64|
-              -> i32 {
-            copy_data_between_cages(
-                thiscage, targetcage, srcaddr, srccage, destaddr, destcage, len, UNUSED_ID,
-                copytype, UNUSED_ID, UNUSED_ARG, UNUSED_ID, UNUSED_ARG, UNUSED_ID,
-            ) as i32
-        },
-    )?;
-
     // attach copy_handler_table_to_cage to wasmtime
     linker.func_wrap(
         "lind",


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Resolves: #504 
Resolves: #506 
Resolves: #748 

Change register_handler and copy_data_between_cages to use make_3i_call routine so that they will become interposable for grates.

TODO:
More tests needed