### PR TITLE
make forkdup test deterministic

### DIFF
--- a/tests/unit-tests/process_tests/deterministic/forkdup.c
+++ b/tests/unit-tests/process_tests/deterministic/forkdup.c
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
         fflush(stdout);
     }
     
-    printf("all done\n");
+    printf("PASS\n");
     fflush(stdout);
     close(fd);
     return 0;


### PR DESCRIPTION
forkdup.c test sometimes failed since its output is not deterministic (race condition output)

fixed forkdup test so that it is always deterministic