### PR TITLE
Fix cxa exit

### DIFF
--- a/src/glibc/stdlib/cxa_atexit.c
+++ b/src/glibc/stdlib/cxa_atexit.c
@@ -50,7 +50,7 @@ __internal_atexit (void (*func) (void *), void *arg, void *d,
     }
 
   PTR_MANGLE (func);
-  new->func.cxa.fn = (void (*) (void *, int)) func;
+  new->func.cxa.fn = func;
   new->func.cxa.arg = arg;
   new->func.cxa.dso_handle = d;
   new->flavor = ef_cxa;

--- a/src/glibc/stdlib/cxa_finalize.c
+++ b/src/glibc/stdlib/cxa_finalize.c
@@ -41,7 +41,7 @@ __cxa_finalize (void *d)
 	if ((d == NULL || d == f->func.cxa.dso_handle) && f->flavor == ef_cxa)
 	  {
 	    const uint64_t check = __new_exitfn_called;
-	    void (*cxafn) (void *arg, int status) = f->func.cxa.fn;
+	    void (*cxafn) (void *arg) = f->func.cxa.fn;
 	    void *cxaarg = f->func.cxa.arg;
 
 	    /* We don't want to run this cleanup more than once.  The Itanium
@@ -79,7 +79,7 @@ __cxa_finalize (void *d)
 
 	    /* Unlock the list while we call a foreign function.  */
 	    __libc_lock_unlock (__exit_funcs_lock);
-	    cxafn (cxaarg, 0);
+	    cxafn (cxaarg);
 	    __libc_lock_lock (__exit_funcs_lock);
 
 	    /* It is possible that that last exit function registered

--- a/src/glibc/stdlib/exit.c
+++ b/src/glibc/stdlib/exit.c
@@ -93,7 +93,7 @@ __run_exit_handlers (int status, struct exit_function_list **listp,
 	    {
 	      void (*atfct) (void);
 	      void (*onfct) (int status, void *arg);
-	      void (*cxafct) (void *arg, int status);
+	      void (*cxafct) (void *arg);
 	      void *arg;
 
 	    case ef_free:
@@ -128,7 +128,7 @@ __run_exit_handlers (int status, struct exit_function_list **listp,
 
 	      /* Unlock the list while we call a foreign function.  */
 	      __libc_lock_unlock (__exit_funcs_lock);
-	      cxafct (arg, status);
+	      cxafct (arg);
 	      __libc_lock_lock (__exit_funcs_lock);
 	      break;
 	    }

--- a/src/glibc/stdlib/exit.h
+++ b/src/glibc/stdlib/exit.h
@@ -46,7 +46,7 @@ struct exit_function
 	  } on;
 	struct
 	  {
-	    void (*fn) (void *arg, int status);
+	    void (*fn) (void *arg);
 	    void *arg;
 	    void *dso_handle;
 	  } cxa;

--- a/tests/unit-tests/process_tests/deterministic/cxa_atexit_test.c
+++ b/tests/unit-tests/process_tests/deterministic/cxa_atexit_test.c
@@ -1,0 +1,31 @@
+/* Test that __cxa_atexit handlers run correctly on exit.
+ *
+ * glibc's __cxa_atexit registers void(*)(void*) functions, but internally
+ * stored them as void(*)(void*, int) and called with an extra status arg.
+ * In native C the extra arg is harmlessly ignored. In WASM, the indirect
+ * call type check catches the signature mismatch and traps.
+ *
+ * This test registers a handler via __cxa_atexit and exits normally.
+ * Without the fix: WASM trap "indirect call type mismatch" in __run_exit_handlers.
+ * With the fix: handler runs, prints output, process exits cleanly.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+extern int __cxa_atexit(void (*func)(void *), void *arg, void *d);
+
+static int handler_ran = 0;
+
+static void cleanup(void *arg) {
+    handler_ran = 1;
+    const char *msg = (const char *)arg;
+    printf("cxa_atexit handler called: %s\n", msg);
+}
+
+int main(void) {
+    __cxa_atexit(cleanup, "test_arg", NULL);
+
+    printf("main returning, handler should run during exit\n");
+    return 0;
+}


### PR DESCRIPTION
  glibc's __cxa_atexit registers functions with signature void (*)(void *) (per the Itanium C++ ABI), but internally casts and stores them as void (*)(void *, int), calling them with an  extra status argument. 

In native C, the extra argument is harmlessly ignored due to calling convention flexibility. In WASM, indirect calls through the function table are strictly type-checked — the signature mismatch causes a trap: "indirect call type mismatch".
                                                                                                                                                                                              
This caused any program that registered __cxa_atexit handlers (most non-trivial C/C++ programs) to trap inside _run_exit_handlers during exit(). The trap was silently swallowed by  invoke_func (let _ = func.call(...)), making it appear as a hang — load_main_module returned without the exit syscall ever firing, so lind_manager.wait() blocked forever.                  
                                                                                                    
Note: atexit() was already fixed for this same issue (@qianxichen233 ), but __cxa_atexit was missed.     

This fixes deadlocks in git and curl