### PR TITLE
add two glibc subsystems version files for coreutils

### DIFF
--- a/scripts/version-path-minimal.txt
+++ b/scripts/version-path-minimal.txt
@@ -24,3 +24,5 @@
 ./inet/Versions
 ./setjmp/Versions
 ./debug/Versions
+./intl/Versions
+./iconv/Versions


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Purpose
Append to scripts/version-path-minimal.txt
```
  ./intl/Versions
  ./iconv/Versions
```
as coreutils need symbols like `env::bindtextdomai` at runtime but is failing due to not finding them.

Related to https://github.com/Lind-Project/lind-wasm-apps/pull/176