### PR TITLE
Fix incorrect test case for copy_data_between_cages

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -4,5 +4,3 @@ networking_tests/deterministic/ipv6_basic.c
 networking_tests/deterministic/epoll_edge_triggered.c
 interpose-mmap.c
 interpose-mmap_grate.c
-simple-tests/cpdata.c
-simple-tests/cpdata_grate.c

--- a/tests/grate-tests/simple-tests/cpdata.c
+++ b/tests/grate-tests/simple-tests/cpdata.c
@@ -1,20 +1,14 @@
-// Tests copy_data_between_cages by writing a string through an interposed
-// write() syscall.  The grate intercepts write(), copies the buffer from the
-// cage into a malloc'd destination, and verifies the contents.
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <fcntl.h>
 #include <unistd.h>
-#include <assert.h>
+#include <stdio.h>
 
-int main(int argc, char *argv[]) {
-    const char *msg = "hello";
-    // write() to stdout — the grate intercepts this and validates via copy_data
-    ssize_t ret = write(STDOUT_FILENO, msg, strlen(msg));
-    if (ret < 0) {
-        perror("write");
-        assert(0);
-    }
-    printf("[Cage | cpdata] PASS: write returned %zd\n", ret);
-    return 0;
+int main() {
+	int fd = open("random", O_CREAT | O_RDONLY, 0544);
+
+    // We don't test redirecting the open call. We just want 
+    // to make sure that the open call goes through and the data 
+    // is copied correctly, so the return value here should be 
+    // arbitrary number defined in grate, not the actual fd for 
+    // "random".
+	printf("[cage] fd=%d\n", fd);
 }

--- a/tests/grate-tests/simple-tests/cpdata_grate.c
+++ b/tests/grate-tests/simple-tests/cpdata_grate.c
@@ -1,155 +1,104 @@
-// Grate side of the copy_data_between_cages test (issue #833).
-// Intercepts write(1, buf, count) from the cage, mallocs a local buffer,
-// uses copy_data_between_cages() to copy the cage's data into it, and
-// verifies the contents match.
 #include <errno.h>
 #include <lind_syscall.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 #include <assert.h>
 
-// Dispatcher function — required by 3i grate callback trampoline
+// Dispatcher function
 int pass_fptr_to_wt(uint64_t fn_ptr_uint, uint64_t cageid, uint64_t arg1,
-                    uint64_t arg1cage, uint64_t arg2, uint64_t arg2cage,
-                    uint64_t arg3, uint64_t arg3cage, uint64_t arg4,
-                    uint64_t arg4cage, uint64_t arg5, uint64_t arg5cage,
-                    uint64_t arg6, uint64_t arg6cage) {
-    if (fn_ptr_uint == 0) {
-        fprintf(stderr, "[Grate|cpdata] Invalid function ptr\n");
-        assert(0);
-    }
+		    uint64_t arg1cage, uint64_t arg2, uint64_t arg2cage,
+		    uint64_t arg3, uint64_t arg3cage, uint64_t arg4,
+		    uint64_t arg4cage, uint64_t arg5, uint64_t arg5cage,
+		    uint64_t arg6, uint64_t arg6cage) {
+	if (fn_ptr_uint == 0) {
+		return -1;
+	}
 
-    // The handler for write() receives all 6 arg pairs
-    int (*fn)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-              uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-              uint64_t, uint64_t, uint64_t) =
-        (int (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-                 uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
-                 uint64_t, uint64_t, uint64_t))(uintptr_t)fn_ptr_uint;
+	int (*fn)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+		  uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+		  uint64_t) =
+	    (int (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+		     uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+		     uint64_t))(uintptr_t)fn_ptr_uint;
 
-    return fn(cageid, arg1, arg1cage, arg2, arg2cage,
-              arg3, arg3cage, arg4, arg4cage,
-              arg5, arg5cage, arg6, arg6cage);
+	return fn(cageid, arg1, arg1cage, arg2, arg2cage, arg3, arg3cage, arg4,
+		  arg4cage, arg5, arg5cage, arg6, arg6cage);
 }
 
