### PR TITLE
Fix tcache dtv

### DIFF
--- a/src/glibc/elf/dl-tls.c
+++ b/src/glibc/elf/dl-tls.c
@@ -638,13 +638,18 @@ _dl_deallocate_tls (void *tcb, bool dealloc_tcb)
 {
   dtv_t *dtv = GET_DTV (tcb);
 
-  /* We need to free the memory allocated for non-static TLS.  */
-  for (size_t cnt = 0; cnt < dtv[-1].counter; ++cnt)
-    free (dtv[1 + cnt].pointer.to_free);
+  /* In WASM, glibc's DTV is unused (TLS managed by __builtin_wasm_tls_*),
+     so dtv is NULL.  Skip DTV cleanup to avoid dereferencing NULL.  */
+  if (dtv != NULL)
+    {
+      /* We need to free the memory allocated for non-static TLS.  */
+      for (size_t cnt = 0; cnt < dtv[-1].counter; ++cnt)
+	free (dtv[1 + cnt].pointer.to_free);
 
-  /* The array starts with dtv[-1].  */
-  if (dtv != GL(dl_initial_dtv))
-    free (dtv - 1);
+      /* The array starts with dtv[-1].  */
+      if (dtv != GL(dl_initial_dtv))
+	free (dtv - 1);
+    }
 
   if (dealloc_tcb)
     free (*tcb_to_pointer_to_free_location (tcb));

--- a/src/glibc/nptl/allocatestack.c
+++ b/src/glibc/nptl/allocatestack.c
@@ -132,14 +132,20 @@ get_cached_stack (size_t *sizep, void **memp)
   __libc_lock_init (result->exit_lock);
   memset (&result->tls_state, 0, sizeof result->tls_state);
 
-  /* Clear the DTV.  */
+  /* Clear the DTV.  In WASM, glibc's DTV mechanism is unused (TLS is
+     managed by __builtin_wasm_tls_*), so the dtv pointer in tcbhead_t
+     is never set and remains NULL.  Skip the DTV cleanup to avoid
+     dereferencing NULL (dtv[-1] would access address 0xfffffff8).  */
   dtv_t *dtv = GET_DTV (TLS_TPADJ (result));
-  for (size_t cnt = 0; cnt < dtv[-1].counter; ++cnt)
-    free (dtv[1 + cnt].pointer.to_free);
-  memset (dtv, '\0', (dtv[-1].counter + 1) * sizeof (dtv_t));
+  if (dtv != NULL)
+    {
+      for (size_t cnt = 0; cnt < dtv[-1].counter; ++cnt)
+	free (dtv[1 + cnt].pointer.to_free);
+      memset (dtv, '\0', (dtv[-1].counter + 1) * sizeof (dtv_t));
 
-  /* Re-initialize the TLS.  */
-  _dl_allocate_tls_init (TLS_TPADJ (result), true);
+      /* Re-initialize the TLS.  */
+      _dl_allocate_tls_init (TLS_TPADJ (result), true);
+    }
 
   return result;
 }

