### PR TITLE
Create smoke test for dlopen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ test: lindfs
 	fi; \
 	if LIND_WASM_BASE=. LINDFS_ROOT=$(LINDFS_ROOT) \
 	python3 ./scripts/test_runner.py --export-report report.html && \
+	./scripts/dlopen_smoke_test.sh && \
 	find reports -maxdepth 1 -name '*.json' -print -exec cat {} \; && \
 	if [ "$(LIND_DEBUG)" = "1" ]; then \
 	  python3 ./scripts/check_reports.py --debug; \
@@ -119,6 +120,7 @@ test: lindfs
 	  if [ ! -f reports/report.html ]; then cp report.html reports/report.html; fi; \
 	  if [ ! -f reports/wasm.json ]; then printf '%s\n' '{"number_of_failures":1,"results":[],"error":"missing wasm report"}' > reports/wasm.json; fi; \
 	  if [ ! -f reports/grates.json ]; then printf '%s\n' '{"number_of_failures":1,"results":[],"error":"missing grate report"}' > reports/grates.json; fi; \
+	  if [ ! -f reports/dlopen.json ]; then printf '%s\n' '{"number_of_failures":1,"results":[],"error":"missing dlopen report"}' > reports/dlopen.json; fi; \
 	fi; \
 	exit 0
 

