### PR TITLE
Correct output of debug info

### DIFF
--- a/scripts/wasmtestreport.py
+++ b/scripts/wasmtestreport.py
@@ -521,15 +521,10 @@ def run_compiled_wasm(wasm_file, timeout_sec=DEFAULT_TIMEOUT):
     try:
         run_start = time.perf_counter()
         proc = run_subprocess(run_cmd,label="wasm run",timeout=timeout_sec, cwd=None, shell = False)
-        run_time = round(time.perf_counter() - run_start, 6)
-        full_output = proc.stdout + proc.stderr
-        
-        #removing the first line in output as it is the command being run by the bash script
-        lines = full_output.splitlines()
-        filtered_lines = lines[1:]
-        filtered_output = "\n".join(filtered_lines)
+        run_time = round(time.perf_counter() - run_start, 6)       
+        output = proc.stdout if proc.returncode == 0 else (proc.stdout + proc.stderr)
 
-        return (proc.returncode, full_output, run_time)
+        return (proc.returncode, output, run_time)
 
     except subprocess.TimeoutExpired as e:
         return ("timeout", f"Timed Out (timeout: {timeout_sec}s)", None)


### PR DESCRIPTION
## Motivation
Deterministic tests in `scripts/wasmtestreport.py` compare expected/native output against WASM output exactly.

When `lind_debug` is enabled, host-side runtime diagnostics such as:

- `[LIND DEBUG NUM]: 0`
- `[LIND DEBUG STR]: LIND DEGUG INIT`

are emitted on `stderr`.

Previously, successful WASM execution returned `stdout + stderr`, which polluted deterministic comparisons and produced false `Output_mismatch` failures even when the program behavior was correct.

## What changed
In `run_compiled_wasm()`:

- If `returncode == 0`, the function now returns **stdout only**.
- If `returncode != 0`, the function still returns **stdout + stderr** to preserve debugging context for real failures.
- Timeout and exception handling behavior is unchanged.

## Impact
- Fixes false negatives in deterministic tests when debug logging is enabled.
- Does not hide diagnostics for compile/runtime failures.
