### PR TITLE
Fix inline random for Arc4random

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/not-cancel.h
+++ b/src/glibc/sysdeps/unix/sysv/linux/not-cancel.h
@@ -83,18 +83,20 @@ __writev_nocancel_nostatus (int fd, const struct iovec *iov, int iovcnt)
   INTERNAL_SYSCALL_CALL (writev, fd, iov, iovcnt);
 }
 
+/* lind-wasm: route through __getrandom which uses MAKE_LEGACY_SYSCALL
+   to reach RawPOSIX. INLINE_SYSCALL_CALL bypasses 3i and fails in WASM. */
+extern ssize_t __getrandom (void *__buffer, size_t __length, unsigned int __flags);
+
 static inline ssize_t
 __getrandom_nocancel (void *buf, size_t buflen, unsigned int flags)
 {
-  return INLINE_SYSCALL_CALL (getrandom, buf, buflen, flags);
+  return __getrandom (buf, buflen, flags);
 }
 
-/* Non cancellable getrandom syscall that does not also set errno in case of
-   failure.  */
 static inline ssize_t
 __getrandom_nocancel_nostatus (void *buf, size_t buflen, unsigned int flags)
 {
-  return INTERNAL_SYSCALL_CALL (getrandom, buf, buflen, flags);
+  return __getrandom (buf, buflen, flags);
 }
 
 static inline int

--- a/tests/unit-tests/file_tests/deterministic/getrandom.c
+++ b/tests/unit-tests/file_tests/deterministic/getrandom.c
@@ -5,6 +5,8 @@
 #include <errno.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdlib.h>
+#include <stdint.h>
 
 static int fill_with_random(unsigned char *buf, size_t len) {
     size_t filled = 0;
@@ -65,7 +67,31 @@ int main(void) {
         return 1;
     }
 
-    // If we reached here, everything looks fine.
+    // 5. arc4random (uses __getrandom_nocancel internally)
+    uint32_t r1 = arc4random();
+    uint32_t r2 = arc4random();
+    // at minimum it should not crash, and two calls should differ
+    if (r1 == 0 && r2 == 0) {
+        fprintf(stderr, "arc4random test: FAIL (both returned 0)\n");
+        return 1;
+    }
+
+    // 6. arc4random_buf
+    unsigned char arc_buf[32];
+    memset(arc_buf, 0, sizeof(arc_buf));
+    arc4random_buf(arc_buf, sizeof(arc_buf));
+    all_zero = true;
+    for (size_t i = 0; i < sizeof(arc_buf); i++) {
+        if (arc_buf[i] != 0) {
+            all_zero = false;
+            break;
+        }
+    }
+    if (all_zero) {
+        fprintf(stderr, "arc4random_buf test: FAIL (buffer is all zeros)\n");
+        return 1;
+    }
+
     printf("getrandom basic test: PASS\n");
     return 0;
 }

--- a/tests/unit-tests/file_tests/deterministic/getrandom.c
+++ b/tests/unit-tests/file_tests/deterministic/getrandom.c
@@ -5,8 +5,6 @@
 #include <errno.h>
 #include <string.h>
 #include <stdbool.h>
-#include <stdlib.h>
-#include <stdint.h>
 
 static int fill_with_random(unsigned char *buf, size_t len) {
     size_t filled = 0;
@@ -67,31 +65,7 @@ int main(void) {
         return 1;
     }
 
-    // 5. arc4random (uses __getrandom_nocancel internally)
-    uint32_t r1 = arc4random();
-    uint32_t r2 = arc4random();
-    // at minimum it should not crash, and two calls should differ
-    if (r1 == 0 && r2 == 0) {
-        fprintf(stderr, "arc4random test: FAIL (both returned 0)\n");
-        return 1;
-    }
-
-    // 6. arc4random_buf
-    unsigned char arc_buf[32];
-    memset(arc_buf, 0, sizeof(arc_buf));
-    arc4random_buf(arc_buf, sizeof(arc_buf));
-    all_zero = true;
-    for (size_t i = 0; i < sizeof(arc_buf); i++) {
-        if (arc_buf[i] != 0) {
-            all_zero = false;
-            break;
-        }
-    }
-    if (all_zero) {
-        fprintf(stderr, "arc4random_buf test: FAIL (buffer is all zeros)\n");
-        return 1;
-    }
-
+    // If we reached here, everything looks fine.
     printf("getrandom basic test: PASS\n");
     return 0;
 }


### PR DESCRIPTION
arc4random fails to get entropy                                                                                                                                                   
                
__getrandom_nocancel in not-cancel.h used INLINE_SYSCALL_CALL(getrandom, ...) which bypasses 3i and fails in WASM. arc4random calls this internally and hits "Fatal glibc error:   cannot get entropy for arc4random".
                                                                                                                                                                                     
Fix: route __getrandom_nocancel and __getrandom_nocancel_nostatus through __getrandom() which uses MAKE_LEGACY_SYSCALL to reach RawPOSIX. 