### PR TITLE
Fix lind debug ifdef

### DIFF
--- a/src/glibc/lind_syscall/lind_debug.c
+++ b/src/glibc/lind_syscall/lind_debug.c
@@ -12,6 +12,7 @@ void lind_debug_panic (const char* msg)
     __lind_debug_panic(TRANSLATE_GUEST_POINTER_TO_HOST(msg));
 }
 
+#ifdef LIND_DEBUG
 // These functions returns the input value to ensure the operand
 // remains on the WASM stack for potential debugging
 
@@ -36,3 +37,4 @@ void __lind_debug_import(void) {
     __lind_debug_num(0);
     __lind_debug_str("LIND DEGUG INIT");
 }
+#endif // LIND_DEBUG


### PR DESCRIPTION
Summary                                                                                                                                                                              
                                                                                                                                                                                 
- Wrapped __lind_debug_num, __lind_debug_str imports and __lind_debug_import() in #ifdef LIND_DEBUG in lind_debug.c

Context

The debug WASM imports (debug::lind_debug_num, debug::lind_debug_str) were always compiled into lind_debug.o due to __attribute__((used)) with no #ifdef guard. The header and crt1both gate on LIND_DEBUG, but the actual import declarations in the .c file were unconditional. This meant the final binary always had unresolved imports from the "debug" module.

wasm-opt masked this by stripping the dead imports, but running an unoptimized .wasm binary against a lind-boot built without --features lind_debug fails with "lind_debug_num is not defined".

Fixes #884
