### PR TITLE
Fix addr_translation init order

### DIFF
--- a/src/glibc/lind_syscall/addr_translation.c
+++ b/src/glibc/lind_syscall/addr_translation.c
@@ -8,7 +8,13 @@ uint64_t __lind_base = 0ULL;
 // Cached cage id (pid), initialized on first call
 uint64_t __lind_cageid = 0ULL;
 
-void
+/* Run as a high-priority .init_array constructor so that syscalls from
+   user/library constructors (e.g. mimalloc's _mi_process_init) already
+   have __lind_base and __lind_cageid available.  Priority 101 runs
+   after memory.init (passive data segments) but before default-priority
+   constructors.  A host-side call before _start doesn't work because
+   memory.init resets the globals back to zero.  See issue #883.  */
+void __attribute__ ((constructor (101)))
 __lind_init_addr_translation (void)
 {
   if (__lind_base != 0ULL && __lind_cageid != 0ULL)

--- a/tests/unit-tests/process_tests/deterministic/ctor_syscall_test.c
+++ b/tests/unit-tests/process_tests/deterministic/ctor_syscall_test.c
@@ -1,0 +1,28 @@
+/* Test that syscalls work from constructors (__attribute__((constructor))).
+   This validates that __lind_init_addr_translation runs before user
+   constructors via .init_array priority ordering.  Without the fix,
+   clock_gettime called from a constructor would panic in 3i because
+   __lind_cageid is still 0.  See issue #883.  */
+
+#include <assert.h>
+#include <time.h>
+
+static int ctor_ran = 0;
+
+__attribute__((constructor))
+static void my_early_init(void)
+{
+    /* This syscall requires __lind_cageid to be initialized.
+       Before the fix it would panic with "cage 0" in 3i.  */
+    struct timespec ts;
+    int ret = clock_gettime(CLOCK_MONOTONIC, &ts);
+    assert(ret == 0);
+    assert(ts.tv_sec >= 0);
+    ctor_ran = 1;
+}
+
+int main(void)
+{
+    assert(ctor_ran == 1);
+    return 0;
+}


### PR DESCRIPTION
Closes #883 

                                                                                        
Summary                                                                                                                                                                              
                                                                                                                                                                                     
- lind-boot now explicitly calls __lind_init_addr_translation before _initialize (which runs __wasm_call_ctors), guaranteeing __lind_base and __lind_cageid are set before any WASM constructors execute
- Exported __lind_init_addr_translation from the linker via --export in lind_compile
- Removed the now-redundant call from _start() in crt1
- Added ctor_syscall_test.c which calls clock_gettime from a constructor to verify the fix

Context

__wasm_call_ctors runs all .init_array constructors before _start. Libraries like mimalloc inject constructors (e.g. _mi_process_init) that make syscalls during initialization. Previously __lind_init_addr_translation was called at the top of _start, so these constructors ran with __lind_cageid = 0, panicking 3i.

Moving initialization to the host side (before _initialize) is more robust than using constructor priorities, since it avoids any ambiguity about ordering between same-priority constructors.
