### PR TITLE
optimize compiled grate wasm bin with static flag

### DIFF
--- a/scripts/cargo-lind_compile
+++ b/scripts/cargo-lind_compile
@@ -42,7 +42,7 @@ cargo +nightly-2026-02-11 build -Z build-std=std,panic_abort "${CARGO_ARGS[@]}"
 echo "-------------------------------"
 for f in $(find "$CARGO_TARGET_DIR/wasm32-wasip1/$PROFILE" -name "*.wasm" ! -path "*deps*" 2>/dev/null | sort -r); do
         # Find the wasm files in the appropriate profile directory
-        lind_compile --opt-only "$f" &> /dev/null || true
+        lind_compile -s --opt-only "$f" &> /dev/null || true
         # Precompile the optimized wasm file to cache it to LindFS
         lind_compile --precompile-only "$f" &> /dev/null || true
 done


### PR DESCRIPTION
Default optimizations on the grate's compiled wasm binary are done by passing additional flags to `wasm-opt` that are required for dynamic building. This results in export related issues for building rust grates, thus adding `-s` flag to `lind_compile --opt-only` optimizes the binary for static build.

<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
