### PR TITLE
Fix INTERNAL_SYSCALL uninitialized resultvar

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/i386/sysdep.h
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/sysdep.h
@@ -319,12 +319,12 @@ struct libc_do_syscall_args
 
 #define INTERNAL_SYSCALL(name, nr, args...) \
   ({									      \
-    register unsigned int resultvar;					      \
+    register unsigned int resultvar = 0;			      \
     INTERNAL_SYSCALL_MAIN_##nr (name, args);			      	      \
     (int) resultvar; })
 #define INTERNAL_SYSCALL_NCS(name, nr, args...) \
   ({									      \
-    register unsigned int resultvar;					      \
+    register unsigned int resultvar = 0;				     \
     INTERNAL_SYSCALL_MAIN_NCS_##nr (name, args);		      	      \
     (int) resultvar; })
 


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Purpose
As reported in https://github.com/issues/assigned?issue=Lind-Project%7Clind-wasm-apps%7C161, nginx fails when `setgid` returns a non-zero value.
```
>> cat lindfs/var/log/nginx/error.log 
2026/03/26 16:17:37 [emerg] 3#0: setgid(65534) failed
2026/03/26 16:17:37 [alert] 2#0: worker process 3 exited with fatal code 2 and cannot be respawned
```

Upon investigation, nginx calls setgid which goes through this trace
1. https://github.com/Lind-Project/lind-wasm/blob/ebbe66c3d5e58ab735584e4131be8fcf9aa5c2e5/src/glibc/sysdeps/unix/sysv/linux/setgid.c#L23-L29
2. https://github.com/Lind-Project/lind-wasm/blob/ebbe66c3d5e58ab735584e4131be8fcf9aa5c2e5/src/glibc/sysdeps/unix/sysv/linux/i386/sysdep.h#L320-L329

The `register unsigned int resultvar;` is uninitialized which returns a garbage value back to nginx. 

# Fix
Initialize resultvar as 0 solved the problem


# Test
```
lind@9d66bdc4863c:~/lind-wasm-apps$  bash nginx/test.sh 
[nginx-test] nginx binary found at: /home/lind/lind-wasm/lindfs/usr/sbin/nginx
[nginx-test] starting nginx on port 8080...
[nginx-test] nginx ready (PID 273205)

[nginx-test] === Running nginx tests ===

[nginx-test] [PASS] GET index page
[nginx-test] [PASS] HEAD request
[nginx-test] [PASS] 404 error page
[nginx-test] [PASS] Static file serving
[nginx-test] [PASS] Content-Length validation
[nginx-test] [PASS] POST method
[nginx-test] [PASS] Multiple sequential requests
[nginx-test] [PASS] Keepalive connection reuse
[nginx-test] [PASS] Concurrent requests

[nginx-test] 9/9 tests passed, 0 failed
[nginx-test] Log saved to: /tmp/nginx_test_results.log
```