### PR TITLE
Fix broken disable signals feature

### DIFF
--- a/src/lind-boot/Cargo.toml
+++ b/src/lind-boot/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
-disable_signals = []
+disable_signals = ["cage/disable_signals", "wasmtime-lind-multi-process/disable_signals"]
 secure = ["typemap/secure"]
 lind_debug = ["wasmtime-lind-common/lind_debug"]
 


### PR DESCRIPTION
Closes #456 

- Propagate disable_signals feature from lind-boot to cage and wasmtime-lind-multi-process crates — previously the feature was [] so it never reached those crates, meaning cfg guards in cage code were never activated
- Guard all 6 epoch-pointer-dereferencing functions in cage/src/signal/signal.rs with #[cfg(not(feature = "disable_signals"))] — these were unconditionally dereferencing a null pointer (set to 0 by execute.rs when the feature is enabled)
- Clean up the partial workaround in lind_thread_exit (the state = 1 hack) by wrapping the entire epoch migration block in a single #[cfg(not(feature = "disable_signals"))]

