### PR TITLE
Add support for scheduler calls

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_getp.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_getp.c
@@ -1,11 +1,15 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sched.h>
+#include <lind_debug.h>
 
 int
 __sched_getparam (pid_t pid, struct sched_param *param)
 {
+  lind_debug_panic("sched_getparam called but not supported!");
   return -1;
 }
+libc_hidden_def (__sched_getparam)
+stub_warning (sched_getparam)
 
-
+weak_alias (__sched_getparam, sched_getparam)

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_gets.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_gets.c
@@ -1,8 +1,10 @@
 #include <unistd.h>
+#include <lind_debug.h>
 
 int
 __GI___sched_getscheduler (__pid_t __pid)
 {
+  lind_debug_panic("sched_getscheduler called but not supported!");
   return -1;
 }
 

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_primax.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_primax.c
@@ -1,8 +1,10 @@
 #include <unistd.h>
+#include <lind_debug.h>
 
 int
 __GI___sched_get_priority_max (int __algorithm)
 {
+  lind_debug_panic("sched_get_priority_max called but not supported!");
   return 0;
 }
 

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_primin.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_primin.c
@@ -1,8 +1,10 @@
 #include <unistd.h>
+#include <lind_debug.h>
 
 int
 __GI___sched_get_priority_min (int __algorithm)
 {
+  lind_debug_panic("sched_get_priority_min called but not supported!");
   return 0;
 }
 

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_setp.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_setp.c
@@ -1,11 +1,15 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sched.h>
+#include <lind_debug.h>
 
 int
 __sched_setparam (pid_t pid, const struct sched_param *param)
 {
+  lind_debug_panic("sched_setparam called but not supported!");
   return -1;
 }
+libc_hidden_def (__sched_setparam)
+stub_warning (sched_setparam)
 
-
+weak_alias (__sched_setparam, sched_setparam)

--- a/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_sets.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/i686/sched_sets.c
@@ -1,10 +1,12 @@
 #include <unistd.h>
 #include <sched.h>
 #include <sys/types.h>
+#include <lind_debug.h>
 
 int
 __sched_setscheduler (pid_t pid, int policy, const struct sched_param *param)
 {
+  lind_debug_panic("sched_setscheduler called but not supported!");
   return -1;
 }
 libc_hidden_def (__sched_setscheduler)


### PR DESCRIPTION
Add support for scheduler calls

Changes:
- `sched_setscheduler`, `sched_getscheduler`, `sched_get_priority_max`, `sched_get_priority_min`, `sched_getparam`, `sched_setparam` now call `lind_debug_panic()` before returning
- Fixed missing `weak_alias`/`libc_hidden_def` in `sched_getp.c` and `sched_setp.c` so their symbols are properly exported

Closes #523