### PR TITLE
Rust Grates: Pin cargo-nightly to a stable working version

### DIFF
--- a/scripts/cargo-lind_compile
+++ b/scripts/cargo-lind_compile
@@ -37,7 +37,7 @@ WASM_OPT_BIN="${WASM_OPT_BIN:-wasm-opt}"
 WASMTIME_BIN="${WASMTIME_BIN:-wasmtime}"
 
 echo "Building with profile: $PROFILE"
-cargo +nightly build -Z build-std=std,panic_abort "${CARGO_ARGS[@]}"
+cargo +nightly-2026-02-11 build -Z build-std=std,panic_abort "${CARGO_ARGS[@]}"
 
 echo "-------------------------------"
 for f in $(find "$CARGO_TARGET_DIR/wasm32-wasip1/$PROFILE" -name "*.wasm" ! -path "*deps*" 2>/dev/null | sort -r); do


### PR DESCRIPTION
With newer versions of cargo nightly (needed for building Rust grates), we see some breaking issues with the linker scripts. While we debug the root cause, pinning the builds to use a known-to-work version of nightly.