--- a/scripts/dlopen_smoke_test.sh
+++ b/scripts/dlopen_smoke_test.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Dedicated dlopen positive-path smoke test for CI.
+# Emits reports/dlopen.json with number_of_failures=0|1 and returns matching exit code.
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+REPORTS_DIR="${REPO_ROOT}/reports"
+REPORT_FILE="${REPORTS_DIR}/dlopen.json"
+
+LIB_SOURCE="tests/unit-tests/dylink_tests/deterministic/lib.c"
+MAIN_SOURCE="tests/unit-tests/dylink_tests/deterministic/main.c"
+EXPECTED_SUBSTRING="Hello, main module! (from shared library)"
+
+mkdir -p "${REPORTS_DIR}"
+cd "${REPO_ROOT}"
+
+tmp_dir="$(mktemp -d)"
+manifest_file="${tmp_dir}/checks.tsv"
+cleanup() {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+compile_lib_output="${tmp_dir}/compile_library.log"
+compile_main_output="${tmp_dir}/compile_main.log"
+run_main_output="${tmp_dir}/run_main.log"
+verify_output_log="${tmp_dir}/verify_output_substring.log"
+run_main_status="skipped"
+
+compile_lib_cmd="${REPO_ROOT}/scripts/lind_compile --compile-library ${LIB_SOURCE}"
+if "${REPO_ROOT}/scripts/lind_compile" --compile-library "${LIB_SOURCE}" > "${compile_lib_output}" 2>&1; then
+  compile_lib_status="pass"
+  pass_count=$((pass_count + 1))
+else
+  compile_lib_status="fail"
+  fail_count=$((fail_count + 1))
+fi
+printf '%s\t%s\t%s\t%s\n' "compile_library" "${compile_lib_status}" "${compile_lib_cmd}" "${compile_lib_output}" >> "${manifest_file}"
+
+compile_main_cmd="${REPO_ROOT}/scripts/lind_compile ${MAIN_SOURCE}"
+if "${REPO_ROOT}/scripts/lind_compile" "${MAIN_SOURCE}" > "${compile_main_output}" 2>&1; then
+  compile_main_status="pass"
+  pass_count=$((pass_count + 1))
+else
+  compile_main_status="fail"
+  fail_count=$((fail_count + 1))
+fi
+printf '%s\t%s\t%s\t%s\n' "compile_main" "${compile_main_status}" "${compile_main_cmd}" "${compile_main_output}" >> "${manifest_file}"
+
+run_main_cmd="${REPO_ROOT}/scripts/lind_run main.cwasm"
+if [[ "${compile_main_status}" = "pass" ]]; then
+  if "${REPO_ROOT}/scripts/lind_run" main.cwasm > "${run_main_output}" 2>&1; then
+    run_main_status="pass"
+    pass_count=$((pass_count + 1))
+  else
+    run_main_status="fail"
+    fail_count=$((fail_count + 1))
+  fi
+else
+  run_main_status="skipped"
+  skip_count=$((skip_count + 1))
+  printf '%s\n' "Skipped: run step requires compile_main pass." > "${run_main_output}"
+fi
+printf '%s\t%s\t%s\t%s\n' "run_main" "${run_main_status}" "${run_main_cmd}" "${run_main_output}" >> "${manifest_file}"
+
+verify_cmd="grep -Fq '${EXPECTED_SUBSTRING}' run_main_output"
+if [[ "${run_main_status}" = "pass" ]]; then
+  if grep -Fq "${EXPECTED_SUBSTRING}" "${run_main_output}"; then
+    verify_status="pass"
+    pass_count=$((pass_count + 1))
+    printf '%s\n' "Matched expected substring: ${EXPECTED_SUBSTRING}" > "${verify_output_log}"
+  else
+    verify_status="fail"
+    fail_count=$((fail_count + 1))
+    {
+      printf '%s\n' "Expected substring not found: ${EXPECTED_SUBSTRING}"
+      printf '\n'
+      printf '%s\n' "Observed run output:"
+      cat "${run_main_output}"
+    } > "${verify_output_log}"
+  fi
+else
+  verify_status="skipped"
+  skip_count=$((skip_count + 1))
+  printf '%s\n' "Skipped: output verification requires run_main pass." > "${verify_output_log}"
+fi
+printf '%s\t%s\t%s\t%s\n' "verify_output_substring" "${verify_status}" "${verify_cmd}" "${verify_output_log}" >> "${manifest_file}"
+
+python3 - "${manifest_file}" "${REPORT_FILE}" "${pass_count}" "${fail_count}" "${skip_count}" <<'PY'
+import json
+import pathlib
+import sys
+
+manifest_path, report_path, pass_count, fail_count, skip_count = sys.argv[1:]
+checks = []
+for raw in pathlib.Path(manifest_path).read_text(encoding="utf-8", errors="replace").splitlines():
+    if not raw.strip():
+        continue
+    name, status, command, output_path = raw.split("\t", 3)
+    output = pathlib.Path(output_path).read_text(encoding="utf-8", errors="replace")
+    checks.append({
+        "name": name,
+        "status": status,
+        "command": command,
+        "output": output,
+    })
+
+summary = {
+    "total": len(checks),
+    "passed": int(pass_count),
+    "failed": int(fail_count),
+    "skipped": int(skip_count),
+}
+
+report = {
+    "number_of_failures": summary["failed"],
+    "status": "pass" if summary["failed"] == 0 else "fail",
+    "test": "dlopen_smoke",
+    "checks": checks,
+    "summary": summary,
+    "results": [],
+}
+
+if summary["failed"] > 0:
+    report["error"] = "dlopen smoke failed"
+
+pathlib.Path(report_path).write_text(json.dumps(report, ensure_ascii=True), encoding="utf-8")
+PY
+
+if [[ "${fail_count}" -eq 0 ]]; then
+  printf '%s\n' "dlopen smoke test: PASS (passed=${pass_count}, failed=${fail_count}, skipped=${skip_count})"
+  exit 0
+fi
+
+printf '%s\n' "dlopen smoke test: FAIL (passed=${pass_count}, failed=${fail_count}, skipped=${skip_count})" >&2
+awk -F'\t' '$2=="fail" {print "failed_check: " $1}' "${manifest_file}" >&2
+exit 1


### PR DESCRIPTION
## Add Dedicated `dlopen` Smoke Validation to Existing E2E Test Flow

### Why

We need explicit CI signal for dynamic library loading via `dlopen`, while keeping the current harness architecture stable.

The existing unit harness (`scripts/test_runner.py` + `scripts/harnesses/wasmtestreport.py`) is still the main path, but `dlopen` positive-path validation needs a two-phase compile sequence:

1. compile library with `--compile-library`
2. compile main binary
3. run main and verify it loaded the library successfully

### What Changed

- Added a dedicated script: `scripts/dlopen_smoke_test.sh`
- Integrated one call to it in the existing `make test` command chain
- Added `reports/dlopen.json` as a normal report artifact consumed by existing report checks
- Kept existing harness scripts unchanged

### How the `dlopen` Smoke Test Works

The script executes four explicit checks and logs each one in JSON:

1. `compile_library`
2. `compile_main`
3. `run_main`
4. `verify_output_substring`

For each check, the script records:

- `name`
- `status` (`pass`, `fail`, or `skipped`)
- `command`
- `output` (captured stdout/stderr or skip reason)

At the end it writes a summary:

- `summary.total`
- `summary.passed`
- `summary.failed`
- `summary.skipped`

Top-level status is reflected as:

- `status: pass|fail`
- `number_of_failures: <failed count>`

### Expected Success Condition

The smoke test is considered successful when:

- library compilation succeeds
- main compilation succeeds
- main execution succeeds
- runtime output contains:

`Hello, main module! (from shared library)`

### How It Folds into Existing `make test`

This is integrated directly into the current `Makefile` `test` target sequence:

1. run unified harness (`python3 ./scripts/test_runner.py --export-report report.html`)
2. run `./scripts/dlopen_smoke_test.sh`
3. continue with existing JSON scan + `scripts/check_reports.py`

This keeps behavior consistent with current E2E flow and avoids creating a separate CI path.

### CI / Buildx Behavior

No workflow-level changes are required.

The normal E2E build command still works and now includes the new signal:

```bash
docker buildx build \
  --platform linux/amd64 \
  --file Docker/Dockerfile.e2e \
  --tag e2e:latest \
  --output type=local,dest=test-reports \
  .
```

Artifacts now include:

- `test-reports/reports/dlopen.json`
- existing reports (`wasm.json`, `grates.json`, `report.html`, etc.)
