### PR TITLE
Correct store fault mechanism to report once

### DIFF
--- a/src/wasmtime/crates/wasmtime/src/runtime/store.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/store.rs
@@ -2294,7 +2294,13 @@ impl StoreOpaque {
         let mut fault = None;
         for instance in self.instances.iter() {
             if let Some(f) = instance.handle.wasm_fault(addr) {
-                assert!(fault.is_none());
+                // Multiple instances may share the same linear memory (e.g.,
+                // backup VMContext pool instances import the same shared memory).
+                // Return the first match — all shared instances report identical
+                // fault info so subsequent matches can be skipped.
+                if fault.is_some() {
+                    continue;
+                }
                 fault = Some(f);
             }
         }


### PR DESCRIPTION
- Fixed assertion panic in store.rs:2297 where multiple instances sharing the same linear memory (backup VMContext pool instances) caused assert!(fault.is_none()) to fire during WASM fault handling                                                                                                                                                                                   
- The signal handler now returns the first matching fault instead of panicking on duplicate shared-memory matches  

Closes #784 