--- a/src/glibc/nptl/pthread_create.c
+++ b/src/glibc/nptl/pthread_create.c
@@ -325,14 +325,19 @@ static int create_thread (struct pthread *pd, const struct pthread_attr *attr,
         ----------- <--- stack_bottom
   */
   size_t tls_size = __builtin_wasm_tls_size();
+  size_t tls_align = __builtin_wasm_tls_align();
+  // __copy_tls aligns mem UP by up to tls_align bytes before writing tls_size
+  // bytes of TLS data.  Reserve the extra alignment padding so TLS doesn't
+  // overflow into the pthread struct above it.
+  size_t tls_alloc = tls_size + tls_align;
   // stack bottom = stack top + stack size
   unsigned char *stack_bottom = (void *)pd->stackblock + pd->stackblock_size;
   // calculate the offset for each field based on the above diagram
 
   // Reserve space for the pthread struct just below the stack
   unsigned char *pthread_addr = stack_bottom - TLS_TCB_SIZE;
-  // Allocate space for TLS data below pthread struct
-  unsigned char *TLS_addr = pthread_addr - tls_size;
+  // Allocate space for TLS data (+ alignment padding) below pthread struct
+  unsigned char *TLS_addr = pthread_addr - tls_alloc;
   // Allocate space for clone_args below TLS data
   struct clone_args *args = (struct clone_args *)(TLS_addr - sizeof(struct clone_args));
   // Reserve 8 bytes below clone_args for the TLS base pointer
@@ -344,7 +349,7 @@ static int create_thread (struct pthread *pd, const struct pthread_attr *attr,
   memset(args, 0, sizeof(struct clone_args));
   args->flags = clone_flags;
   args->stack = real_stack_bottom;
-  args->stack_size = stacksize - sizeof(struct clone_args) - TLS_TCB_SIZE - tls_size - 8;
+  args->stack_size = stacksize - sizeof(struct clone_args) - TLS_TCB_SIZE - tls_alloc - 8;
   args->child_tid = &pd->tid;
 
   // initialize TLS data
@@ -397,7 +402,9 @@ start_thread (void *arg)
 
   // retrieve the TLS data address
   size_t tls_size = __builtin_wasm_tls_size();
-  uintptr_t* tls_base_addr = pd->stackblock + pd->stackblock_size - sizeof(struct clone_args) - TLS_TCB_SIZE - tls_size - 8;
+  size_t tls_align = __builtin_wasm_tls_align();
+  size_t tls_alloc = tls_size + tls_align;
+  uintptr_t* tls_base_addr = pd->stackblock + pd->stackblock_size - sizeof(struct clone_args) - TLS_TCB_SIZE - tls_alloc - 8;
   void* tls_base = (void*)(*tls_base_addr);
 
   // set __tls_base wasm global

--- a/tests/unit-tests/memory_tests/deterministic/thread_malloc_sequential.c
+++ b/tests/unit-tests/memory_tests/deterministic/thread_malloc_sequential.c
@@ -1,0 +1,67 @@
+/* Threads run fully sequentially — thread 1 finishes before thread 2 starts.
+   Eliminates ALL concurrency. If this crashes, the bug is in heap state
+   corruption from multiple threads' tcache, not concurrent access. */
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define NALLOCS 32
+#define SIZES_COUNT 4
+static const size_t sizes[SIZES_COUNT] = {16, 32, 64, 128};
+
+static void tag(int id, int phase) {
+    char buf[] = "[T0:P0]\n";
+    buf[2] = '0' + id;
+    buf[5] = '0' + phase;
+    write(2, buf, 8);
+}
+
+void *thread_fn(void *arg) {
+    int id = *(int *)arg;
+    void *ptrs[NALLOCS];
+
+    tag(id, 1);
+    for (int i = 0; i < NALLOCS; i++) {
+        size_t sz = sizes[i % SIZES_COUNT];
+        ptrs[i] = malloc(sz);
+        if (!ptrs[i]) { write(2, "malloc failed\n", 14); return (void *)1; }
+        memset(ptrs[i], id + i, sz);
+    }
+
+    tag(id, 2);
+    for (int i = 0; i < NALLOCS; i++)
+        free(ptrs[i]);
+
+    tag(id, 3);
+    for (int i = 0; i < NALLOCS; i++) {
+        size_t sz = sizes[i % SIZES_COUNT];
+        ptrs[i] = malloc(sz);
+        if (!ptrs[i]) { write(2, "re-malloc failed\n", 17); return (void *)1; }
+        memset(ptrs[i], 0xAA, sz);
+    }
+
+    tag(id, 4);
+    for (int i = 0; i < NALLOCS; i++)
+        free(ptrs[i]);
+
+    tag(id, 5);
+    return NULL;
+}
+
+int main(void) {
+    /* Run threads one at a time — fully sequential */
+    for (int i = 0; i < 4; i++) {
+        int id = i + 1;
+        pthread_t t;
+        pthread_create(&t, NULL, thread_fn, &id);
+        void *ret;
+        pthread_join(t, &ret);
+        if (ret != NULL) {
+            write(1, "FAIL\n", 5);
+            return 1;
+        }
+    }
+    write(1, "done\n", 5);
+    return 0;
+}


### PR DESCRIPTION
Summary                                                                                                                                                                              
                                                                             
- Fix crash caused by NULL DTV (Dynamic Thread Vector) pointer dereference when reusing cached thread stacks — WASM uses __builtin_wasm_tls_* for TLS, not glibc's DTV mechanism, so the DTV pointer in tcbhead_t is never initialized and stays NULL                                                                                                                     
- get_cached_stack in allocatestack.c and _dl_deallocate_tls in dl-tls.c both access dtv[-1], which with dtv=NULL reads address 0xfffffff8 (OOB in 4GB linear memory)
- Also fix TLS allocation overflow in pthread_create.c where __copy_tls aligns memory UP by up to tls_align bytes before writing tls_size bytes, but only tls_size was reserved — now  reserves tls_size + tls_align

Closes #872
