### PR TITLE
Fix epoll events bug

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -4,4 +4,3 @@ networking_tests/deterministic/uds-serverclient.c
 process_tests/deterministic/exit_failure.c
 networking_tests/deterministic/getifaddrs.c
 networking_tests/deterministic/ipv6_basic.c
-networking_tests/deterministic/epoll_edge_triggered.c

--- a/src/rawposix/src/net_calls.rs
+++ b/src/rawposix/src/net_calls.rs
@@ -897,9 +897,8 @@ pub extern "C" fn epoll_wait_syscall(
     //   kernel to host buffer (underfd) --> translate to guest buffer (vfd).
     let mut events = unsafe { std::slice::from_raw_parts_mut(events_ptr, maxevents as usize) };
 
-    let mut kernel_events: Vec<libc::epoll_event> = Vec::with_capacity(maxevents as usize);
-    // Should always be null value before we call libc::epoll_wait
-    kernel_events.push(libc::epoll_event { events: 0, u64: 0 });
+    let mut kernel_events: Vec<libc::epoll_event> =
+        vec![libc::epoll_event { events: 0, u64: 0 }; maxevents as usize];
 
     if maxevents != 0 {
         let start_time = starttimer();

--- a/src/typemap/src/datatype_conversion.rs
+++ b/src/typemap/src/datatype_conversion.rs
@@ -330,6 +330,10 @@ pub fn sc_convert_addr_to_epollevent<'a>(
     arg_cageid: u64,
     cageid: u64,
 ) -> Result<&'a mut libc::epoll_event, Errno> {
+    if arg == 0 {
+        return Err(Errno::EFAULT);
+    }
+
     #[cfg(feature = "secure")]
     {
         if !validate_cageid(arg_cageid, cageid) {

--- a/tests/unit-tests/networking_tests/deterministic/epoll_edge_triggered.c
+++ b/tests/unit-tests/networking_tests/deterministic/epoll_edge_triggered.c
@@ -1,11 +1,6 @@
 /*
  * Advanced epoll tests: EPOLLET (edge-triggered), EPOLLONESHOT,
- * EPOLL_CTL_MOD, EPOLL_CTL_DEL, error cases.
- *
- * NOTE: maxevents is kept at 1 throughout to work around a known
- * RawPOSIX bug where kernel_events Vec has len=1 regardless of
- * maxevents, causing an index-out-of-bounds panic when >1 events
- * are returned simultaneously (net_calls.rs:946).
+ * EPOLL_CTL_MOD, EPOLL_CTL_DEL, multi-event epoll_wait, error cases.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -43,21 +38,21 @@ int main(void) {
     /* Don't read. Second wait: should NOT fire (edge already delivered) */
     n = epoll_wait(epfd, out, 1, 50);
     assert(n == 0);
-    printf("1b. ET: second epoll_wait without read → 0 events (correct)\n");
+    printf("1b. ET: second epoll_wait without read -> 0 events (correct)\n");
 
-    /* Now read partially, then check — still no new edge (no new write) */
+    /* Now read partially, then check -- still no new edge (no new write) */
     char buf[16];
     assert(read(p[0], buf, 2) == 2); /* read 2 of 3 bytes */
 
     n = epoll_wait(epfd, out, 1, 50);
     assert(n == 0);
-    printf("1c. ET: partial read, no new write → 0 events\n");
+    printf("1c. ET: partial read, no new write -> 0 events\n");
 
-    /* Write more → new edge */
+    /* Write more -> new edge */
     assert(write(p[1], "d", 1) == 1);
     n = epoll_wait(epfd, out, 1, 100);
     assert(n == 1);
-    printf("1d. ET: new write → edge fires again\n");
+    printf("1d. ET: new write -> edge fires again\n");
 
     /* Drain remaining bytes (abc + d = 4, read 2 already, so 2 left) */
     assert(read(p[0], buf, sizeof(buf)) == 2);
@@ -85,11 +80,11 @@ int main(void) {
     /* Read the data */
     assert(read(p[0], buf, sizeof(buf)) == 1);
 
-    /* Write more — should NOT fire (oneshot disabled it) */
+    /* Write more -- should NOT fire (oneshot disabled it) */
     assert(write(p[1], "y", 1) == 1);
     n = epoll_wait(epfd, out, 1, 50);
     assert(n == 0);
-    printf("2b. ONESHOT: second write → 0 events (disabled)\n");
+    printf("2b. ONESHOT: second write -> 0 events (disabled)\n");
 
     /* Re-arm with EPOLL_CTL_MOD */
     ev.events = EPOLLIN | EPOLLONESHOT;
@@ -97,7 +92,7 @@ int main(void) {
 
     n = epoll_wait(epfd, out, 1, 100);
     assert(n == 1);
-    printf("2c. ONESHOT: re-armed via MOD → fires again\n");
+    printf("2c. ONESHOT: re-armed via MOD -> fires again\n");
 
     assert(read(p[0], buf, sizeof(buf)) == 1);
     close(p[0]);
@@ -121,7 +116,7 @@ int main(void) {
     /* Delete pa before any data */
     assert(epoll_ctl(epfd, EPOLL_CTL_DEL, pa[0], NULL) == 0);
 
-    /* Write to both — only pb should fire */
+    /* Write to both -- only pb should fire */
     assert(write(pa[1], "a", 1) == 1);
     assert(write(pb[1], "b", 1) == 1);
 
@@ -134,7 +129,41 @@ int main(void) {
     close(pb[0]); close(pb[1]);
     close(epfd);
 
-    /* --- 4) Error: add same FD twice → EEXIST --- */
+    /* --- 4) Multi-event epoll_wait (maxevents > 1) --- */
+    int pc[2], pd[2];
+    assert(pipe(pc) == 0);
+    assert(pipe(pd) == 0);
+
+    epfd = epoll_create1(0);
+    assert(epfd >= 0);
+
+    ev.events = EPOLLIN;
+    ev.data.fd = pc[0];
+    assert(epoll_ctl(epfd, EPOLL_CTL_ADD, pc[0], &ev) == 0);
+    ev.data.fd = pd[0];
+    assert(epoll_ctl(epfd, EPOLL_CTL_ADD, pd[0], &ev) == 0);
+
+    /* Write to both pipes so both are ready */
+    assert(write(pc[1], "c", 1) == 1);
+    assert(write(pd[1], "d", 1) == 1);
+
+    struct epoll_event multi_out[4];
+    n = epoll_wait(epfd, multi_out, 4, 100);
+    assert(n == 2);
+    /* Both FDs should be reported (order not guaranteed) */
+    int saw_pc = 0, saw_pd = 0;
+    for (int i = 0; i < n; i++) {
+        if (multi_out[i].data.fd == pc[0]) saw_pc = 1;
+        if (multi_out[i].data.fd == pd[0]) saw_pd = 1;
+    }
+    assert(saw_pc && saw_pd);
+    printf("4. Multi-event: epoll_wait returned 2 events with maxevents=4\n");
+
+    close(pc[0]); close(pc[1]);
+    close(pd[0]); close(pd[1]);
+    close(epfd);
+
+    /* --- 5) Error: add same FD twice -> EEXIST --- */
     assert(pipe(p) == 0);
     epfd = epoll_create1(0);
     assert(epfd >= 0);
@@ -147,12 +176,12 @@ int main(void) {
     int ret = epoll_ctl(epfd, EPOLL_CTL_ADD, p[0], &ev);
     assert(ret == -1);
     assert(errno == EEXIST);
-    printf("4. EPOLL_CTL_ADD duplicate → EEXIST\n");
+    printf("5. EPOLL_CTL_ADD duplicate -> EEXIST\n");
 
     close(p[0]); close(p[1]);
     close(epfd);
 
-    /* --- 5) Error: mod non-existent FD → ENOENT --- */
+    /* --- 6) Error: mod non-existent FD -> ENOENT --- */
     assert(pipe(p) == 0);
     epfd = epoll_create1(0);
     assert(epfd >= 0);
@@ -163,18 +192,18 @@ int main(void) {
     ret = epoll_ctl(epfd, EPOLL_CTL_MOD, p[0], &ev);
     assert(ret == -1);
     assert(errno == ENOENT);
-    printf("5. EPOLL_CTL_MOD on unadded FD → ENOENT\n");
+    printf("6. EPOLL_CTL_MOD on unadded FD -> ENOENT\n");
 
     close(p[0]); close(p[1]);
     close(epfd);
 
-    /* --- 6) EPOLL_CLOEXEC via epoll_create1 --- */
+    /* --- 7) EPOLL_CLOEXEC via epoll_create1 --- */
     epfd = epoll_create1(EPOLL_CLOEXEC);
     assert(epfd >= 0);
 
     int fdflags = fcntl(epfd, F_GETFD);
     assert(fdflags & FD_CLOEXEC);
-    printf("6. epoll_create1(EPOLL_CLOEXEC) sets FD_CLOEXEC\n");
+    printf("7. epoll_create1(EPOLL_CLOEXEC) sets FD_CLOEXEC\n");
 
     close(epfd);
 


### PR DESCRIPTION
 Closes #809

 - Fix segfault when calling epoll_ctl(EPOLL_CTL_DEL, fd, NULL) — sc_convert_addr_to_epollevent dereferenced the NULL guest pointer before the caller's error handling could intercept it.  Added a NULL check that returns Err(EFAULT), which the existing DEL path already handles correctly.
  - Fix index-out-of-bounds panic in epoll_wait when >1 events are returned — kernel_events Vec was allocated with with_capacity(maxevents) but only 1 element was pushed, so kernel_events[i] panicked for i >= 1. Replaced with vec![zeroed; maxevents].
  - Removed epoll_edge_triggered.c from the skip list and added a multi-event test case (maxevents=4, 2 ready FDs).
