### PR TITLE
docs: fix typo in getting-started.md (hello.cwasm → hello.wasm)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ Use lind scripts to compile and run your program in the Lind Sandbox.
 
 ```bash
 lind-clang hello.c
-lind-wasm hello.cwasm
+lind-wasm hello.wasm
 ```
 
 *Here is what happens under the hood:*


### PR DESCRIPTION
## Summary

Fixes a typo in the Getting Started guide where the run command incorrectly shows `hello.cwasm` instead of `hello.wasm`.

The `lind-clang` compiler produces a `.wasm` file, not `.cwasm`.

Fixes #761