### PR TITLE
fix clone3 cageid overwrite bug

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/i386/clone3.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/clone3.c
@@ -15,11 +15,16 @@ int __GI___clone3 (struct clone_args *cl_args, size_t size, int (*func)(void *),
                          host_cl_args,
                          NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
 
-  // Reinitialize address translation for child processes
   if (pid == 0) {
-    __lind_base = 0ULL;
-    __lind_cageid = 0ULL;
-    __lind_init_addr_translation ();
+    // Reinitialize address translation only for fork (new cage).
+    // For threads (CLONE_VM), the address space is shared with the parent,
+    // so __lind_cageid and __lind_base are already correct.  Resetting them
+    // in shared memory would race with the parent's syscalls (cage 0 panic).
+    if (!(cl_args->flags & 0x00000100 /* CLONE_VM */)) {
+      __lind_base = 0ULL;
+      __lind_cageid = 0ULL;
+      __lind_init_addr_translation ();
+    }
 
     // Execute child function if in child process
     if (func != NULL) {

--- a/tests/unit-tests/process_tests/deterministic/thread_cageid_race.c
+++ b/tests/unit-tests/process_tests/deterministic/thread_cageid_race.c
@@ -1,0 +1,35 @@
+/* Test: pthread_create must not clobber __lind_cageid in shared memory.
+ *
+ * Before the clone3.c fix, the child thread's clone3 return path would
+ * write __lind_cageid = 0 to shared linear memory before re-querying
+ * the host.  This raced with the parent (and sibling) threads, which
+ * read __lind_cageid during every syscall.  A zero cage ID causes a
+ * 3i panic: "handler table for cage 0 not found".
+ *
+ * This test spawns enough threads to reliably trigger the race window.
+ * With the fix, it should print "done" and exit cleanly every time.
+ */
+#include <stdio.h>
+#include <pthread.h>
+
+#define NUM_THREADS 20
+
+static volatile int dummy;
+
+static void *thread_fn(void *arg) {
+    for (int i = 0; i < 1000; i++)
+        dummy = i;
+    return NULL;
+}
+
+int main(void) {
+    pthread_t threads[NUM_THREADS];
+
+    for (int i = 0; i < NUM_THREADS; i++)
+        pthread_create(&threads[i], NULL, thread_fn, NULL);
+    for (int i = 0; i < NUM_THREADS; i++)
+        pthread_join(threads[i], NULL);
+
+    printf("done\n");
+    return 0;
+}


### PR DESCRIPTION
clone3's child return path unconditionally zeroed __lind_cageid and __lind_base in shared linear memory before re-querying the host. 

For threads (CLONE_VM), this raced with parent/sibling  threads reading __lind_cageid on every syscall, causing 3i panics: "handler table for cage 0 not found". Guard the reset with !(flags & CLONE_VM) so threads skip the zeroing. Fork still  reinitializes as before. 
