### PR TITLE
Add support for wasmtime backtrace again.

### DIFF
--- a/src/lind-boot/Cargo.toml
+++ b/src/lind-boot/Cargo.toml
@@ -19,7 +19,7 @@ sysdefs = { path = "../wasmtime/crates/sysdefs" }
 typemap = { path = "../wasmtime/crates/typemap" }
 wasi-common = { path = "../wasmtime/crates/wasi-common", features = ["sync"] ,default-features = false }
 wasmtime-lind-3i = { path = "../wasmtime/crates/lind-3i" }
-wasmtime = { path = "../wasmtime/crates/wasmtime", features = ["cranelift", "pooling-allocator", "gc", "threads"], default-features = false }
+wasmtime = { path = "../wasmtime/crates/wasmtime", features = ["cranelift", "pooling-allocator", "gc", "threads", "demangle", "addr2line"], default-features = false }
 wasmtime-wasi-threads = { path = "../wasmtime/crates/wasi-threads" }
 wasmtime-wasi = { version = "23.0.0", features = ["preview1"] , default-features = false }
 

--- a/src/lind-boot/src/cli.rs
+++ b/src/lind-boot/src/cli.rs
@@ -15,6 +15,14 @@ pub struct CliOptions {
     #[arg(long)]
     pub precompile: bool,
 
+    /// Enables wasmtime backtrace details. Equivalent to wasmtime binary's
+    /// WASMTIME_BACKTRACE_DETAILS=1 environment variable.
+    ///
+    /// Does not need any special requirements for .wasm files, for .cwasm files, this configuration must
+    /// remain the same during compile and run.
+    #[arg(long = "wasmtime-backtrace")]
+    pub wasmtime_backtrace: bool,
+
     /// First item is WASM file (argv[0]), rest are program args (argv[1..])
     ///
     /// Example:

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -11,6 +11,7 @@ use threei::threei_const;
 use wasi_common::sync::WasiCtxBuilder;
 use wasmtime::{
     AsContextMut, Engine, Func, InstantiateType, Linker, Module, Precompiled, Store, Val, ValType,
+    WasmBacktraceDetails,
 };
 use wasmtime_lind_3i::{VmCtxWrapper, init_vmctx_pool, rm_vmctx, set_vmctx, set_vmctx_thread};
 use wasmtime_lind_multi_process::{CAGE_START_ID, LindCtx, THREAD_START_ID};
@@ -48,7 +49,7 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<Vec<Val>> {
     // -- Initialize the Wasmtime execution environment --
     let wasm_file_path = Path::new(lindboot_cli.wasm_file());
     let args = lindboot_cli.args.clone();
-    let wt_config = wasmtime::Config::new();
+    let wt_config = make_wasmtime_config(lindboot_cli.wasmtime_backtrace);
     let engine = Engine::new(&wt_config).context("failed to create execution engine")?;
     let host = HostCtx::default();
     let mut wstore = Store::new(&engine, host);
@@ -137,7 +138,7 @@ pub fn execute_with_lind(
     // -- Initialize the Wasmtime execution environment --
     let wasm_file_path = Path::new(lind_boot.wasm_file());
     let args = lind_boot.args.clone();
-    let wt_config = wasmtime::Config::new();
+    let wt_config = make_wasmtime_config(lind_boot.wasmtime_backtrace);
     let engine = Engine::new(&wt_config).context("failed to create execution engine")?;
     let host = HostCtx::default();
     let mut wstore = Store::new(&engine, host);
@@ -498,7 +499,8 @@ pub fn precompile_module(cli: &CliOptions) -> Result<()> {
     let wasm_path = Path::new(cli.wasm_file());
     let cwasm_path = wasm_path.with_extension("cwasm");
 
-    let engine = Engine::new(&wasmtime::Config::new()).context("failed to create engine")?;
+    let wt_config = make_wasmtime_config(cli.wasmtime_backtrace);
+    let engine = Engine::new(&wt_config).context("failed to create engine")?;
     let wasm_bytes = std::fs::read(wasm_path)
         .with_context(|| format!("failed to read {}", wasm_path.display()))?;
     let cwasm_bytes = engine
@@ -557,9 +559,28 @@ fn invoke_func(store: &mut Store<HostCtx>, func: Func, args: &[String]) -> Resul
     // Invoke the function and then afterwards print all the results that came
     // out, if there are any.
     let mut results = vec![Val::null_func_ref(); ty.results().len()];
-    let _ = func
-        .call(&mut *store, &values, &mut results)
-        .with_context(|| format!("failed to invoke command default"));
+
+    // Unwind in case of an error, this allows us to pretty-print the WasmBacktrace context when option
+    // is enabled.
+    func.call(&mut *store, &values, &mut results)
+        .with_context(|| format!("failed to invoke command default"))?;
 
     Ok(results)
+}
+
+/// Generates a wasmtime config based on the whether or not the --wasmtime-backtrace flag was
+/// provided to lind-boot.
+fn make_wasmtime_config(backtrace: bool) -> wasmtime::Config {
+    let mut wt_config = wasmtime::Config::new();
+    wt_config.wasm_backtrace(backtrace);
+
+    let details = if backtrace {
+        WasmBacktraceDetails::Enable
+    } else {
+        WasmBacktraceDetails::Disable
+    };
+
+    wt_config.wasm_backtrace_details(details);
+
+    wt_config
 }


### PR DESCRIPTION
After migrating to lind-boot, we do not have support for the `WASMTIME_BACKTRACE_DETAILS=1` flag, which in case of a webassembly trap provide more details about the originating stack/line that caused it. 

This PR brings support for this flag to lind-boot, using the `--wasmtime-backtrace` flag. 

Example information that we have access to again: 

```bash
lind@232affd4dc4d:~/lind-wasm/src/lind-boot$ sudo lind-boot trap.wasm
Hello World!
Error: failed to run main module

Caused by:
    0: failed to invoke command default
    1: wasm trap: wasm `unreachable` instruction executed


lind@232affd4dc4d:~/lind-wasm/src/lind-boot$ sudo lind-boot --wasmtime-backtrace trap.wasm
Hello World!
Error: failed to run main module

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
           0: 0x1977 - abort
                           at /home/lind/lind-wasm/src/glibc/stdlib/abort.c:125:1
           1: 0x11e8 - __main_argc_argv
                           at /home/lind/lind-wasm/trap.c:8:9
           2:  0xddc - trap.wasm!__main_void
           3: 0x105d - _start
                           at /home/lind/lind-wasm/src/glibc/lind_syscall/crt1/crt1.c:220:10
           4: 0x87b40 - trap.wasm!_start.command_export
    2: wasm trap: wasm `unreachable` instruction executed
```