-// write() handler: intercepts write(fd, buf, count)
-// arg1/arg1cage = fd, arg2/arg2cage = buf (host-translated), arg3/arg3cage = count
-int write_grate(uint64_t cageid,
-                uint64_t arg1, uint64_t arg1cage,
-                uint64_t arg2, uint64_t arg2cage,
-                uint64_t arg3, uint64_t arg3cage,
-                uint64_t arg4, uint64_t arg4cage,
-                uint64_t arg5, uint64_t arg5cage,
-                uint64_t arg6, uint64_t arg6cage) {
-    uint64_t src_host_addr = arg2;  // already host-translated by glibc
-    uint64_t src_cage = arg2cage;   // cage that owns the buffer
-    size_t count = (size_t)arg3;
+int open_grate(uint64_t cageid, uint64_t arg1, uint64_t arg1cage, uint64_t arg2,
+	       uint64_t arg2cage, uint64_t arg3, uint64_t arg3cage,
+	       uint64_t arg4, uint64_t arg4cage, uint64_t arg5,
+	       uint64_t arg5cage, uint64_t arg6, uint64_t arg6cage) {
+	int thiscage = getpid();
 
-    printf("[Grate|cpdata] Intercepted write: cage=%llu, buf=%llx, count=%zu\n",
-           cageid, src_host_addr, count);
+    printf("[Grate|open] intercepts open call: thiscage=%d, arg1cage=%llu\n", thiscage, arg1cage);
 
-    // Allocate a local buffer via malloc — this is the pattern that triggered #833
-    char *dest = (char *)malloc(count + 1);
-    if (!dest) {
-        fprintf(stderr, "[Grate|cpdata] malloc failed\n");
-        assert(0);
-    }
-    memset(dest, 0, count + 1);
+	char *pathname = malloc(256);
 
-    uint64_t grate_cageid = (uint64_t)getpid();
+	if (pathname == NULL) {
+		perror("malloc failed");
+		assert(0);
+	}
 
-    // Copy data from cage's buffer into grate's malloc'd buffer
-    int ret = copy_data_between_cages(
-        grate_cageid,       // thiscage
-        src_cage,           // targetcage
-        src_host_addr,      // srcaddr (host addr, passed through for foreign cage)
-        src_cage,           // srccage
-        (uint64_t)(uintptr_t)dest, // destaddr (user-space, will be translated)
-        grate_cageid,       // destcage
-        (uint64_t)count,    // len
-        0                   // copytype = memcpy
-    );
-    if (ret < 0) {
-        fprintf(stderr, "[Grate|cpdata] FAIL: copy_data_between_cages returned %d\n", ret);
-        free(dest);
+	copy_data_between_cages(thiscage, arg1cage, arg1, arg1cage,
+				(uint64_t)pathname, thiscage, 256, 1);
+
+    printf("[Grate|open] copied pathname: %s\n", pathname);
+
+    if (strcmp(pathname, "random") != 0) {
+        fprintf(stderr, "[Grate|open] FAIL: expected pathname 'random', got '%s'\n", pathname);
+        free(pathname);
         assert(0);
     }
 
-    // Verify the copied data
-    if (memcmp(dest, "hello", count) != 0) {
-        fprintf(stderr, "[Grate|cpdata] FAIL: data mismatch, got '%s'\n", dest);
-        free(dest);
-        assert(0);
-    }
-    printf("[Grate|cpdata] copy_data OK: '%s'\n", dest);
+	free(pathname);
 
-    free(dest);
-
-    // Forward the original write to the actual syscall so cage gets correct return
-    int self_grate_id = getpid();
-    int write_ret = make_threei_call(
-        1,  // syscallnum for write
-        0, self_grate_id, self_grate_id,
-        arg1, arg1cage,
-        arg2, arg2cage,
-        arg3, arg3cage,
-        arg4, arg4cage,
-        arg5, arg5cage,
-        arg6, arg6cage,
-        0  // no errno translation
-    );
-    return write_ret;
+    // We return arbitrary value here since we're just testing 
+    // that the grate can copy the data correctly
+    // This is only a simple test case for only testing the 
+    // copy_data_between_cages() function, so we don't need to 
+    // perform the actual open call for "random".
+	return 10;
 }
 
-// Main function — same boilerplate as all grates
 int main(int argc, char *argv[]) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: %s <cage_file> [<grate_file> <cage_file> ...]\n",
-                argv[0]);
-        assert(0);
-    }
+	if (argc < 2) {
+		assert(0);
+	}
 
