### PR TITLE
Enable signal tests

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -5,3 +5,6 @@ process_tests/deterministic/tls_test.c
 process_tests/deterministic/exit_failure.c
 process_tests/deterministic/thread-test.c
 networking_tests/deterministic/getifaddrs.c
+signal_tests/deterministic/signal_procmask.c
+signal_tests/deterministic/signal_sa_mask.c
+signal_tests/deterministic/sigpipe.c


### PR DESCRIPTION
Want to get an idea of what the signal tests that are currently disabled look like here.

Edit: a fair amount of these pass, lets re-enable them. I'm handling the other ones on a separate PR.