### PR TITLE
Fix signal rewind data underflow on fork

### DIFF
--- a/src/wasmtime/crates/wasmtime/src/runtime/store.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/store.rs
@@ -1426,12 +1426,15 @@ impl<'a, T> StoreContextMut<'a, T> {
 
     // get the current signal callstack information
     pub fn get_current_signal_rewind_data(&mut self) -> Option<SignalAsyncifyData> {
+        let length = self.0.signal_asyncify_data.len();
+        if length == 0 {
+            return None;
+        }
         let data = self
             .0
             .signal_asyncify_data
             .get(self.0.signal_asyncify_counter as usize)
             .cloned();
-        let length = self.0.signal_asyncify_data.len();
         if self.0.signal_asyncify_counter == (length - 1) as u64 {
             self.0.signal_asyncify_counter = 0;
         } else {


### PR DESCRIPTION
get_current_signal_rewind_data in store.rs:1435 computes length - 1 on the signal_asyncify_data vec length without checking for empty. When a forked child process receives an epoch  interrupt before any signal data has been pushed, the vec is empty and 0 - 1 overflows on usize.
                                                                                                                                                                                   
Fix: early return None when the vec is empty. The caller in signal.rs:59-61 already handles None correctly — it returns 0 and lets the non-signal rewind complete.
