### PR TITLE
Reorder build sequence to resolve cwasm library corruption in dynamic loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LINDFS_DIRS := \
 	       var/run
 
 .PHONY: build 
-build: sysroot lind-boot lindfs
+build: lindfs lind-boot sysroot
 	@echo "Build complete"
 
 .PHONY: all


### PR DESCRIPTION
### **Summary**
This PR corrects the build order to ensure that `libc.cwasm` and `libm.cwasm` are generated correctly during a single build cycle. 

Previously, running `make` followed by `make test` would fail on the first attempt due to corrupted `.cwasm` files. The issue was rooted in an incorrect dependency sequence: **glibc** was being built before its underlying dependencies were fully prepared.

### **The Issue**
The scripts responsible for producing the shared WASM libraries (`scripts/make_shared_glibc.sh` and `scripts/make_shared_libm.sh`) invoke `wasm-opt` to inject epochs and other metadata. This process appears to have a functional dependency on the `lind-boot` build. When built out of order, the resulting WASM files become corrupted, requiring a second `make` command to stabilize the environment.

### **Changes**
The build pipeline has been reordered to ensure all dependencies are satisfied before glibc compilation:
1.  **lindfs**
2.  **lind-boot**
3.  **glibc**

### **Verification**
*   Verified that a clean build (`make`) followed by `make test` now passes on the first attempt.