### PR TITLE
Undo resetting errno to 0 on successful calls.

### DIFF
--- a/src/glibc/lind_syscall/lind_syscall.c
+++ b/src/glibc/lind_syscall/lind_syscall.c
@@ -98,15 +98,14 @@ int make_threei_call (unsigned int callnumber,
     // multiple of pages (typically 4096) even when overflow, therefore we can distinguish
     // the errno and mmap result by simply checking if the return value is
     // within the valid errno range
+    //
+    // errno should only be 'set' and never 'unset'. i.e. successful calls should not set this to 0.
     if(ret < 0 && ret > -MAX_ERRNO)
     {
         errno = -ret;
         return -1;
     }
-    else
-    {
-        errno = 0;
-    }
+
     return ret;
 }
 


### PR DESCRIPTION
Currently, on successful syscall invocations, we reset errno back to 0, this is different to how linux handles this where errno only represents the last error that was recorded. 

Because of this change, if you run things like `perror("...")` or printf, the errno gets reset causing all sort of issues with error handling checks, specifically for grates.

This change ensures that errno is only set and never unset.