-    int grateid = getpid();
+	int grateid = getpid();
 
-    for (int i = 1; i < (argc < 3 ? argc : 3); i++) {
-        pid_t pid = fork();
-        if (pid < 0) {
-            perror("fork failed");
-            assert(0);
-        } else if (pid == 0) {
-            if (i % 2 != 0) {
-                int cageid = getpid();
-                // Interpose write (syscall 1)
-                uint64_t fn_ptr_addr = (uint64_t)(uintptr_t)&write_grate;
-                printf("[Grate|cpdata] Registering write handler for cage %d in "
-                       "grate %d with fn ptr addr: %llu\n",
-                       cageid, grateid, fn_ptr_addr);
-                int ret = register_handler(cageid, 1, grateid, fn_ptr_addr);
-                if (ret != 0) {
-                    fprintf(stderr, "[Grate|cpdata] Failed to register handler, ret: %d\n", ret);
-                    assert(0);
-                }
-            }
+	pid_t pid = fork();
+	if (pid < 0) {
+		perror("fork failed");
+		assert(0);
+	} else if (pid == 0) {
+		int cageid = getpid();
 
-            if (execv(argv[i], &argv[i]) == -1) {
-                perror("execv failed");
-                assert(0);
-            }
-        }
-    }
+        // Set the open (syscallnum=2) of this cage to call this grate
+        // function open_grate 
+        // Syntax of register_handler:
+        // <targetcage, targetcallnum, this_grate_id, fn_ptr_u64)>
+		uint64_t fn_ptr_addr = (uint64_t)(uintptr_t)&open_grate;
+		int ret = register_handler(cageid, 2, grateid, fn_ptr_addr);
 
-    int status;
+		if (execv(argv[1], &argv[1]) == -1) {
+			perror("execv failed");
+			assert(0);
+		}
+	}
+
+	int status;
+    int failed = 0;
     while (wait(&status) > 0) {
         if (status != 0) {
-            fprintf(stderr, "[Grate|cpdata] FAIL: child exited with status %d\n", status);
-            assert(0);
+        fprintf(stderr, "[Grate|open] FAIL: child exited with status %d\n", status);
+        assert(0);
         }
     }
 
-    printf("[Grate|cpdata] PASS\n");
-    return 0;
+	return 0;
 }


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Resolves #841 

In #841, it was reported that copy_data_between_cages copies incorrect content. After deeper analysis, the issue was traced to an incorrect test case design rather than a bug in copy_data_between_cages itself.

This PR replaces the existing test with a simplified and isolated test case that correctly validates the behavior of copy_data_between_cages.

**Root cause:**

In the current test setup, all write calls inside the cage are redirected to the grate. This includes (1) The intended test call `write(STDOUT_FILENO, msg, strlen(msg));` and (2) other unrelated calls such as `printf(...)`.

Because the grate interposes every write syscall, it captures not only the expected "hello" message, but also additional output such as `[Cage | cpdata] PASS: write returned`. However, the grate’s validation logic was written under the assumption that only a single write syscall would be interposed, and therefore it expects only "hello" as the copied result. As a result, the test fails due to unexpected additional output being captured.

When the test is redesigned to isolate and validate only the behavior of copy_data_between_cage, copy_data_between_cages works correctly and copies the intended content.

This PR focuses solely on correcting the test case. More comprehensive and complex integration tests (including multi-syscall interposition scenarios) can be introduced in a follow-up PR.