### PR TITLE
Fix sigchld determinism

### DIFF
--- a/src/rawposix/src/sys_calls.rs
+++ b/src/rawposix/src/sys_calls.rs
@@ -496,12 +496,17 @@ pub extern "C" fn waitpid_syscall(
                 unsafe {
                     sched_yield();
                 }
-                // Check for pending signals after yielding (only if WNOHANG is not set)
+                // Check for pending signals after yielding (only if WNOHANG is not set).
+                // Re-acquire the zombie lock first: the child's exit may have both
+                // added a zombie AND sent SIGCHLD, so the zombie could already be
+                // available. Prefer completing the wait over returning EINTR.
+                zombies = cage.zombies.write();
+                if zombies.len() > 0 {
+                    continue;
+                }
                 if (options & WNOHANG == 0) && signal_check_trigger(cage.cageid) {
                     return syscall_error(Errno::EINTR, "waitpid", "interrupted by signal");
                 }
-                // after sleep, get the write access of zombies list back
-                zombies = cage.zombies.write();
                 continue;
             } else {
                 // there are zombies avaliable
@@ -552,11 +557,10 @@ pub extern "C" fn waitpid_syscall(
                 unsafe {
                     sched_yield();
                 }
-                // Check for pending signals after yielding (only if WNOHANG is not set)
-                if (options & WNOHANG == 0) && signal_check_trigger(cage.cageid) {
-                    return syscall_error(Errno::EINTR, "waitpid", "interrupted by signal");
-                }
-                // after sleep, get the write access of zombies list back
+                // Re-acquire the zombie lock before checking signals: the child's
+                // exit may have both added a zombie AND sent SIGCHLD atomically,
+                // so the zombie could already be available. Prefer completing the
+                // wait over returning EINTR.
                 zombies = cage.zombies.write();
 
                 // let's check if the zombie list contains the cage
@@ -567,6 +571,11 @@ pub extern "C" fn waitpid_syscall(
                     // find the cage in zombie list, remove it from the list and break
                     zombie_opt = Some(zombies.remove(index));
                     break;
+                }
+
+                // Check for pending signals after yielding (only if WNOHANG is not set)
+                if (options & WNOHANG == 0) && signal_check_trigger(cage.cageid) {
+                    return syscall_error(Errno::EINTR, "waitpid", "interrupted by signal");
                 }
 
                 continue;


### PR DESCRIPTION
Closes #840 

Summary

- Fix non-deterministic waitpid failure where SIGCHLD delivery causes an early -EINTR return even though the child's zombie is already in the parent's zombie list 
- Reorder both waitpid wait loops (wait-for-any and wait-for-specific-pid) to check the zombie list before checking for pending signals after sched_yield()

Problem

When a child calls _exit(), the exit path does two things in sequence:
1. Adds a zombie entry to the parent's zombie list
2. Sends SIGCHLD to the parent (sets epoch to EPOCH_SIGNAL)

Meanwhile, the parent's waitpid loop does:
1. drop(zombies) — release lock
2. sched_yield() — child exits here, adds zombie + sends SIGCHLD
3. signal_check_trigger() — sees SIGCHLD epoch → returns -EINTR
4. Zombie list check — never reached

The zombie is already available, but waitpid returns -EINTR instead of the child's pid. This matches real Linux behavior where waitpid should prefer completing over returning EINTR when the result is already available.

Fix

In both wait loops, re-acquire the zombie lock and check for the target zombie before checking signal_check_trigger(). If a zombie appeared during sched_yield(), complete the wait normally. Only return EINTR if no zombie is available.
