### PR TITLE
add lindfs to make target for lind-debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,13 @@ lindfs:
 	cp -rT scripts/lindfs-conf/usr/share/zoneinfo $(LINDFS_ROOT)/usr/share/zoneinfo
 
 .PHONY: lind-debug
-lind-debug: build-dir lindfs
-	# Build glibc with LIND_DEBUG enabled (by setting the LIND_DEBUG variable)
-	$(MAKE) build_glibc LIND_DEBUG=1
-	
+lind-debug: lindfs build-dir
 	# Build lind-boot with the lind_debug feature enabled
 	cargo build --manifest-path src/lind-boot/Cargo.toml --features lind_debug
 	cp src/lind-boot/target/debug/lind-boot $(LINDBOOT_BIN)
+
+	# Build glibc with LIND_DEBUG enabled (by setting the LIND_DEBUG variable)
+	$(MAKE) build_glibc LIND_DEBUG=1
 build_glibc:
 	# build sysroot passing -DLIND_DEBUG if LIND_DEBUG is set
 	if [ "$(LIND_DEBUG)" = "1" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lindfs:
 	cp -rT scripts/lindfs-conf/usr/share/zoneinfo $(LINDFS_ROOT)/usr/share/zoneinfo
 
 .PHONY: lind-debug
-lind-debug: build-dir
+lind-debug: build-dir lindfs
 	# Build glibc with LIND_DEBUG enabled (by setting the LIND_DEBUG variable)
 	$(MAKE) build_glibc LIND_DEBUG=1
 	


### PR DESCRIPTION
## Summary
This change updates the `lind-debug` target so it also builds `lindfs`.

Before this change, `make lind-debug` built debug glibc and debug `lind-boot`, but did not run the `lindfs` setup steps. Now `lind-debug` includes `lindfs` as a prerequisite, so the filesystem tree is prepared in the same flow.

## What Changed
- Updated `Makefile` target prerequisites:
  - From: `lind-debug: build-dir`
  - To: `lind-debug: build-dir lindfs`

## Validation
- Verified target wiring with:
  - `make -pn | rg '^lind-debug:'`
  - built docker dev container and verified presence of `build/` and `lindfs/` locations
