### PR TITLE
Fix apply_GOT_relocs overflow by skipping non-GOT globals

### DIFF
--- a/src/wasmtime/crates/lind-utils/src/lib.rs
+++ b/src/wasmtime/crates/lind-utils/src/lib.rs
@@ -186,6 +186,11 @@ impl LindGOT {
         Some(cell.load(Ordering::Acquire))
     }
 
+    /// Check whether a symbol has a GOT entry (regardless of whether it is resolved).
+    pub fn has_entry(&self, name: &str) -> bool {
+        self.global_offset_table.contains_key(name)
+    }
+
     /// print unresolved symbols.
     ///
     /// Convention: a GOT cell value of 0 means "unresolved".

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -1110,6 +1110,11 @@ impl Instance {
             let got_inner = got.as_ref().unwrap();
             let memory_base = memory_base.unwrap();
             for (name, global) in globals {
+                // Only relocate globals that are actually registered in the GOT.
+                // Applying memory_base to an unrelated exported global would overflow.
+                if !got_inner.has_entry(&name) {
+                    continue;
+                }
                 let val = global.get(&mut store);
                 // relocate the variable
                 let val = val.i32().unwrap() as u32 + memory_base;

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -1486,6 +1486,11 @@ impl<T> Linker<T> {
                     }
                 }
                 for (name, global) in globals {
+                    // Only relocate globals that are actually registered in the GOT.
+                    // Applying memory_base to an unrelated exported global would overflow.
+                    if !got.has_entry(&name) {
+                        continue;
+                    }
                     // TODO: probably needs to skip if the symbol is internal symbols (e.g. epoch symbols)
                     let val = global.get(&mut store);
                     // relocate the variable


### PR DESCRIPTION
When iterating exported globals to apply relocations, only globals registered in the GOT should have memory_base added to their value. Applying memory_base to unrelated exported globals causes an overflow panic ("attempt to add with overflow") as their values are not module-relative data pointers.

Add LindGOT::has_entry() and guard the relocation arithmetic in both apply_GOT_relocs (instance.rs) and the equivalent loop in linker.rs.

Fixes #1042
