### PR TITLE
pin rustup src version

### DIFF
--- a/Docker/Dockerfile.dev
+++ b/Docker/Dockerfile.dev
@@ -86,7 +86,7 @@ WORKDIR /home/${USERNAME}
 # --profile minimal tells rustup to install only the essentials for the toolchain
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --profile minimal
-RUN /home/${USERNAME}/.cargo/bin/rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+RUN /home/${USERNAME}/.cargo/bin/rustup component add rust-src --toolchain nightly-2026-02-11-x86_64-unknown-linux-gnu
 
 # --- Clone the repo as user ---
 RUN git clone --branch "${BRANCH_NAME}" --single-branch "${REPO_URL}" /home/${USERNAME}/lind-wasm

--- a/Docker/Dockerfile.e2e
+++ b/Docker/Dockerfile.e2e
@@ -99,7 +99,7 @@ RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
     sh -s -- -y --profile minimal
 ENV PATH="/root/.cargo/bin:${PATH}"
-RUN rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+RUN rustup component add rust-src --toolchain nightly-2026-02-11-x86_64-unknown-linux-gnu
 
 
 # Build lind-boot


### PR DESCRIPTION
Pins rustup add rust-src to the pinned cargo version: nightly-2026-02-11-x86_64-unknown-linux-gnu
