### PR TITLE
Add back wasm cache

### DIFF
--- a/src/lind-boot/Cargo.toml
+++ b/src/lind-boot/Cargo.toml
@@ -19,7 +19,7 @@ sysdefs = { path = "../wasmtime/crates/sysdefs" }
 typemap = { path = "../wasmtime/crates/typemap" }
 wasi-common = { path = "../wasmtime/crates/wasi-common", features = ["sync"] ,default-features = false }
 wasmtime-lind-3i = { path = "../wasmtime/crates/lind-3i" }
-wasmtime = { path = "../wasmtime/crates/wasmtime", features = ["cranelift", "pooling-allocator", "gc", "threads", "demangle", "addr2line"], default-features = false }
+wasmtime = { path = "../wasmtime/crates/wasmtime", features = ["cranelift", "pooling-allocator", "gc", "threads", "demangle", "addr2line", "cache"], default-features = false }
 wasmtime-wasi-threads = { path = "../wasmtime/crates/wasi-threads" }
 wasmtime-wasi = { version = "23.0.0", features = ["preview1"] , default-features = false }
 

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -583,5 +583,12 @@ fn make_wasmtime_config(backtrace: bool) -> wasmtime::Config {
 
     wt_config.wasm_backtrace_details(details);
 
+    // Enable compilation cache — compiled .wasm artifacts are stored on disk
+    // so subsequent runs skip compilation. Best-effort: if config loading
+    // fails (e.g. no home dir), caching is simply disabled.
+    if let Err(e) = wt_config.cache_config_load_default() {
+        eprintln!("[lind-boot] warning: failed to enable wasm cache: {e}");
+    }
+
     wt_config
 }


### PR DESCRIPTION
Closes #816 

- Enable wasmtime's built-in compilation cache (wasmtime-cache crate) in lind-boot so that compiled .wasm artifacts are stored on disk and reused across runs
- Second and subsequent runs of the same .wasm file skip compilation entirely, significantly improving dev iteration speed
- Cache is best-effort — if config loading fails (e.g. no home directory), a warning is printed and execution continues without caching
