### PR TITLE
sync fdtables implementations and apply rustfmt

### DIFF
--- a/src/fdtables/src/dashmaparrayglobal.rs
+++ b/src/fdtables/src/dashmaparrayglobal.rs
@@ -1,4 +1,4 @@
-//  DashMap<u64,[Option<FDTableEntry>;FD_PER_PROCESSS_MAX]>  Space is ~24KB 
+//  DashMap<u64,[Option<FDTableEntry>;FD_PER_PROCESSS_MAX]>  Space is ~24KB
 //  per cage w/ 1024 fds?!?
 //      Static DashMap.  Let's see if having the FDTableEntries be a static
 //      array is any faster...
@@ -30,12 +30,12 @@ pub const ALGONAME: &str = "DashMapArrayGlobal";
 
 // We will raise a panic anywhere we receive an unknown cageid.  This frankly
 // should not be possible and indicates some sort of internal error in our
-// code.  However, other issues, such as an invalid file descriptor when a 
+// code.  However, other issues, such as an invalid file descriptor when a
 // cage makes a call, will be handled by returning the appropriate errno.
 
 // In order to store this information, I'm going to use a DashMap which
 // has keys of (cageid:u64) and values that are an array of FD_PER_PROCESS_MAX
-// Option<FDTableEntry> items. 
+// Option<FDTableEntry> items.
 //
 //
 
@@ -56,10 +56,10 @@ lazy_static! {
 
 lazy_static! {
     // This is needed for close and similar functionality.  I need track the
-    // number of times a (fdkind,underfd) is open.  Note that this is across 
-    // cages in order to enable a library to have  situations where two cages 
-    // have the same fd open.  The (fdkind,underfd) tuple is the key and the 
-    // number of times it appears is the value.  If it reaches 0, the entry 
+    // number of times a (fdkind,underfd) is open.  Note that this is across
+    // cages in order to enable a library to have  situations where two cages
+    // have the same fd open.  The (fdkind,underfd) tuple is the key and the
+    // number of times it appears is the value.  If it reaches 0, the entry
     // is removed.
     #[derive(Debug)]
     static ref FDCOUNT: DashMap<(u32,u64), u64> = {
@@ -75,19 +75,20 @@ pub fn check_cage_exists(cageid: u64) -> bool {
 
 #[doc = include_str!("../docs/init_empty_cage.md")]
 pub fn init_empty_cage(cageid: u64) {
+    assert!(!check_cage_exists(cageid), "Known cageid in fdtable access");
 
-    assert!(!check_cage_exists(cageid),"Known cageid in fdtable access");
-
-    FDTABLE.insert(cageid,[Option::None;FD_PER_PROCESS_MAX as usize]);
+    FDTABLE.insert(cageid, [Option::None; FD_PER_PROCESS_MAX as usize]);
 }
 
 #[doc = include_str!("../docs/translate_virtual_fd.md")]
 pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry, threei::RetVal> {
-
     // They should not be able to pass a new cage I don't know.  I should
     // always have a table for each cage because each new cage is added at fork
     // time
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
     // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
@@ -100,7 +101,6 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
         None => Err(threei::Errno::EBADFD as u64),
     };
 }
-
 
 // This is fairly slow if I just iterate sequentially through numbers.
 // However there are not that many to choose from.  I could pop from a list
@@ -117,8 +117,10 @@ pub fn get_unused_virtual_fd(
     should_cloexec: bool,
     perfdinfo: u64,
 ) -> Result<u64, threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
     // Set up the entry so it has the right info...
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
@@ -146,8 +148,8 @@ pub fn get_unused_virtual_fd(
     Err(threei::Errno::EMFILE as u64)
 }
 
-/// This is used to request an unused fd from specific starting position. This is 
-/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// This is used to request an unused fd from specific starting position. This is
+/// similar to `get_unused_virtual_fd` except this function starts from a specific
 /// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
 #[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
 pub fn get_unused_virtual_fd_from_startfd(
@@ -158,8 +160,10 @@ pub fn get_unused_virtual_fd_from_startfd(
     perfdinfo: u64,
     arg: u64,
 ) -> Result<u64, threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
     // Set up the entry so it has the right info...
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
@@ -198,14 +202,16 @@ pub fn get_specific_virtual_fd(
     should_cloexec: bool,
     perfdinfo: u64,
 ) -> Result<(), threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // If you ask for a FD number that is too large, I'm going to reject it.
     // Note that, I need to use the FD_PER_PROCESS_MAX setting because this
     // is also how I'm tracking how many values you have open.  If this
     // changed, then these constants could be decoupled...
-    if requested_virtualfd >= FD_PER_PROCESS_MAX {
+    if requested_virtualfd > FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADF as u64);
     }
 
@@ -239,27 +245,30 @@ pub fn get_specific_virtual_fd(
 // We're just setting a flag here, so this should be pretty straightforward.
 #[doc = include_str!("../docs/set_cloexec.md")]
 pub fn set_cloexec(cageid: u64, virtualfd: u64, is_cloexec: bool) -> Result<(), threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // return EBADFD, if the fd is missing...
     if FDTABLE.get(&cageid).unwrap()[virtualfd as usize].is_none() {
         return Err(threei::Errno::EBADFD as u64);
     }
     // Set the is_cloexec flag
-    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize].as_mut().unwrap().should_cloexec = is_cloexec;
+    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize]
+        .as_mut()
+        .unwrap()
+        .should_cloexec = is_cloexec;
     Ok(())
 }
 
 // We're setting an opaque value here. This should be pretty straightforward.
 #[doc = include_str!("../docs/set_perfdinfo.md")]
-pub fn set_perfdinfo(
-    cageid: u64,
-    virtualfd: u64,
-    perfdinfo: u64,
-) -> Result<(), threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn set_perfdinfo(cageid: u64, virtualfd: u64, perfdinfo: u64) -> Result<(), threei::RetVal> {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // return EBADFD, if the fd is missing...
     if FDTABLE.get(&cageid).unwrap()[virtualfd as usize].is_none() {
@@ -267,19 +276,27 @@ pub fn set_perfdinfo(
     }
 
     // Set optionalinfo or return EBADFD, if that's missing...
-    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize].as_mut().unwrap().perfdinfo = perfdinfo;
+    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize]
+        .as_mut()
+        .unwrap()
+        .perfdinfo = perfdinfo;
     Ok(())
 }
 
 // Helper function used for fork...  Copies an fdtable for another process
 #[doc = include_str!("../docs/copy_fdtable_for_cage.md")]
 pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), threei::Errno> {
-
-    assert!(check_cage_exists(srccageid),"Unknown cageid in fdtable access");
-    assert!(!check_cage_exists(newcageid),"Known cageid in fdtable access");
+    assert!(
+        check_cage_exists(srccageid),
+        "Unknown cageid in fdtable access"
+    );
+    assert!(
+        !check_cage_exists(newcageid),
+        "Known cageid in fdtable access"
+    );
 
     // Insert a copy and ensure it didn't exist...
-    // I've checked this should be a copy, not a ref to the same thing.  
+    // I've checked this should be a copy, not a ref to the same thing.
     let hmcopy = *FDTABLE.get(&srccageid).unwrap();
 
     // Increment copied items
@@ -290,7 +307,7 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
     }
 
     assert!(FDTABLE.insert(newcageid, hmcopy).is_none());
-    
+
     // I'm not going to bother to check the number of fds used overall yet...
     //    Err(threei::Errno::EMFILE as u64),
     Ok(())
@@ -300,7 +317,6 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
 // for the cage.
 #[doc = include_str!("../docs/remove_cage_from_fdtable.md")]
 pub fn remove_cage_from_fdtable(cageid: u64) {
-
     // In multi-cage (grate) scenarios, concurrent exit paths may race to
     // remove the same cage. If already removed, there's nothing to clean up.
     if let Some((_, myfdrow)) = FDTABLE.remove(&cageid) {
@@ -309,18 +325,19 @@ pub fn remove_cage_from_fdtable(cageid: u64) {
             _decrement_fdcount(entry);
         }
     }
-
 }
 
 // This removes all fds with the should_cloexec flag set.  They are returned
 // in a new hashmap...
 #[doc = include_str!("../docs/empty_fds_for_exec.md")]
 pub fn empty_fds_for_exec(cageid: u64) {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
-    // I need to call all the close handlers at the end.  So I need to 
+    // I need to call all the close handlers at the end.  So I need to
     // get vector of them to do the operation on...
     let mut closevec = Vec::new();
 
@@ -341,30 +358,29 @@ pub fn empty_fds_for_exec(cageid: u64) {
     for entry in closevec {
         _decrement_fdcount(entry);
     }
-
 }
 
-// Returns the HashMap returns a copy of the fdtable for a cage.  Useful 
+// Returns the HashMap returns a copy of the fdtable for a cage.  Useful
 // helper function for a caller that needs to examine the table.  Likely could
 // be more efficient by letting the caller borrow this...
 #[doc = include_str!("../docs/return_fdtable_copy.md")]
 #[must_use] // must use the return value if you call it.
 pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut myhashmap = HashMap::new();
 
     let myfdrow = FDTABLE.get(&cageid).unwrap();
     for item in 0..FD_PER_PROCESS_MAX as usize {
         if myfdrow[item].is_some() {
-            myhashmap.insert(item as u64,myfdrow[item].unwrap());
+            myhashmap.insert(item as u64, myfdrow[item].unwrap());
         }
     }
     myhashmap
 }
-
-
 
 /******************* CLOSE SPECIFIC FUNCTIONALITY *******************/
 
@@ -375,12 +391,11 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
 struct CloseHandlers {
     // Called when close is called, but at least one (fdkind,underfd)
     // reference still remains.  Called with (fdkind,underfd,count)
-    intermediate: fn(FDTableEntry,u64),
+    intermediate: fn(FDTableEntry, u64),
     // Called when close is called, but at least one (fdkind,underfd)
     // reference still remains. Called with (fdkind,underfd,0)
-    last: fn(FDTableEntry,u64),
+    last: fn(FDTableEntry, u64),
 }
-
 
 lazy_static! {
     // This holds the user registered handlers they want to have called when
@@ -392,52 +407,52 @@ lazy_static! {
     };
 }
 
-
 #[doc = include_str!("../docs/close_virtualfd.md")]
-pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
-
+pub fn close_virtualfd(cageid: u64, virtfd: u64) -> Result<(), threei::RetVal> {
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
 
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
-    // Mutate in place under the guard, extract the entry, then drop the
-    // guard before calling the close handler (which may re-enter fdtables).
-    let entry = {
-        let mut guard = FDTABLE.get_mut(&cageid).unwrap();
-        let entry = guard[virtfd as usize];
-        guard[virtfd as usize] = None;
-        entry
-        // guard drops here — lock released
-    };
+    // derefing this so I don't hold a lock and deadlock close handlers
+    let mut myfdrow = *FDTABLE.get_mut(&cageid).unwrap();
 
-    match entry {
-        Some(e) => {
-            _decrement_fdcount(e);
-            Ok(())
-        }
-        None => Err(threei::Errno::EBADFD as u64),
+    if myfdrow[virtfd as usize].is_some() {
+        let entry = myfdrow[virtfd as usize];
+
+        // Zero out this entry before calling the close handler...
+        myfdrow[virtfd as usize] = None;
+
+        // Re-insert the modified myfdrow since I've been modifying a copy
+        FDTABLE.insert(cageid, myfdrow.clone());
+
+        // always _decrement last as it may call the user handler...
+        _decrement_fdcount(entry.unwrap());
+        return Ok(());
     }
+    Err(threei::Errno::EBADFD as u64)
 }
-
 
 // Register a series of helpers to be called for close.  Can be called
 // multiple times to override the older helpers.
 #[doc = include_str!("../docs/register_close_handlers.md")]
-pub fn register_close_handlers(fdkind:u32, intermediate: fn(FDTableEntry,u64), last: fn(FDTableEntry,u64)) {
+pub fn register_close_handlers(
+    fdkind: u32,
+    intermediate: fn(FDTableEntry, u64),
+    last: fn(FDTableEntry, u64),
+) {
     // Unlock the table and set the handlers...
     let mut closehandlertable = CLOSEHANDLERTABLE.lock().unwrap();
-    let closehandler = CloseHandlers {
-        intermediate,
-        last,
-    };
+    let closehandler = CloseHandlers { intermediate, last };
     // overwrite whatever is in there...
-    closehandlertable.insert(fdkind,closehandler);
+    closehandlertable.insert(fdkind, closehandler);
 }
-
 
 // Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
@@ -496,30 +511,30 @@ fn _decrement_fdcount(entry: FDTableEntry) {
 
 // Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _increment_fdcount(entry:FDTableEntry) {
-
+fn _increment_fdcount(entry: FDTableEntry) {
     let mytuple = (entry.fdkind, entry.underfd);
 
-    // Atomic increment-or-insert via entry API to avoid race where two
-    // threads both see None and both insert 1.
-    *FDCOUNT.entry(mytuple).or_insert(0) += 1;
+    // Get a mutable reference to the entry so we can update it.
+    if let Some(mut count) = FDCOUNT.get_mut(&mytuple) {
+        *count += 1;
+    } else {
+        FDCOUNT.insert(mytuple, 1);
+    }
 }
-
-
 
 /***************   Code for handling select() ****************/
 
 use libc::fd_set;
-use std::collections::HashSet;
 use std::cmp;
+use std::collections::HashSet;
 use std::mem;
 
-// Helper to get an empty fd_set.  Helper function to isolate unsafe code, 
+// Helper to get an empty fd_set.  Helper function to isolate unsafe code,
 // etc.
 #[doc(hidden)]
 #[must_use] // must use the return value if you call it.
 pub fn _init_fd_set() -> fd_set {
-    let raw_fd_set:fd_set;
+    let raw_fd_set: fd_set;
     unsafe {
         let mut this_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
         libc::FD_ZERO(this_fd_set.as_mut_ptr());
@@ -529,28 +544,26 @@ pub fn _init_fd_set() -> fd_set {
 }
 
 #[doc(hidden)]
-pub fn _fd_set(fd:u64, thisfdset:&mut fd_set) {
-    unsafe{libc::FD_SET(fd as i32,thisfdset)}
+pub fn _fd_set(fd: u64, thisfdset: &mut fd_set) {
+    unsafe { libc::FD_SET(fd as i32, thisfdset) }
 }
 
 #[doc(hidden)]
 #[must_use] // must use the return value if you call it.
-pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
-    unsafe{libc::FD_ISSET(fd as i32,thisfdset)}
+pub fn _fd_isset(fd: u64, thisfdset: &fd_set) -> bool {
+    unsafe { libc::FD_ISSET(fd as i32, thisfdset) }
 }
-
-
 
 // This is a helper that just does a single type (r/w/e) and returns:
 //    bithashmap: HashMap<fdkind, (nfds, fd_set)>
 //    unhandledhashmap: HashMap<fdkind, HashSet<FDTableEntry>>
 //    mappingtable: HashMap<FDTableEntry, virt_fd>
-// 
+//
 // With this we trivially build the whole function...
 
-// helper to call before calling select beneath you.  Translates your virtfds 
+// helper to call before calling select beneath you.  Translates your virtfds
 // into a bitmask you may use for select.
-// See: https://man7.org/linux/man-pages/man2/select.2.html for details / 
+// See: https://man7.org/linux/man-pages/man2/select.2.html for details /
 // corner cases about the arguments.
 //
 
@@ -558,18 +571,32 @@ pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
 #[allow(clippy::type_complexity)]
 #[allow(clippy::implicit_hasher)]
 #[doc = include_str!("../docs/get_bitmask_for_select.md")]
-pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds:&HashSet<u32>) -> Result<(HashMap<u32,(u64, fd_set)>, HashMap<u32,HashSet<FDTableEntry>>, HashMap<(u32,u64),u64>),threei::RetVal> {
-    
+pub fn get_bitmask_for_select(
+    cageid: u64,
+    nfds: u64,
+    bits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        HashMap<u32, (u64, fd_set)>,
+        HashMap<u32, HashSet<FDTableEntry>>,
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
     if nfds >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EINVAL as u64);
     }
 
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // The three things I will return...
-    let mut retbittable:HashMap<u32,(u64,fd_set)> = HashMap::new();
-    let mut retunparsedtable:HashMap<u32,HashSet<FDTableEntry>> = HashMap::new();
-    let mut mappingtable:HashMap<(u32,u64),u64> = HashMap::new();
+    let mut retbittable: HashMap<u32, (u64, fd_set)> = HashMap::new();
+    let mut retunparsedtable: HashMap<u32, HashSet<FDTableEntry>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
 
     // If we were asked to do this on nothing, return empty mappings...
     if bits.is_none() {
@@ -579,7 +606,7 @@ pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds
     let infdset = bits.unwrap();
 
     // dashmaps are lockless, but usually I would grab a lock on the fdtable
-    // here...  
+    // here...
     let binding = FDTABLE.get(&cageid).unwrap();
     let myfdrow = *binding.value();
 
@@ -589,64 +616,74 @@ pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds
     // iterate through the set bits...
     for bit in 0..nfds as usize {
         let pos = bit as u64;
-        if _fd_isset(pos,&infdset) {
+        if _fd_isset(pos, &infdset) {
             if let Some(entry) = myfdrow[bit] {
-                
-                // I like to do the shorter case first rather than having 
+                // I like to do the shorter case first rather than having
                 // it later.
                 #[allow(clippy::if_not_else)]
                 // Which return set do I go in?
                 if !fdkinds.contains(&entry.fdkind) {
                     // Is unparsed...  Clippy's suggestion to insert if missing
                     retunparsedtable.entry(entry.fdkind).or_default();
-                    retunparsedtable.get_mut(&entry.fdkind).unwrap().insert(entry);
+                    retunparsedtable
+                        .get_mut(&entry.fdkind)
+                        .unwrap()
+                        .insert(entry);
                     // and update the mappingtable to have the bit from the
                     // original fd...
-                    mappingtable.insert((entry.fdkind,entry.underfd),pos);
-                }
-                else {
-
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+                } else {
                     let startingnfds;
                     let mut startingfdset;
 
                     // Either initialize it or use what exists
                     if retbittable.contains_key(&entry.fdkind) {
                         (startingnfds, startingfdset) = *retbittable.get(&entry.fdkind).unwrap();
-                    }
-                    else{
+                    } else {
                         startingnfds = 1;
                         // I don't init this above because a fd_set is a large
-                        // data structure and would be costly. 
+                        // data structure and would be costly.
                         startingfdset = _init_fd_set();
                     }
 
                     // Update the table and the nfds
-                    _fd_set(entry.underfd,&mut startingfdset);
-                    let newnfds = cmp::max(startingnfds, entry.underfd+1);
+                    _fd_set(entry.underfd, &mut startingfdset);
+                    let newnfds = cmp::max(startingnfds, entry.underfd + 1);
 
                     // and update the mappingtable to have the bit from the
                     // original fd...
-                    mappingtable.insert((entry.fdkind,entry.underfd),pos);
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
 
                     // insert the item
-                    retbittable.insert(entry.fdkind,(newnfds,startingfdset));
+                    retbittable.insert(entry.fdkind, (newnfds, startingfdset));
                 }
-            }
-            else {
+            } else {
                 return Err(threei::Errno::EBADF as u64);
             }
         }
     }
     Ok((retbittable, retunparsedtable, mappingtable))
-    
 }
-
 
 #[allow(clippy::type_complexity)]
 #[allow(clippy::implicit_hasher)]
 #[doc = include_str!("../docs/prepare_bitmasks_for_select.md")]
-pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, wbits:Option<fd_set>, ebits:Option<fd_set>, fdkinds:&HashSet<u32>) -> Result<([HashMap<u32,(u64, fd_set)>;3], [HashMap<u32,HashSet<FDTableEntry>>;3], HashMap<(u32,u64),u64>),threei::RetVal> {
-    // This is a pretty simple function.  Calls get_bitmask_for_select 
+pub fn prepare_bitmasks_for_select(
+    cageid: u64,
+    nfds: u64,
+    rbits: Option<fd_set>,
+    wbits: Option<fd_set>,
+    ebits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        [HashMap<u32, (u64, fd_set)>; 3],
+        [HashMap<u32, HashSet<FDTableEntry>>; 3],
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
+    // This is a pretty simple function.  Calls get_bitmask_for_select
     // repeatedly and combines the results...
     // [HashSet<(u64,u64)>;3]
 
@@ -659,12 +696,14 @@ pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, w
     mappingtable.extend(wresult.2);
     mappingtable.extend(eresult.2);
 
-    Ok(([rresult.0,wresult.0,eresult.0],[rresult.1,wresult.1,eresult.1],mappingtable))
-
+    Ok((
+        [rresult.0, wresult.0, eresult.0],
+        [rresult.1, wresult.1, eresult.1],
+        mappingtable,
+    ))
 }
 
-
-// helper to call after calling select beneath you.  returns the fd_set you 
+// helper to call after calling select beneath you.  returns the fd_set you
 // need for your return from a select call and the number of unique flags
 // set...
 
@@ -672,19 +711,28 @@ pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, w
 #[allow(clippy::implicit_hasher)]
 #[must_use] // must use the return value if you call it.
 #[doc = include_str!("../docs/get_one_virtual_bitmask_from_select_result.md")]
-pub fn get_one_virtual_bitmask_from_select_result(fdkind:u32, nfds:u64, bits:Option<fd_set>, unprocessedset:HashSet<u64>, startingbits:Option<fd_set>,mappingtable:&HashMap<(u32,u64),u64>) -> (u64, Option<fd_set>) {
-
+pub fn get_one_virtual_bitmask_from_select_result(
+    fdkind: u32,
+    nfds: u64,
+    bits: Option<fd_set>,
+    unprocessedset: HashSet<u64>,
+    startingbits: Option<fd_set>,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> (u64, Option<fd_set>) {
     // Note, I don't need the cage_id here because I have the mappingtable...
 
-    assert!(nfds < FD_PER_PROCESS_MAX,"This shouldn't be possible because we shouldn't have returned this previously");
+    assert!(
+        nfds < FD_PER_PROCESS_MAX,
+        "This shouldn't be possible because we shouldn't have returned this previously"
+    );
 
     let mut flagsset = 0;
 
     if bits.is_none() && unprocessedset.is_empty() {
-        return (flagsset,None);
+        return (flagsset, None);
     }
 
-    // I probably should pass a reference to startingbits to avoid copying the 
+    // I probably should pass a reference to startingbits to avoid copying the
     // bit structure...
     let mut retbits = match startingbits {
         Some(val) => val,
@@ -694,82 +742,93 @@ pub fn get_one_virtual_bitmask_from_select_result(fdkind:u32, nfds:u64, bits:Opt
     if let Some(inset) = bits {
         for bit in 0..nfds as usize {
             let pos = bit as u64;
-            if _fd_isset(pos,&inset)&& !_fd_isset(*mappingtable.get(&(fdkind,pos)).unwrap(),&retbits) {
-                flagsset+=1;
-                _fd_set(*mappingtable.get(&(fdkind,pos)).unwrap(),&mut retbits);
+            if _fd_isset(pos, &inset)
+                && !_fd_isset(*mappingtable.get(&(fdkind, pos)).unwrap(), &retbits)
+            {
+                flagsset += 1;
+                _fd_set(*mappingtable.get(&(fdkind, pos)).unwrap(), &mut retbits);
             }
         }
     }
     for virtfd in unprocessedset {
-        if !_fd_isset(virtfd,&retbits) {
-            flagsset+=1;
-            _fd_set(virtfd,&mut retbits);
+        if !_fd_isset(virtfd, &retbits) {
+            flagsset += 1;
+            _fd_set(virtfd, &mut retbits);
         }
     }
 
-    (flagsset,Some(retbits))
-
+    (flagsset, Some(retbits))
 }
-
-
 
 /********************** POLL SPECIFIC FUNCTIONS **********************/
 
-// helper to call before calling poll beneath you.  replaces the fds in 
+// helper to call before calling poll beneath you.  replaces the fds in
 // the poll struct with virtual versions and returns the items you need
 // to check yourself...
 #[allow(clippy::implicit_hasher)]
 #[allow(clippy::type_complexity)]
 #[doc = include_str!("../docs/convert_virtualfds_for_poll.md")]
 #[must_use] // must use the return value if you call it.
-pub fn convert_virtualfds_for_poll(cageid:u64, virtualfds:HashSet<u64>) -> (HashMap<u32,HashSet<(u64,FDTableEntry)>>, HashMap<(u32,u64),u64>) {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn convert_virtualfds_for_poll(
+    cageid: u64,
+    virtualfds: HashSet<u64>,
+) -> (
+    HashMap<u32, HashSet<(u64, FDTableEntry)>>,
+    HashMap<(u32, u64), u64>,
+) {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let thefdrow = *FDTABLE.get(&cageid).unwrap();
-    let mut mappingtable:HashMap<(u32,u64),u64> = HashMap::new();
-    let mut rethashmap:HashMap<u32,HashSet<(u64,FDTableEntry)>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
+    let mut rethashmap: HashMap<u32, HashSet<(u64, FDTableEntry)>> = HashMap::new();
 
-    
     // BUG?: I'm ignoring the fact that virtualfds can show up multiple times.
     // I'm not sure this actually matters, but I didn't think hard about it.
     for virtfd in virtualfds {
         if let Some(entry) = thefdrow[virtfd as usize] {
             // Insert an empty HashSet, if needed
             rethashmap.entry(entry.fdkind).or_default();
-            mappingtable.entry((entry.fdkind,entry.underfd)).or_default();
+            mappingtable
+                .entry((entry.fdkind, entry.underfd))
+                .or_default();
 
-            rethashmap.get_mut(&entry.fdkind).unwrap().insert((virtfd,entry));
-            mappingtable.insert((entry.fdkind,entry.underfd), virtfd);
-        }
-        else {
+            rethashmap
+                .get_mut(&entry.fdkind)
+                .unwrap()
+                .insert((virtfd, entry));
+            mappingtable.insert((entry.fdkind, entry.underfd), virtfd);
+        } else {
             let myentry = FDTableEntry {
-                fdkind:FDT_INVALID_FD,
-                underfd:virtfd,
-                should_cloexec:false,
-                perfdinfo:u64::from(FDT_INVALID_FD),
+                fdkind: FDT_INVALID_FD,
+                underfd: virtfd,
+                should_cloexec: false,
+                perfdinfo: u64::from(FDT_INVALID_FD),
             };
 
             // Insert an empty HashSet, if needed
             rethashmap.entry(FDT_INVALID_FD).or_default();
-            mappingtable.entry((FDT_INVALID_FD,virtfd)).or_default();
+            mappingtable.entry((FDT_INVALID_FD, virtfd)).or_default();
 
-            rethashmap.get_mut(&FDT_INVALID_FD).unwrap().insert((virtfd,myentry));
+            rethashmap
+                .get_mut(&FDT_INVALID_FD)
+                .unwrap()
+                .insert((virtfd, myentry));
             // Add this because they need to handle it if POLLNVAL is set.
             // An exception should not be raised!!!
 
             // I will add this to the mapping table, because I do think they
             // may want to raise an exception, etc. based upon this and signal
-            // back.  I am setting the underfd to be the virtfd, so I can 
+            // back.  I am setting the underfd to be the virtfd, so I can
             // reverse this process, if multiple entries like this occur.
-            mappingtable.insert((FDT_INVALID_FD,virtfd), virtfd);
+            mappingtable.insert((FDT_INVALID_FD, virtfd), virtfd);
         }
     }
 
     (rethashmap, mappingtable)
 }
-
-
 
 // helper to call after calling poll.  replaces the fds in the vector
 // with virtual ones...
@@ -777,60 +836,59 @@ pub fn convert_virtualfds_for_poll(cageid:u64, virtualfds:HashSet<u64>) -> (Hash
 // I give them the hashmap, so don't need flexibility in what they return...
 #[allow(clippy::implicit_hasher)]
 #[must_use] // must use the return value if you call it.
-pub fn convert_poll_result_back_to_virtual(fdkind:u32,underfd:u64, mappingtable:&HashMap<(u32,u64),u64>) -> Option<u64> {
-
+pub fn convert_poll_result_back_to_virtual(
+    fdkind: u32,
+    underfd: u64,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> Option<u64> {
     // I don't care what cage was used, and don't need to lock anything...
     // I have the mappingtable!
-    
+
     // Should this even be a function?
-    mappingtable.get(&(fdkind,underfd)).copied()
+    mappingtable.get(&(fdkind, underfd)).copied()
 }
-
-
 
 /********************** EPOLL SPECIFIC FUNCTIONS **********************/
 
-
-// Supporting epollfds is done by a fdkind which is not set by the user.  
+// Supporting epollfds is done by a fdkind which is not set by the user.
 // There are a few complexities here:
 // 1) an epollfd gets a virtual file descriptor
 // 2) a epollfd can point to any number of other fds of different kinds
 // 3) an epollfd can point to epollfds, which can point to other epollfds, etc.
 //    and possibly cause a loop to occur (which is an error)
-// 
+//
 // My thinking is this is handled as similarly to poll as possible.  We push
 // off the problem of understanding what the event types are to the implementer
 // of the library.
 //
-// In my view, epoll_wait() is quite simple to support.  One basically just 
-// keeps a list of virtual fds for this epollfd and their corresponding event 
+// In my view, epoll_wait() is quite simple to support.  One basically just
+// keeps a list of virtual fds for this epollfd and their corresponding event
 // types, which they may need to poll themselves.  After this, they handle the
 // call.
 //
-// epoll_ctl is complex, but really has the same fundamental problem as 
+// epoll_ctl is complex, but really has the same fundamental problem as
 // epoll_create: the epollfd.
 //
-// I'll create a new fdkind for epoll.  When epoll_create is called, the 
-// caller can decide which fdkinds need to be passed down to the underlying 
-// epoll_create call(s).  Similarly, when epoll_ctl is called, one either 
+// I'll create a new fdkind for epoll.  When epoll_create is called, the
+// caller can decide which fdkinds need to be passed down to the underlying
+// epoll_create call(s).  Similarly, when epoll_ctl is called, one either
 // handles the call internally or uses the underfd for the fdkind...
 //
 // Interestingly, this actually would be just as easy to build on top of the
-// fdtables library as into it.  
+// fdtables library as into it.
 //
 // Each epollfd will have some virtual fds associated with it.  Each of those
 // will have an event mask.  So I'll have a mutex around an EPollTable struct.
-// This contains the next available entry and an epollhashmap<virtfd, event>.  
+// This contains the next available entry and an epollhashmap<virtfd, event>.
 // I use a hashmap here to better support removing and modifying items.
 
 // Note, I'm defining a bunch of symbols myself because libc doesn't import
 // them on systems that don't support epoll and I want to be able to build
 // the code anywhere.  See commonconstants.rs for more info.
 
-
 // Okay, so the basic structure is like this:
-// 1) epoll_create_helper sets up an epollfd.  You will need to have a unique 
-// underfd for each fdkind below you, if you want to call down.   
+// 1) epoll_create_helper sets up an epollfd.  You will need to have a unique
+// underfd for each fdkind below you, if you want to call down.
 // 2) my API should track all of the fdkinds where there isn't an underlying
 // epollfd
 // 3) epoll_ctl / epoll_wait will work on whichever is appropriate
@@ -840,31 +898,29 @@ pub fn convert_poll_result_back_to_virtual(fdkind:u32,underfd:u64, mappingtable:
 //  HashMap<fdkind,HashMap<virtfd,epoll_event>> seems to make the most sense for the other
 //      descriptors.
 
-
 // a structure that exists for each epoll descriptor to track the underfd(s)
 // and parts the user will handle
 #[derive(Clone, Debug, Default)]
 struct EPollDescriptorInfo {
     // I didn't combine thewe two hashmaps into one because they are used
     // separately and the resulting value type would be too messy...
-
-    underfdhashmap: HashMap<u32,u64>, // The underfd for a specific fdkind.
-                                      // Used only when an epoll call will
-                                      // call down beneath it.
-    userhandledhashmap: HashMap<u32,HashMap<u64,epoll_event>>,
-                                      // This has all of the things the user
-                                      // will virtualize and handle.  The key
-                                      // is the fdkind.  
+    underfdhashmap: HashMap<u32, u64>, // The underfd for a specific fdkind.
+    // Used only when an epoll call will
+    // call down beneath it.
+    userhandledhashmap: HashMap<u32, HashMap<u64, epoll_event>>,
+    // This has all of the things the user
+    // will virtualize and handle.  The key
+    // is the fdkind.
 }
 
-// TODO: I don't clean up this table yet.  I probably should when the last 
+// TODO: I don't clean up this table yet.  I probably should when the last
 // reference to a fd is closed, but this bookkeeping seems excessive at this
 // time...
 #[derive(Clone, Debug)]
 struct EPollTable {
     highestneverusedentry: u64, // Never resets (even after close).  Used to
-                                // let us quickly get an unused entry
-    thisepolltable: HashMap<u64,EPollDescriptorInfo>, 
+    // let us quickly get an unused entry
+    thisepolltable: HashMap<u64, EPollDescriptorInfo>,
 }
 
 lazy_static! {
@@ -873,102 +929,128 @@ lazy_static! {
     static ref EPOLLTABLE: Mutex<EPollTable> = {
         let newetable = HashMap::new();
         let m = EPollTable {
-            highestneverusedentry:0, 
+            highestneverusedentry:0,
             thisepolltable:newetable,
         };
         Mutex::new(m)
     };
 }
 
-fn _get_epoll_entrynum_or_error(cageid:u64, epfd:u64) -> Result<u64,threei::RetVal> {
-    // Is the epfd ok? 
+fn _get_epoll_entrynum_or_error(cageid: u64, epfd: u64) -> Result<u64, threei::RetVal> {
+    // Is the epfd ok?
     match FDTABLE.get(&cageid).unwrap()[epfd as usize] {
-        None => {
-            Err(threei::Errno::EBADF as u64)
-        },
-        Some(tableentry) => { 
+        None => Err(threei::Errno::EBADF as u64),
+        Some(tableentry) => {
             // You must call this on an epoll fd
             if tableentry.fdkind == FDT_KINDEPOLL {
                 Ok(tableentry.underfd)
-            }
-            else {
+            } else {
                 Err(threei::Errno::EINVAL as u64)
             }
-        },
+        }
     }
 }
 
-
 #[doc = include_str!("../docs/epoll_create_empty.md")]
-pub fn epoll_create_empty(cageid:u64, should_cloexec:bool) -> Result<u64,threei::RetVal> {
-
+pub fn epoll_create_empty(cageid: u64, should_cloexec: bool) -> Result<u64, threei::RetVal> {
     let mut ept = EPOLLTABLE.lock().unwrap();
 
-    // return the same errno (EMFile), if we get one 
-    let newepollfd = get_unused_virtual_fd(cageid, FDT_KINDEPOLL, ept.highestneverusedentry, should_cloexec, 0)?;
+    // return the same errno (EMFile), if we get one
+    let newepollfd = get_unused_virtual_fd(
+        cageid,
+        FDT_KINDEPOLL,
+        ept.highestneverusedentry,
+        should_cloexec,
+        0,
+    )?;
 
     let newentrynum = ept.highestneverusedentry;
-    ept.highestneverusedentry+=1;
-    
+    ept.highestneverusedentry += 1;
+
     // Create a new entry with empty values
     ept.thisepolltable.entry(newentrynum).or_default();
     Ok(newepollfd)
-
 }
 
 #[doc = include_str!("../docs/epoll_add_underfd.md")]
-pub fn epoll_add_underfd(cageid:u64, virtepollfd:u64, fdkind:u32, underfd:u64) -> Result<(),threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn epoll_add_underfd(
+    cageid: u64,
+    virtepollfd: u64,
+    fdkind: u32,
+    underfd: u64,
+) -> Result<(), threei::RetVal> {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut ept = EPOLLTABLE.lock().unwrap();
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
 
-    let myhm = &mut ept.thisepolltable.get_mut(&epentrynum).unwrap().underfdhashmap;
+    let myhm = &mut ept
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .underfdhashmap;
 
-    assert!(!myhm.contains_key(&fdkind),"Adding duplicate underfd to epollfd");
-        
-    myhm.insert(fdkind,underfd);
+    assert!(
+        !myhm.contains_key(&fdkind),
+        "Adding duplicate underfd to epollfd"
+    );
+
+    myhm.insert(fdkind, underfd);
 
     Ok(())
-
 }
 
-
 #[doc = include_str!("../docs/epoll_get_underfd_hashmap.md")]
-pub fn epoll_get_underfd_hashmap(cageid:u64, virtepollfd:u64) -> Result<HashMap<u32,u64>,threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn epoll_get_underfd_hashmap(
+    cageid: u64,
+    virtepollfd: u64,
+) -> Result<HashMap<u32, u64>, threei::RetVal> {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let ept = EPOLLTABLE.lock().unwrap();
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
 
-    Ok(ept.thisepolltable.get(&epentrynum).unwrap().underfdhashmap.clone())
-
+    Ok(ept
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .underfdhashmap
+        .clone())
 }
 
-
-
 #[doc = include_str!("../docs/virtualize_epoll_ctl.md")]
-pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epoll_event) -> Result<(),threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn virtualize_epoll_ctl(
+    cageid: u64,
+    epfd: u64,
+    op: i32,
+    virtfd: u64,
+    event: epoll_event,
+) -> Result<(), threei::RetVal> {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     if epfd == virtfd {
         return Err(threei::Errno::EINVAL as u64);
     }
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, epfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, epfd)?;
 
     // Okay, I know which table entry, now verify the virtfd...
 
-
-    let virtfdkind:u32;
+    let virtfdkind: u32;
 
     if let Some(tableentry) = FDTABLE.get(&cageid).unwrap()[virtfd as usize] {
         // Right now, I don't support this, so error...
@@ -977,14 +1059,17 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             return Err(threei::Errno::ENOSYS as u64);
         }
         virtfdkind = tableentry.fdkind;
-    }
-    else {
+    } else {
         // The virtual Fd doesn't exist -- error...
         return Err(threei::Errno::EBADF as u64);
     }
 
     let mut eptable = EPOLLTABLE.lock().unwrap();
-    let userhm = &mut eptable.thisepolltable.get_mut(&epentrynum).unwrap().userhandledhashmap;
+    let userhm = &mut eptable
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .userhandledhashmap;
 
     match op {
         EPOLL_CTL_ADD => {
@@ -996,7 +1081,7 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             // referencing each other...
 
             thisuserhm.insert(virtfd, event);
-        },
+        }
         EPOLL_CTL_MOD => {
             if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
@@ -1006,7 +1091,7 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
                 return Err(threei::Errno::ENOENT as u64);
             }
             thisuserhm.insert(virtfd, event);
-        },
+        }
         EPOLL_CTL_DEL => {
             if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
@@ -1020,28 +1105,35 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             if thisuserhm.is_empty() {
                 userhm.remove(&virtfdkind);
             }
-        },
+        }
         _ => {
             return Err(threei::Errno::EINVAL as u64);
-        },
+        }
     };
     Ok(())
 }
 
-
 #[doc = include_str!("../docs/get_virtual_epoll_wait_data.md")]
-pub fn get_virtual_epoll_wait_data(cageid:u64, epfd:u64) -> Result<HashMap<u32,HashMap<u64,epoll_event>>,threei::RetVal> {
-
-    assert!(check_cage_exists(cageid),"Unknown cageid in fdtable access");
+pub fn get_virtual_epoll_wait_data(
+    cageid: u64,
+    epfd: u64,
+) -> Result<HashMap<u32, HashMap<u64, epoll_event>>, threei::RetVal> {
+    assert!(
+        check_cage_exists(cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, epfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, epfd)?;
 
     let eptable = EPOLLTABLE.lock().unwrap();
-    Ok(eptable.thisepolltable.get(&epentrynum).unwrap().userhandledhashmap.clone())
+    Ok(eptable
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .userhandledhashmap
+        .clone())
 }
-
-
 
 /********************** TESTING HELPER FUNCTION **********************/
 
@@ -1050,7 +1142,10 @@ pub fn get_virtual_epoll_wait_data(cageid:u64, epfd:u64) -> Result<HashMap<u32,H
 // This is only used in tests, thus is hidden...
 pub fn refresh() {
     FDTABLE.clear();
-    FDTABLE.insert(threei::TESTING_CAGEID,[Option::None;FD_PER_PROCESS_MAX as usize]);
+    FDTABLE.insert(
+        threei::TESTING_CAGEID,
+        [Option::None; FD_PER_PROCESS_MAX as usize],
+    );
     let mut closehandlers = CLOSEHANDLERTABLE.lock().unwrap_or_else(|e| {
         CLOSEHANDLERTABLE.clear_poison();
         e.into_inner()

--- a/src/fdtables/src/dashmapvecglobal.rs
+++ b/src/fdtables/src/dashmapvecglobal.rs
@@ -1,4 +1,4 @@
-//  DashMap<u64,vec![Option<FDTableEntry>;FD_PER_PROCESSS_MAX]>  Space is ~30KB 
+//  DashMap<u64,vec![Option<FDTableEntry>;FD_PER_PROCESSS_MAX]>  Space is ~30KB
 //  per cage w/ 1024 fds?!?
 //      Static DashMap.  Let's see if having the FDTableEntries be a Vector
 //      is any faster...
@@ -30,12 +30,12 @@ pub const ALGONAME: &str = "DashMapVecGlobal";
 
 // We will raise a panic anywhere we receive an unknown cageid.  This frankly
 // should not be possible and indicates some sort of internal error in our
-// code.  However, other issues, such as an invalid file descriptor when a 
+// code.  However, other issues, such as an invalid file descriptor when a
 // cage makes a call, will be handled by returning the appropriate errno.
 
 // In order to store this information, I'm going to use a DashMap which
 // has keys of (cageid:u64) and values that are an array of FD_PER_PROCESS_MAX
-// Option<FDTableEntry> items. 
+// Option<FDTableEntry> items.
 //
 //
 
@@ -56,10 +56,10 @@ lazy_static! {
 
 lazy_static! {
     // This is needed for close and similar functionality.  I need track the
-    // number of times a (fdkind,underfd) is open.  Note that this is across 
-    // cages in order to enable a library to have  situations where two cages 
-    // have the same fd open.  The (fdkind,underfd) tuple is the key and the 
-    // number of times it appears is the value.  If it reaches 0, the entry 
+    // number of times a (fdkind,underfd) is open.  Note that this is across
+    // cages in order to enable a library to have  situations where two cages
+    // have the same fd open.  The (fdkind,underfd) tuple is the key and the
+    // number of times it appears is the value.  If it reaches 0, the entry
     // is removed.
     #[derive(Debug)]
     static ref FDCOUNT: DashMap<(u32,u64), u64> = {
@@ -75,21 +75,25 @@ pub fn check_cage_exists(cageid: u64) -> bool {
 
 #[doc = include_str!("../docs/init_empty_cage.md")]
 pub fn init_empty_cage(cageid: u64) {
+    assert!(
+        !FDTABLE.contains_key(&cageid),
+        "Known cageid in fdtable access"
+    );
 
-    assert!(!FDTABLE.contains_key(&cageid),"Known cageid in fdtable access");
-
-    FDTABLE.insert(cageid,vec!(Option::None;FD_PER_PROCESS_MAX as usize));
+    FDTABLE.insert(cageid, vec![Option::None; FD_PER_PROCESS_MAX as usize]);
 }
 
 #[doc = include_str!("../docs/translate_virtual_fd.md")]
 pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry, threei::RetVal> {
-
     // They should not be able to pass a new cage I don't know.  I should
     // always have a table for each cage because each new cage is added at fork
     // time
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtualfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
@@ -99,7 +103,6 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry,
         None => Err(threei::Errno::EBADFD as u64),
     };
 }
-
 
 // This is fairly slow if I just iterate sequentially through numbers.
 // However there are not that many to choose from.  I could pop from a list
@@ -116,8 +119,10 @@ pub fn get_unused_virtual_fd(
     should_cloexec: bool,
     perfdinfo: u64,
 ) -> Result<u64, threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
     // Set up the entry so it has the right info...
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
@@ -145,8 +150,8 @@ pub fn get_unused_virtual_fd(
     Err(threei::Errno::EMFILE as u64)
 }
 
-/// This is used to request an unused fd from specific starting position. This is 
-/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// This is used to request an unused fd from specific starting position. This is
+/// similar to `get_unused_virtual_fd` except this function starts from a specific
 /// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
 #[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
 pub fn get_unused_virtual_fd_from_startfd(
@@ -157,8 +162,10 @@ pub fn get_unused_virtual_fd_from_startfd(
     perfdinfo: u64,
     arg: u64,
 ) -> Result<u64, threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
     // Set up the entry so it has the right info...
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
@@ -197,14 +204,16 @@ pub fn get_specific_virtual_fd(
     should_cloexec: bool,
     perfdinfo: u64,
 ) -> Result<(), threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // If you ask for a FD number that is too large, I'm going to reject it.
     // Note that, I need to use the FD_PER_PROCESS_MAX setting because this
     // is also how I'm tracking how many values you have open.  If this
     // changed, then these constants could be decoupled...
-    if requested_virtualfd >= FD_PER_PROCESS_MAX {
+    if requested_virtualfd > FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADF as u64);
     }
 
@@ -238,27 +247,30 @@ pub fn get_specific_virtual_fd(
 // We're just setting a flag here, so this should be pretty straightforward.
 #[doc = include_str!("../docs/set_cloexec.md")]
 pub fn set_cloexec(cageid: u64, virtualfd: u64, is_cloexec: bool) -> Result<(), threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // return EBADFD, if the fd is missing...
     if FDTABLE.get(&cageid).unwrap()[virtualfd as usize].is_none() {
         return Err(threei::Errno::EBADFD as u64);
     }
     // Set the is_cloexec flag
-    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize].as_mut().unwrap().should_cloexec = is_cloexec;
+    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize]
+        .as_mut()
+        .unwrap()
+        .should_cloexec = is_cloexec;
     Ok(())
 }
 
 // We're setting an opaque value here. This should be pretty straightforward.
 #[doc = include_str!("../docs/set_perfdinfo.md")]
-pub fn set_perfdinfo(
-    cageid: u64,
-    virtualfd: u64,
-    perfdinfo: u64,
-) -> Result<(), threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn set_perfdinfo(cageid: u64, virtualfd: u64, perfdinfo: u64) -> Result<(), threei::RetVal> {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // return EBADFD, if the fd is missing...
     if FDTABLE.get(&cageid).unwrap()[virtualfd as usize].is_none() {
@@ -266,16 +278,24 @@ pub fn set_perfdinfo(
     }
 
     // Set optionalinfo or return EBADFD, if that's missing...
-    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize].as_mut().unwrap().perfdinfo = perfdinfo;
+    FDTABLE.get_mut(&cageid).unwrap()[virtualfd as usize]
+        .as_mut()
+        .unwrap()
+        .perfdinfo = perfdinfo;
     Ok(())
 }
 
 // Helper function used for fork...  Copies an fdtable for another process
 #[doc = include_str!("../docs/copy_fdtable_for_cage.md")]
 pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), threei::Errno> {
-
-    assert!(FDTABLE.contains_key(&srccageid),"Unknown cageid in fdtable access");
-    assert!(!FDTABLE.contains_key(&newcageid),"Known cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&srccageid),
+        "Unknown cageid in fdtable access"
+    );
+    assert!(
+        !FDTABLE.contains_key(&newcageid),
+        "Known cageid in fdtable access"
+    );
 
     // Insert a copy and ensure it didn't exist...
     let hmcopy = FDTABLE.get(&srccageid).unwrap().clone();
@@ -288,7 +308,7 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
     }
 
     assert!(FDTABLE.insert(newcageid, hmcopy).is_none());
-    
+
     // I'm not going to bother to check the number of fds used overall yet...
     //    Err(threei::Errno::EMFILE as u64),
     Ok(())
@@ -298,7 +318,6 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
 // for the cage.
 #[doc = include_str!("../docs/remove_cage_from_fdtable.md")]
 pub fn remove_cage_from_fdtable(cageid: u64) {
-
     // In multi-cage (grate) scenarios, concurrent exit paths may race to
     // remove the same cage. If already removed, there's nothing to clean up.
     if let Some((_, myfdrow)) = FDTABLE.remove(&cageid) {
@@ -307,18 +326,19 @@ pub fn remove_cage_from_fdtable(cageid: u64) {
             _decrement_fdcount(entry);
         }
     }
-
 }
 
 // This removes all fds with the should_cloexec flag set.  They are returned
 // in a new hashmap...
 #[doc = include_str!("../docs/empty_fds_for_exec.md")]
 pub fn empty_fds_for_exec(cageid: u64) {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap();
-    // I need to call all the close handlers at the end.  So I need to 
+    // I need to call all the close handlers at the end.  So I need to
     // get vector of them to do the operation on...
     let mut closevec = Vec::new();
 
@@ -339,30 +359,29 @@ pub fn empty_fds_for_exec(cageid: u64) {
     for entry in closevec {
         _decrement_fdcount(entry);
     }
-
 }
 
-// Returns the HashMap returns a copy of the fdtable for a cage.  Useful 
+// Returns the HashMap returns a copy of the fdtable for a cage.  Useful
 // helper function for a caller that needs to examine the table.  Likely could
 // be more efficient by letting the caller borrow this...
 #[doc = include_str!("../docs/return_fdtable_copy.md")]
 #[must_use] // must use the return value if you call it.
 pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut myhashmap = HashMap::new();
 
     let myfdrow = FDTABLE.get(&cageid).unwrap();
     for item in 0..FD_PER_PROCESS_MAX as usize {
         if myfdrow[item].is_some() {
-            myhashmap.insert(item as u64,myfdrow[item].unwrap());
+            myhashmap.insert(item as u64, myfdrow[item].unwrap());
         }
     }
     myhashmap
 }
-
-
 
 /******************* CLOSE SPECIFIC FUNCTIONALITY *******************/
 
@@ -373,12 +392,11 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
 struct CloseHandlers {
     // Called when close is called, but at least one (fdkind,underfd)
     // reference still remains.  Called with (fdkind,underfd,count)
-    intermediate: fn(FDTableEntry,u64),
+    intermediate: fn(FDTableEntry, u64),
     // Called when close is called, but at least one (fdkind,underfd)
     // reference still remains. Called with (fdkind,underfd,0)
-    last: fn(FDTableEntry,u64),
+    last: fn(FDTableEntry, u64),
 }
-
 
 lazy_static! {
     // This holds the user registered handlers they want to have called when
@@ -390,52 +408,51 @@ lazy_static! {
     };
 }
 
-
 #[doc = include_str!("../docs/close_virtualfd.md")]
-pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
-
+pub fn close_virtualfd(cageid: u64, virtfd: u64) -> Result<(), threei::RetVal> {
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
 
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
-    // Mutate in place under the guard, extract the entry, then drop the
-    // guard before calling the close handler (which may re-enter fdtables).
-    let entry = {
-        let mut guard = FDTABLE.get_mut(&cageid).unwrap();
-        let entry = guard[virtfd as usize];
-        guard[virtfd as usize] = None;
-        entry
-        // guard drops here — lock released
-    };
+    // cloning this so I don't hold a lock and deadlock close handlers
+    let mut myfdrow = FDTABLE.get_mut(&cageid).unwrap().clone();
 
-    match entry {
-        Some(e) => {
-            _decrement_fdcount(e);
-            Ok(())
-        }
-        None => Err(threei::Errno::EBADFD as u64),
+    if myfdrow[virtfd as usize].is_some() {
+        let entry = myfdrow[virtfd as usize];
+
+        // Zero out this entry before calling the close handler...
+        myfdrow[virtfd as usize] = None;
+
+        FDTABLE.insert(cageid, myfdrow.clone());
+
+        // always _decrement last as it may call the user handler...
+        _decrement_fdcount(entry.unwrap());
+        return Ok(());
     }
+    Err(threei::Errno::EBADFD as u64)
 }
-
 
 // Register a series of helpers to be called for close.  Can be called
 // multiple times to override the older helpers.
 #[doc = include_str!("../docs/register_close_handlers.md")]
-pub fn register_close_handlers(fdkind:u32, intermediate: fn(FDTableEntry,u64), last: fn(FDTableEntry,u64)) {
+pub fn register_close_handlers(
+    fdkind: u32,
+    intermediate: fn(FDTableEntry, u64),
+    last: fn(FDTableEntry, u64),
+) {
     // Unlock the table and set the handlers...
     let mut closehandlertable = CLOSEHANDLERTABLE.lock().unwrap();
-    let closehandler = CloseHandlers {
-        intermediate,
-        last,
-    };
+    let closehandler = CloseHandlers { intermediate, last };
     // overwrite whatever is in there...
-    closehandlertable.insert(fdkind,closehandler);
+    closehandlertable.insert(fdkind, closehandler);
 }
-
 
 // Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
@@ -494,30 +511,30 @@ fn _decrement_fdcount(entry: FDTableEntry) {
 
 // Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _increment_fdcount(entry:FDTableEntry) {
-
+fn _increment_fdcount(entry: FDTableEntry) {
     let mytuple = (entry.fdkind, entry.underfd);
 
-    // Atomic increment-or-insert via entry API to avoid race where two
-    // threads both see None and both insert 1.
-    *FDCOUNT.entry(mytuple).or_insert(0) += 1;
+    // Get a mutable reference to the entry so we can update it.
+    if let Some(mut count) = FDCOUNT.get_mut(&mytuple) {
+        *count += 1;
+    } else {
+        FDCOUNT.insert(mytuple, 1);
+    }
 }
-
-
 
 /***************   Code for handling select() ****************/
 
 use libc::fd_set;
-use std::collections::HashSet;
 use std::cmp;
+use std::collections::HashSet;
 use std::mem;
 
-// Helper to get an empty fd_set.  Helper function to isolate unsafe code, 
+// Helper to get an empty fd_set.  Helper function to isolate unsafe code,
 // etc.
 #[doc(hidden)]
 #[must_use] // must use the return value if you call it.
 pub fn _init_fd_set() -> fd_set {
-    let raw_fd_set:fd_set;
+    let raw_fd_set: fd_set;
     unsafe {
         let mut this_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
         libc::FD_ZERO(this_fd_set.as_mut_ptr());
@@ -527,28 +544,26 @@ pub fn _init_fd_set() -> fd_set {
 }
 
 #[doc(hidden)]
-pub fn _fd_set(fd:u64, thisfdset:&mut fd_set) {
-    unsafe{libc::FD_SET(fd as i32,thisfdset)}
+pub fn _fd_set(fd: u64, thisfdset: &mut fd_set) {
+    unsafe { libc::FD_SET(fd as i32, thisfdset) }
 }
 
 #[doc(hidden)]
 #[must_use] // must use the return value if you call it.
-pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
-    unsafe{libc::FD_ISSET(fd as i32,thisfdset)}
+pub fn _fd_isset(fd: u64, thisfdset: &fd_set) -> bool {
+    unsafe { libc::FD_ISSET(fd as i32, thisfdset) }
 }
-
-
 
 // This is a helper that just does a single type (r/w/e) and returns:
 //    bithashmap: HashMap<fdkind, (nfds, fd_set)>
 //    unhandledhashmap: HashMap<fdkind, HashSet<FDTableEntry>>
 //    mappingtable: HashMap<FDTableEntry, virt_fd>
-// 
+//
 // With this we trivially build the whole function...
 
-// helper to call before calling select beneath you.  Translates your virtfds 
+// helper to call before calling select beneath you.  Translates your virtfds
 // into a bitmask you may use for select.
-// See: https://man7.org/linux/man-pages/man2/select.2.html for details / 
+// See: https://man7.org/linux/man-pages/man2/select.2.html for details /
 // corner cases about the arguments.
 //
 
@@ -556,18 +571,32 @@ pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
 #[allow(clippy::type_complexity)]
 #[allow(clippy::implicit_hasher)]
 #[doc = include_str!("../docs/get_bitmask_for_select.md")]
-pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds:&HashSet<u32>) -> Result<(HashMap<u32,(u64, fd_set)>, HashMap<u32,HashSet<FDTableEntry>>, HashMap<(u32,u64),u64>),threei::RetVal> {
-    
+pub fn get_bitmask_for_select(
+    cageid: u64,
+    nfds: u64,
+    bits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        HashMap<u32, (u64, fd_set)>,
+        HashMap<u32, HashSet<FDTableEntry>>,
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
     if nfds >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EINVAL as u64);
     }
 
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // The three things I will return...
-    let mut retbittable:HashMap<u32,(u64,fd_set)> = HashMap::new();
-    let mut retunparsedtable:HashMap<u32,HashSet<FDTableEntry>> = HashMap::new();
-    let mut mappingtable:HashMap<(u32,u64),u64> = HashMap::new();
+    let mut retbittable: HashMap<u32, (u64, fd_set)> = HashMap::new();
+    let mut retunparsedtable: HashMap<u32, HashSet<FDTableEntry>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
 
     // If we were asked to do this on nothing, return empty mappings...
     if bits.is_none() {
@@ -577,7 +606,7 @@ pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds
     let infdset = bits.unwrap();
 
     // dashmaps are lockless, but usually I would grab a lock on the fdtable
-    // here...  
+    // here...
     let binding = FDTABLE.get(&cageid).unwrap();
     let myfdrow = binding.value().clone();
 
@@ -587,64 +616,74 @@ pub fn get_bitmask_for_select(cageid:u64, nfds:u64, bits:Option<fd_set>, fdkinds
     // iterate through the set bits...
     for bit in 0..nfds as usize {
         let pos = bit as u64;
-        if _fd_isset(pos,&infdset) {
+        if _fd_isset(pos, &infdset) {
             if let Some(entry) = myfdrow[bit] {
-                
-                // I like to do the shorter case first rather than having 
+                // I like to do the shorter case first rather than having
                 // it later.
                 #[allow(clippy::if_not_else)]
                 // Which return set do I go in?
                 if !fdkinds.contains(&entry.fdkind) {
                     // Is unparsed...  Clippy's suggestion to insert if missing
                     retunparsedtable.entry(entry.fdkind).or_default();
-                    retunparsedtable.get_mut(&entry.fdkind).unwrap().insert(entry);
+                    retunparsedtable
+                        .get_mut(&entry.fdkind)
+                        .unwrap()
+                        .insert(entry);
                     // and update the mappingtable to have the bit from the
                     // original fd...
-                    mappingtable.insert((entry.fdkind,entry.underfd),pos);
-                }
-                else {
-
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+                } else {
                     let startingnfds;
                     let mut startingfdset;
 
                     // Either initialize it or use what exists
                     if retbittable.contains_key(&entry.fdkind) {
                         (startingnfds, startingfdset) = *retbittable.get(&entry.fdkind).unwrap();
-                    }
-                    else{
+                    } else {
                         startingnfds = 1;
                         // I don't init this above because a fd_set is a large
-                        // data structure and would be costly. 
+                        // data structure and would be costly.
                         startingfdset = _init_fd_set();
                     }
 
                     // Update the table and the nfds
-                    _fd_set(entry.underfd,&mut startingfdset);
-                    let newnfds = cmp::max(startingnfds, entry.underfd+1);
+                    _fd_set(entry.underfd, &mut startingfdset);
+                    let newnfds = cmp::max(startingnfds, entry.underfd + 1);
 
                     // and update the mappingtable to have the bit from the
                     // original fd...
-                    mappingtable.insert((entry.fdkind,entry.underfd),pos);
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
 
                     // insert the item
-                    retbittable.insert(entry.fdkind,(newnfds,startingfdset));
+                    retbittable.insert(entry.fdkind, (newnfds, startingfdset));
                 }
-            }
-            else {
+            } else {
                 return Err(threei::Errno::EBADF as u64);
             }
         }
     }
     Ok((retbittable, retunparsedtable, mappingtable))
-    
 }
-
 
 #[allow(clippy::type_complexity)]
 #[allow(clippy::implicit_hasher)]
 #[doc = include_str!("../docs/prepare_bitmasks_for_select.md")]
-pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, wbits:Option<fd_set>, ebits:Option<fd_set>, fdkinds:&HashSet<u32>) -> Result<([HashMap<u32,(u64, fd_set)>;3], [HashMap<u32,HashSet<FDTableEntry>>;3], HashMap<(u32,u64),u64>),threei::RetVal> {
-    // This is a pretty simple function.  Calls get_bitmask_for_select 
+pub fn prepare_bitmasks_for_select(
+    cageid: u64,
+    nfds: u64,
+    rbits: Option<fd_set>,
+    wbits: Option<fd_set>,
+    ebits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        [HashMap<u32, (u64, fd_set)>; 3],
+        [HashMap<u32, HashSet<FDTableEntry>>; 3],
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
+    // This is a pretty simple function.  Calls get_bitmask_for_select
     // repeatedly and combines the results...
     // [HashSet<(u64,u64)>;3]
 
@@ -657,12 +696,14 @@ pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, w
     mappingtable.extend(wresult.2);
     mappingtable.extend(eresult.2);
 
-    Ok(([rresult.0,wresult.0,eresult.0],[rresult.1,wresult.1,eresult.1],mappingtable))
-
+    Ok((
+        [rresult.0, wresult.0, eresult.0],
+        [rresult.1, wresult.1, eresult.1],
+        mappingtable,
+    ))
 }
 
-
-// helper to call after calling select beneath you.  returns the fd_set you 
+// helper to call after calling select beneath you.  returns the fd_set you
 // need for your return from a select call and the number of unique flags
 // set...
 
@@ -670,19 +711,28 @@ pub fn prepare_bitmasks_for_select(cageid:u64, nfds:u64, rbits:Option<fd_set>, w
 #[allow(clippy::implicit_hasher)]
 #[must_use] // must use the return value if you call it.
 #[doc = include_str!("../docs/get_one_virtual_bitmask_from_select_result.md")]
-pub fn get_one_virtual_bitmask_from_select_result(fdkind:u32, nfds:u64, bits:Option<fd_set>, unprocessedset:HashSet<u64>, startingbits:Option<fd_set>,mappingtable:&HashMap<(u32,u64),u64>) -> (u64, Option<fd_set>) {
-
+pub fn get_one_virtual_bitmask_from_select_result(
+    fdkind: u32,
+    nfds: u64,
+    bits: Option<fd_set>,
+    unprocessedset: HashSet<u64>,
+    startingbits: Option<fd_set>,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> (u64, Option<fd_set>) {
     // Note, I don't need the cage_id here because I have the mappingtable...
 
-    assert!(nfds < FD_PER_PROCESS_MAX,"This shouldn't be possible because we shouldn't have returned this previously");
+    assert!(
+        nfds < FD_PER_PROCESS_MAX,
+        "This shouldn't be possible because we shouldn't have returned this previously"
+    );
 
     let mut flagsset = 0;
 
     if bits.is_none() && unprocessedset.is_empty() {
-        return (flagsset,None);
+        return (flagsset, None);
     }
 
-    // I probably should pass a reference to startingbits to avoid copying the 
+    // I probably should pass a reference to startingbits to avoid copying the
     // bit structure...
     let mut retbits = match startingbits {
         Some(val) => val,
@@ -692,82 +742,93 @@ pub fn get_one_virtual_bitmask_from_select_result(fdkind:u32, nfds:u64, bits:Opt
     if let Some(inset) = bits {
         for bit in 0..nfds as usize {
             let pos = bit as u64;
-            if _fd_isset(pos,&inset)&& !_fd_isset(*mappingtable.get(&(fdkind,pos)).unwrap(),&retbits) {
-                flagsset+=1;
-                _fd_set(*mappingtable.get(&(fdkind,pos)).unwrap(),&mut retbits);
+            if _fd_isset(pos, &inset)
+                && !_fd_isset(*mappingtable.get(&(fdkind, pos)).unwrap(), &retbits)
+            {
+                flagsset += 1;
+                _fd_set(*mappingtable.get(&(fdkind, pos)).unwrap(), &mut retbits);
             }
         }
     }
     for virtfd in unprocessedset {
-        if !_fd_isset(virtfd,&retbits) {
-            flagsset+=1;
-            _fd_set(virtfd,&mut retbits);
+        if !_fd_isset(virtfd, &retbits) {
+            flagsset += 1;
+            _fd_set(virtfd, &mut retbits);
         }
     }
 
-    (flagsset,Some(retbits))
-
+    (flagsset, Some(retbits))
 }
-
-
 
 /********************** POLL SPECIFIC FUNCTIONS **********************/
 
-// helper to call before calling poll beneath you.  replaces the fds in 
+// helper to call before calling poll beneath you.  replaces the fds in
 // the poll struct with virtual versions and returns the items you need
 // to check yourself...
 #[allow(clippy::implicit_hasher)]
 #[allow(clippy::type_complexity)]
 #[doc = include_str!("../docs/convert_virtualfds_for_poll.md")]
 #[must_use] // must use the return value if you call it.
-pub fn convert_virtualfds_for_poll(cageid:u64, virtualfds:HashSet<u64>) -> (HashMap<u32,HashSet<(u64,FDTableEntry)>>, HashMap<(u32,u64),u64>) {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn convert_virtualfds_for_poll(
+    cageid: u64,
+    virtualfds: HashSet<u64>,
+) -> (
+    HashMap<u32, HashSet<(u64, FDTableEntry)>>,
+    HashMap<(u32, u64), u64>,
+) {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let thefdrow = FDTABLE.get(&cageid).unwrap().clone();
-    let mut mappingtable:HashMap<(u32,u64),u64> = HashMap::new();
-    let mut rethashmap:HashMap<u32,HashSet<(u64,FDTableEntry)>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
+    let mut rethashmap: HashMap<u32, HashSet<(u64, FDTableEntry)>> = HashMap::new();
 
-    
     // BUG?: I'm ignoring the fact that virtualfds can show up multiple times.
     // I'm not sure this actually matters, but I didn't think hard about it.
     for virtfd in virtualfds {
         if let Some(entry) = thefdrow[virtfd as usize] {
             // Insert an empty HashSet, if needed
             rethashmap.entry(entry.fdkind).or_default();
-            mappingtable.entry((entry.fdkind,entry.underfd)).or_default();
+            mappingtable
+                .entry((entry.fdkind, entry.underfd))
+                .or_default();
 
-            rethashmap.get_mut(&entry.fdkind).unwrap().insert((virtfd,entry));
-            mappingtable.insert((entry.fdkind,entry.underfd), virtfd);
-        }
-        else {
+            rethashmap
+                .get_mut(&entry.fdkind)
+                .unwrap()
+                .insert((virtfd, entry));
+            mappingtable.insert((entry.fdkind, entry.underfd), virtfd);
+        } else {
             let myentry = FDTableEntry {
-                fdkind:FDT_INVALID_FD,
-                underfd:virtfd,
-                should_cloexec:false,
-                perfdinfo:u64::from(FDT_INVALID_FD),
+                fdkind: FDT_INVALID_FD,
+                underfd: virtfd,
+                should_cloexec: false,
+                perfdinfo: u64::from(FDT_INVALID_FD),
             };
 
             // Insert an empty HashSet, if needed
             rethashmap.entry(FDT_INVALID_FD).or_default();
-            mappingtable.entry((FDT_INVALID_FD,virtfd)).or_default();
+            mappingtable.entry((FDT_INVALID_FD, virtfd)).or_default();
 
-            rethashmap.get_mut(&FDT_INVALID_FD).unwrap().insert((virtfd,myentry));
+            rethashmap
+                .get_mut(&FDT_INVALID_FD)
+                .unwrap()
+                .insert((virtfd, myentry));
             // Add this because they need to handle it if POLLNVAL is set.
             // An exception should not be raised!!!
 
             // I will add this to the mapping table, because I do think they
             // may want to raise an exception, etc. based upon this and signal
-            // back.  I am setting the underfd to be the virtfd, so I can 
+            // back.  I am setting the underfd to be the virtfd, so I can
             // reverse this process, if multiple entries like this occur.
-            mappingtable.insert((FDT_INVALID_FD,virtfd), virtfd);
+            mappingtable.insert((FDT_INVALID_FD, virtfd), virtfd);
         }
     }
 
     (rethashmap, mappingtable)
 }
-
-
 
 // helper to call after calling poll.  replaces the fds in the vector
 // with virtual ones...
@@ -775,60 +836,59 @@ pub fn convert_virtualfds_for_poll(cageid:u64, virtualfds:HashSet<u64>) -> (Hash
 // I give them the hashmap, so don't need flexibility in what they return...
 #[allow(clippy::implicit_hasher)]
 #[must_use] // must use the return value if you call it.
-pub fn convert_poll_result_back_to_virtual(fdkind:u32,underfd:u64, mappingtable:&HashMap<(u32,u64),u64>) -> Option<u64> {
-
+pub fn convert_poll_result_back_to_virtual(
+    fdkind: u32,
+    underfd: u64,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> Option<u64> {
     // I don't care what cage was used, and don't need to lock anything...
     // I have the mappingtable!
-    
+
     // Should this even be a function?
-    mappingtable.get(&(fdkind,underfd)).copied()
+    mappingtable.get(&(fdkind, underfd)).copied()
 }
-
-
 
 /********************** EPOLL SPECIFIC FUNCTIONS **********************/
 
-
-// Supporting epollfds is done by a fdkind which is not set by the user.  
+// Supporting epollfds is done by a fdkind which is not set by the user.
 // There are a few complexities here:
 // 1) an epollfd gets a virtual file descriptor
 // 2) a epollfd can point to any number of other fds of different kinds
 // 3) an epollfd can point to epollfds, which can point to other epollfds, etc.
 //    and possibly cause a loop to occur (which is an error)
-// 
+//
 // My thinking is this is handled as similarly to poll as possible.  We push
 // off the problem of understanding what the event types are to the implementer
 // of the library.
 //
-// In my view, epoll_wait() is quite simple to support.  One basically just 
-// keeps a list of virtual fds for this epollfd and their corresponding event 
+// In my view, epoll_wait() is quite simple to support.  One basically just
+// keeps a list of virtual fds for this epollfd and their corresponding event
 // types, which they may need to poll themselves.  After this, they handle the
 // call.
 //
-// epoll_ctl is complex, but really has the same fundamental problem as 
+// epoll_ctl is complex, but really has the same fundamental problem as
 // epoll_create: the epollfd.
 //
-// I'll create a new fdkind for epoll.  When epoll_create is called, the 
-// caller can decide which fdkinds need to be passed down to the underlying 
-// epoll_create call(s).  Similarly, when epoll_ctl is called, one either 
+// I'll create a new fdkind for epoll.  When epoll_create is called, the
+// caller can decide which fdkinds need to be passed down to the underlying
+// epoll_create call(s).  Similarly, when epoll_ctl is called, one either
 // handles the call internally or uses the underfd for the fdkind...
 //
 // Interestingly, this actually would be just as easy to build on top of the
-// fdtables library as into it.  
+// fdtables library as into it.
 //
 // Each epollfd will have some virtual fds associated with it.  Each of those
 // will have an event mask.  So I'll have a mutex around an EPollTable struct.
-// This contains the next available entry and an epollhashmap<virtfd, event>.  
+// This contains the next available entry and an epollhashmap<virtfd, event>.
 // I use a hashmap here to better support removing and modifying items.
 
 // Note, I'm defining a bunch of symbols myself because libc doesn't import
 // them on systems that don't support epoll and I want to be able to build
 // the code anywhere.  See commonconstants.rs for more info.
 
-
 // Okay, so the basic structure is like this:
-// 1) epoll_create_helper sets up an epollfd.  You will need to have a unique 
-// underfd for each fdkind below you, if you want to call down.   
+// 1) epoll_create_helper sets up an epollfd.  You will need to have a unique
+// underfd for each fdkind below you, if you want to call down.
 // 2) my API should track all of the fdkinds where there isn't an underlying
 // epollfd
 // 3) epoll_ctl / epoll_wait will work on whichever is appropriate
@@ -838,31 +898,29 @@ pub fn convert_poll_result_back_to_virtual(fdkind:u32,underfd:u64, mappingtable:
 //  HashMap<fdkind,HashMap<virtfd,epoll_event>> seems to make the most sense for the other
 //      descriptors.
 
-
 // a structure that exists for each epoll descriptor to track the underfd(s)
 // and parts the user will handle
 #[derive(Clone, Debug, Default)]
 struct EPollDescriptorInfo {
     // I didn't combine thewe two hashmaps into one because they are used
     // separately and the resulting value type would be too messy...
-
-    underfdhashmap: HashMap<u32,u64>, // The underfd for a specific fdkind.
-                                      // Used only when an epoll call will
-                                      // call down beneath it.
-    userhandledhashmap: HashMap<u32,HashMap<u64,epoll_event>>,
-                                      // This has all of the things the user
-                                      // will virtualize and handle.  The key
-                                      // is the fdkind.  
+    underfdhashmap: HashMap<u32, u64>, // The underfd for a specific fdkind.
+    // Used only when an epoll call will
+    // call down beneath it.
+    userhandledhashmap: HashMap<u32, HashMap<u64, epoll_event>>,
+    // This has all of the things the user
+    // will virtualize and handle.  The key
+    // is the fdkind.
 }
 
-// TODO: I don't clean up this table yet.  I probably should when the last 
+// TODO: I don't clean up this table yet.  I probably should when the last
 // reference to a fd is closed, but this bookkeeping seems excessive at this
 // time...
 #[derive(Clone, Debug)]
 struct EPollTable {
     highestneverusedentry: u64, // Never resets (even after close).  Used to
-                                // let us quickly get an unused entry
-    thisepolltable: HashMap<u64,EPollDescriptorInfo>, 
+    // let us quickly get an unused entry
+    thisepolltable: HashMap<u64, EPollDescriptorInfo>,
 }
 
 lazy_static! {
@@ -871,102 +929,128 @@ lazy_static! {
     static ref EPOLLTABLE: Mutex<EPollTable> = {
         let newetable = HashMap::new();
         let m = EPollTable {
-            highestneverusedentry:0, 
+            highestneverusedentry:0,
             thisepolltable:newetable,
         };
         Mutex::new(m)
     };
 }
 
-fn _get_epoll_entrynum_or_error(cageid:u64, epfd:u64) -> Result<u64,threei::RetVal> {
-    // Is the epfd ok? 
+fn _get_epoll_entrynum_or_error(cageid: u64, epfd: u64) -> Result<u64, threei::RetVal> {
+    // Is the epfd ok?
     match FDTABLE.get(&cageid).unwrap()[epfd as usize] {
-        None => {
-            Err(threei::Errno::EBADF as u64)
-        },
-        Some(tableentry) => { 
+        None => Err(threei::Errno::EBADF as u64),
+        Some(tableentry) => {
             // You must call this on an epoll fd
             if tableentry.fdkind == FDT_KINDEPOLL {
                 Ok(tableentry.underfd)
-            }
-            else {
+            } else {
                 Err(threei::Errno::EINVAL as u64)
             }
-        },
+        }
     }
 }
 
-
 #[doc = include_str!("../docs/epoll_create_empty.md")]
-pub fn epoll_create_empty(cageid:u64, should_cloexec:bool) -> Result<u64,threei::RetVal> {
-
+pub fn epoll_create_empty(cageid: u64, should_cloexec: bool) -> Result<u64, threei::RetVal> {
     let mut ept = EPOLLTABLE.lock().unwrap();
 
-    // return the same errno (EMFile), if we get one 
-    let newepollfd = get_unused_virtual_fd(cageid, FDT_KINDEPOLL, ept.highestneverusedentry, should_cloexec, 0)?;
+    // return the same errno (EMFile), if we get one
+    let newepollfd = get_unused_virtual_fd(
+        cageid,
+        FDT_KINDEPOLL,
+        ept.highestneverusedentry,
+        should_cloexec,
+        0,
+    )?;
 
     let newentrynum = ept.highestneverusedentry;
-    ept.highestneverusedentry+=1;
-    
+    ept.highestneverusedentry += 1;
+
     // Create a new entry with empty values
     ept.thisepolltable.entry(newentrynum).or_default();
     Ok(newepollfd)
-
 }
 
 #[doc = include_str!("../docs/epoll_add_underfd.md")]
-pub fn epoll_add_underfd(cageid:u64, virtepollfd:u64, fdkind:u32, underfd:u64) -> Result<(),threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn epoll_add_underfd(
+    cageid: u64,
+    virtepollfd: u64,
+    fdkind: u32,
+    underfd: u64,
+) -> Result<(), threei::RetVal> {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let mut ept = EPOLLTABLE.lock().unwrap();
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
 
-    let myhm = &mut ept.thisepolltable.get_mut(&epentrynum).unwrap().underfdhashmap;
+    let myhm = &mut ept
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .underfdhashmap;
 
-    assert!(!myhm.contains_key(&fdkind),"Adding duplicate underfd to epollfd");
-        
-    myhm.insert(fdkind,underfd);
+    assert!(
+        !myhm.contains_key(&fdkind),
+        "Adding duplicate underfd to epollfd"
+    );
+
+    myhm.insert(fdkind, underfd);
 
     Ok(())
-
 }
 
-
 #[doc = include_str!("../docs/epoll_get_underfd_hashmap.md")]
-pub fn epoll_get_underfd_hashmap(cageid:u64, virtepollfd:u64) -> Result<HashMap<u32,u64>,threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn epoll_get_underfd_hashmap(
+    cageid: u64,
+    virtepollfd: u64,
+) -> Result<HashMap<u32, u64>, threei::RetVal> {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     let ept = EPOLLTABLE.lock().unwrap();
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, virtepollfd)?;
 
-    Ok(ept.thisepolltable.get(&epentrynum).unwrap().underfdhashmap.clone())
-
+    Ok(ept
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .underfdhashmap
+        .clone())
 }
 
-
-
 #[doc = include_str!("../docs/virtualize_epoll_ctl.md")]
-pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epoll_event) -> Result<(),threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn virtualize_epoll_ctl(
+    cageid: u64,
+    epfd: u64,
+    op: i32,
+    virtfd: u64,
+    event: epoll_event,
+) -> Result<(), threei::RetVal> {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     if epfd == virtfd {
         return Err(threei::Errno::EINVAL as u64);
     }
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, epfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, epfd)?;
 
     // Okay, I know which table entry, now verify the virtfd...
 
-
-    let virtfdkind:u32;
+    let virtfdkind: u32;
 
     if let Some(tableentry) = FDTABLE.get(&cageid).unwrap()[virtfd as usize] {
         // Right now, I don't support this, so error...
@@ -975,14 +1059,17 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             return Err(threei::Errno::ENOSYS as u64);
         }
         virtfdkind = tableentry.fdkind;
-    }
-    else {
+    } else {
         // The virtual Fd doesn't exist -- error...
         return Err(threei::Errno::EBADF as u64);
     }
 
     let mut eptable = EPOLLTABLE.lock().unwrap();
-    let userhm = &mut eptable.thisepolltable.get_mut(&epentrynum).unwrap().userhandledhashmap;
+    let userhm = &mut eptable
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .userhandledhashmap;
 
     match op {
         EPOLL_CTL_ADD => {
@@ -994,7 +1081,7 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             // referencing each other...
 
             thisuserhm.insert(virtfd, event);
-        },
+        }
         EPOLL_CTL_MOD => {
             if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
@@ -1004,7 +1091,7 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
                 return Err(threei::Errno::ENOENT as u64);
             }
             thisuserhm.insert(virtfd, event);
-        },
+        }
         EPOLL_CTL_DEL => {
             if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
@@ -1018,28 +1105,35 @@ pub fn virtualize_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epol
             if thisuserhm.is_empty() {
                 userhm.remove(&virtfdkind);
             }
-        },
+        }
         _ => {
             return Err(threei::Errno::EINVAL as u64);
-        },
+        }
     };
     Ok(())
 }
 
-
 #[doc = include_str!("../docs/get_virtual_epoll_wait_data.md")]
-pub fn get_virtual_epoll_wait_data(cageid:u64, epfd:u64) -> Result<HashMap<u32,HashMap<u64,epoll_event>>,threei::RetVal> {
-
-    assert!(FDTABLE.contains_key(&cageid),"Unknown cageid in fdtable access");
+pub fn get_virtual_epoll_wait_data(
+    cageid: u64,
+    epfd: u64,
+) -> Result<HashMap<u32, HashMap<u64, epoll_event>>, threei::RetVal> {
+    assert!(
+        FDTABLE.contains_key(&cageid),
+        "Unknown cageid in fdtable access"
+    );
 
     // get this or error out...
-    let epentrynum =  _get_epoll_entrynum_or_error(cageid, epfd)?;
+    let epentrynum = _get_epoll_entrynum_or_error(cageid, epfd)?;
 
     let eptable = EPOLLTABLE.lock().unwrap();
-    Ok(eptable.thisepolltable.get(&epentrynum).unwrap().userhandledhashmap.clone())
+    Ok(eptable
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .userhandledhashmap
+        .clone())
 }
-
-
 
 /********************** TESTING HELPER FUNCTION **********************/
 
@@ -1048,7 +1142,10 @@ pub fn get_virtual_epoll_wait_data(cageid:u64, epfd:u64) -> Result<HashMap<u32,H
 // This is only used in tests, thus is hidden...
 pub fn refresh() {
     FDTABLE.clear();
-    FDTABLE.insert(threei::TESTING_CAGEID,vec![Option::None;FD_PER_PROCESS_MAX as usize]);
+    FDTABLE.insert(
+        threei::TESTING_CAGEID,
+        vec![Option::None; FD_PER_PROCESS_MAX as usize],
+    );
     let mut closehandlers = CLOSEHANDLERTABLE.lock().unwrap_or_else(|e| {
         CLOSEHANDLERTABLE.clear_poison();
         e.into_inner()

--- a/src/fdtables/src/muthashmaxglobal.rs
+++ b/src/fdtables/src/muthashmaxglobal.rs
@@ -2,13 +2,12 @@ use crate::threei;
 
 use lazy_static::lazy_static;
 
-use std::sync::Mutex;
-
 use std::collections::HashMap;
 
-// This fdtables library tracks the maxfd so it can more quickly get an unused
-// file descriptor.  
+use std::sync::Mutex;
 
+// This fdtables library tracks the maxfd so it can more quickly get an unused
+// file descriptor.
 
 // Get constants about the fd table sizes, etc.
 pub use super::commonconstants::*;
@@ -19,14 +18,13 @@ pub const ALGONAME: &str = "MutHashMaxGlobal";
 
 #[derive(Clone, Debug)]
 struct FDTable {
-    highestneverusedfd: u64, // Never resets (even after close).  Used to 
-                            // let us quickly get an unused fd
-    thisfdtable: HashMap<u64,FDTableEntry>, // the virtfd -> entry map
+    highestneverusedfd: u64, // Never resets (even after close).  Used to
+    // let us quickly get an unused fd
+    thisfdtable: HashMap<u64, FDTableEntry>, // the virtfd -> entry map
 }
 
 // It's fairly easy to check the fd count on a per-process basis (I just check
-// when I would
-// add a new fd).
+// when I would add a new fd).
 //
 // BUG: I will ignore the total limit for now.  I would ideally do this on
 // every creation, close, fork, etc. but it's a PITA to track this.
@@ -39,8 +37,7 @@ struct FDTable {
 // In order to store this information, I'm going to use a HashMap which
 // has keys of (cageid:u64) and values that are a table with a HashMap and
 // a counter of the highestneverusedfd.
-// HashMap has keys of (virtualfd:64) and values of (realfd:u64,
-// should_cloexec:bool, optionalinfo:u64).
+// HashMap has keys of (virtualfd:64) and values of FDTableEntry.
 //
 // I thought also about having different tables for the entries
 // since they aren't always used together, but this seemed needlessly complex
@@ -52,17 +49,17 @@ lazy_static! {
 
     #[derive(Debug)]
     static ref GLOBALFDTABLE: Mutex<HashMap<u64, FDTable>> = {
-        let mut m = HashMap::new();
+        let m = HashMap::new();
         // Insert a cage so that I have something to fork / test later, if need
         // be. Otherwise, I'm not sure how I get this started. I think this
         // should be invalid from a 3i standpoint, etc. Could this mask an
         // error in the future?
         //
         //
-        let newmap = HashMap::new();
-        let emptytab = FDTable{
+        let _newmap = HashMap::new();
+        let _emptytab = FDTable{
             highestneverusedfd:0,
-            thisfdtable:newmap,
+            thisfdtable:_newmap,
         };
 
         // m.insert(threei::TESTING_CAGEID,emptytab);
@@ -72,34 +69,16 @@ lazy_static! {
 
 lazy_static! {
     // This is needed for close and similar functionality.  I need track the
-    // number of times a realfd is open
+    // number of times a (fdkind,underfd) is open.  Note that this is across
+    // cages in order to enable a library to have situations where two cages
+    // have the same fd open.  The (fdkind,underfd) tuple is the key and the
+    // number of times it appears is the value.  If it reaches 0, the entry
+    // is removed.
     #[derive(Debug)]
-    static ref GLOBALREALFDCOUNT: Mutex<HashMap<u64, u64>> = {
+    static ref GLOBALFDCOUNT: Mutex<HashMap<(u32,u64), u64>> = {
         Mutex::new(HashMap::new())
     };
 
-}
-
-// Internal helper to hold the close handlers...
-struct CloseHandlers {
-    intermediate_handler: fn(u64),
-    final_handler: fn(u64),
-    unreal_handler: fn(u64),
-}
-
-lazy_static! {
-    // This holds the user registered handlers they want to have called when
-    // a close occurs.  I did this rather than return messy data structures
-    // from the close, exec, and exit handlers because it seemed cleaner...
-    #[derive(Debug)]
-    static ref CLOSEHANDLERTABLE: Mutex<CloseHandlers> = {
-        let c = CloseHandlers {
-            intermediate_handler:NULL_FUNC,
-            final_handler:NULL_FUNC,
-            unreal_handler:NULL_FUNC,
-        };
-        Mutex::new(c)
-    };
 }
 
 #[doc = include_str!("../docs/check_cage_exists.md")]
@@ -117,17 +96,16 @@ pub fn init_empty_cage(cageid: u64) {
     }
 
     let newmap = HashMap::new();
-    let emptytab = FDTable{
-        highestneverusedfd:0,
-        thisfdtable:newmap,
+    let emptytab = FDTable {
+        highestneverusedfd: 0,
+        thisfdtable: newmap,
     };
 
-    fdtable.insert(cageid,emptytab);
-
+    fdtable.insert(cageid, emptytab);
 }
 
 #[doc = include_str!("../docs/translate_virtual_fd.md")]
-pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::RetVal> {
+pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry, threei::RetVal> {
     // Get the lock on the fdtable...  I'm not handling "poisoned locks" now
     // where a thread holding the lock died...
     let fdtable = GLOBALFDTABLE.lock().unwrap();
@@ -140,13 +118,13 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
     }
 
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtualfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
-    
+
     return match fdtable.get(&cageid).unwrap().thisfdtable.get(&virtualfd) {
-        Some(tableentry) => Ok(tableentry.realfd),
+        Some(tableentry) => Ok(*tableentry),
         None => Err(threei::Errno::EBADFD as u64),
     };
 }
@@ -161,9 +139,10 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
 #[doc = include_str!("../docs/get_unused_virtual_fd.md")]
 pub fn get_unused_virtual_fd(
     cageid: u64,
-    realfd: u64,
+    fdkind: u32,
+    underfd: u64,
     should_cloexec: bool,
-    optionalinfo: u64,
+    perfdinfo: u64,
 ) -> Result<u64, threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -174,31 +153,30 @@ pub fn get_unused_virtual_fd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
     let myfdentry = fdtable.get_mut(&cageid).unwrap();
 
     if myfdentry.highestneverusedfd < FD_PER_PROCESS_MAX {
-        _increment_realfd(realfd);
         // We have an entry we've never touched!
-        myfdentry.thisfdtable.insert(myfdentry.highestneverusedfd, myentry);
+        let retfd = myfdentry.highestneverusedfd;
+        myfdentry.thisfdtable.insert(retfd, myentry);
         myfdentry.highestneverusedfd += 1;
-        return Ok(myfdentry.highestneverusedfd-1);
+        drop(fdtable);
+        _increment_fdcount(myentry);
+        return Ok(retfd);
     }
 
-    let myfdentry = fdtable.get_mut(&cageid).unwrap();
-    let myfdmap = &mut myfdentry.thisfdtable;
-
-    // Check the fds in order.
+    // Check the fds in order (slow path -- all fds have been used before).
     for fdcandidate in 0..FD_PER_PROCESS_MAX {
-        // Get the entry if it's Vacant and assign it to e (so I can fill
-        // it in).
-        if let std::collections::hash_map::Entry::Vacant(e) = myfdmap.entry(fdcandidate) {
-            e.insert(myentry);
-            _increment_realfd(realfd);
+        if !myfdentry.thisfdtable.contains_key(&fdcandidate) {
+            myfdentry.thisfdtable.insert(fdcandidate, myentry);
+            drop(fdtable);
+            _increment_fdcount(myentry);
             return Ok(fdcandidate);
         }
     }
@@ -207,8 +185,8 @@ pub fn get_unused_virtual_fd(
     Err(threei::Errno::EMFILE as u64)
 }
 
-/// This is used to request an unused fd from specific starting position. This is 
-/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// This is used to request an unused fd from specific starting position. This is
+/// similar to `get_unused_virtual_fd` except this function starts from a specific
 /// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
 #[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
 pub fn get_unused_virtual_fd_from_startfd(
@@ -228,31 +206,25 @@ pub fn get_unused_virtual_fd_from_startfd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
     let myfdentry = fdtable.get_mut(&cageid).unwrap();
 
-    if myfdentry.highestneverusedfd < FD_PER_PROCESS_MAX {
-        _increment_realfd(realfd);
-        // We have an entry we've never touched!
-        myfdentry.thisfdtable.insert(myfdentry.highestneverusedfd, myentry);
-        myfdentry.highestneverusedfd += 1;
-        return Ok(myfdentry.highestneverusedfd-1);
-    }
-
-    let myfdentry = fdtable.get_mut(&cageid).unwrap();
-    let myfdmap = &mut myfdentry.thisfdtable;
-
-    // Check the fds in order.
+    // For from_startfd, we always search starting from arg (no fast path).
+    // Check the fds in order starting from arg.
     for fdcandidate in arg..FD_PER_PROCESS_MAX {
-        // Get the entry if it's Vacant and assign it to e (so I can fill
-        // it in).
-        if let std::collections::hash_map::Entry::Vacant(e) = myfdmap.entry(fdcandidate) {
-            e.insert(myentry);
-            _increment_realfd(realfd);
+        if !myfdentry.thisfdtable.contains_key(&fdcandidate) {
+            myfdentry.thisfdtable.insert(fdcandidate, myentry);
+            // Update highestneverusedfd if needed
+            if fdcandidate >= myfdentry.highestneverusedfd {
+                myfdentry.highestneverusedfd = fdcandidate + 1;
+            }
+            drop(fdtable);
+            _increment_fdcount(myentry);
             return Ok(fdcandidate);
         }
     }
@@ -267,9 +239,10 @@ pub fn get_unused_virtual_fd_from_startfd(
 pub fn get_specific_virtual_fd(
     cageid: u64,
     requested_virtualfd: u64,
-    realfd: u64,
+    fdkind: u32,
+    underfd: u64,
     should_cloexec: bool,
-    optionalinfo: u64,
+    perfdinfo: u64,
 ) -> Result<(), threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -289,29 +262,27 @@ pub fn get_specific_virtual_fd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
-    // I moved this up so that if I decrement the same realfd, it calls
-    // the intermediate handler instead of the final one.
-    _increment_realfd(realfd);
-    
+    // This is before the FDTABLE action, so if I decrement the same fd, it
+    // calls the intermediate handler instead of the last one.
+    _increment_fdcount(myentry);
+
     // always add the new entry.  insert returns the old entry.
-    let myoptionentry = fdtable.get_mut(&cageid).unwrap().thisfdtable.insert(requested_virtualfd,myentry);
+    let myoptionentry = fdtable
+        .get_mut(&cageid)
+        .unwrap()
+        .thisfdtable
+        .insert(requested_virtualfd, myentry);
     drop(fdtable);
 
-    // Close the old entry, if I need to...
+    // Update the fdcount / close the old entry, if existed
     if let Some(entry) = myoptionentry {
-        if entry.realfd != NO_REAL_FD {
-            _decrement_realfd(entry.realfd);
-        }
-        else {
-            // Let their code know this has been closed...
-            let unrealclosehandler = (*CLOSEHANDLERTABLE.lock().unwrap()).unreal_handler;
-            (unrealclosehandler)(entry.optionalinfo);
-        }
+        _decrement_fdcount(entry);
     }
 
     Ok(())
@@ -327,7 +298,12 @@ pub fn set_cloexec(cageid: u64, virtualfd: u64, is_cloexec: bool) -> Result<(), 
     }
 
     // Set the is_cloexec flag or return EBADFD, if that's missing...
-    return match fdtable.get_mut(&cageid).unwrap().thisfdtable.get_mut(&virtualfd) {
+    return match fdtable
+        .get_mut(&cageid)
+        .unwrap()
+        .thisfdtable
+        .get_mut(&virtualfd)
+    {
         Some(tableentry) => {
             tableentry.should_cloexec = is_cloexec;
             Ok(())
@@ -336,37 +312,24 @@ pub fn set_cloexec(cageid: u64, virtualfd: u64, is_cloexec: bool) -> Result<(), 
     };
 }
 
-// Super easy, just return the optionalinfo field...
-#[doc = include_str!("../docs/get_optionalinfo.md")]
-pub fn get_optionalinfo(cageid: u64, virtualfd: u64) -> Result<u64, threei::RetVal> {
-    let fdtable = GLOBALFDTABLE.lock().unwrap();
-    if !fdtable.contains_key(&cageid) {
-        panic!("Unknown cageid in fdtable access");
-    }
-
-    return match fdtable.get(&cageid).unwrap().thisfdtable.get(&virtualfd) {
-        Some(tableentry) => Ok(tableentry.optionalinfo),
-        None => Err(threei::Errno::EBADFD as u64),
-    };
-}
-
 // We're setting an opaque value here. This should be pretty straightforward.
-#[doc = include_str!("../docs/set_optionalinfo.md")]
-pub fn set_optionalinfo(
-    cageid: u64,
-    virtualfd: u64,
-    optionalinfo: u64,
-) -> Result<(), threei::RetVal> {
+#[doc = include_str!("../docs/set_perfdinfo.md")]
+pub fn set_perfdinfo(cageid: u64, virtualfd: u64, perfdinfo: u64) -> Result<(), threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Set optionalinfo or return EBADFD, if that's missing...
-    return match fdtable.get_mut(&cageid).unwrap().thisfdtable.get_mut(&virtualfd) {
+    // Set perfdinfo or return EBADFD, if that's missing...
+    return match fdtable
+        .get_mut(&cageid)
+        .unwrap()
+        .thisfdtable
+        .get_mut(&virtualfd)
+    {
         Some(tableentry) => {
-            tableentry.optionalinfo = optionalinfo;
+            tableentry.perfdinfo = perfdinfo;
             Ok(())
         }
         None => Err(threei::Errno::EBADFD as u64),
@@ -390,9 +353,7 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
 
     // increment the reference to items in the fdtable appropriately...
     for v in fdtable.get(&srccageid).unwrap().thisfdtable.values() {
-        if v.realfd != NO_REAL_FD {
-            _increment_realfd(v.realfd);
-        }
+        _increment_fdcount(*v);
     }
 
     // insert the new table...
@@ -418,16 +379,8 @@ pub fn remove_cage_from_fdtable(cageid: u64) {
 
     // decrement the reference to items in the fdtable appropriately...
     for v in cagetable.thisfdtable.values() {
-        if v.realfd != NO_REAL_FD {
-            _decrement_realfd(v.realfd);
-        }
-        else {
-            // Let their code know this has been closed...
-            let unrealclosehandler = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-            (unrealclosehandler)(v.optionalinfo);
-        }
+        _decrement_fdcount(*v);
     }
-
 }
 
 // This removes all fds with the should_cloexec flag set.  They are returned
@@ -440,68 +393,47 @@ pub fn empty_fds_for_exec(cageid: u64) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Create this hashmap through an lambda that checks should_cloexec...
-    // See: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.extract_if
-
-/*    fdtable
-        .get_mut(&cageid)
-        .unwrap()
-        .extract_if(|_k, v| v.should_cloexec)
-        .collect()*/
-
-    // I'm writing the below code to avoid using the extract_if experimental 
+    // I'm writing the below code to avoid using the extract_if experimental
     // nightly function...
     let thiscagefdtable = &mut fdtable.get_mut(&cageid).unwrap().thisfdtable;
 
-    let mut without_cloexec_hm:HashMap<u64,FDTableEntry> = HashMap::new();
-    // I bother to put this in a hashmap so I can call the closehandlers
+    let mut without_cloexec_hm: HashMap<u64, FDTableEntry> = HashMap::new();
+    // I bother to put this in a vec so I can call the closehandlers
     // all after I have re-inserted everything.  This ensures the state
     // is consistent.  I only need the values, not the keys...
-    let mut with_cloexec_vec:Vec<FDTableEntry> = Vec::new();
+    let mut with_cloexec_vec: Vec<FDTableEntry> = Vec::new();
 
-    for (k,v) in thiscagefdtable.drain() {
+    for (k, v) in thiscagefdtable.drain() {
         if v.should_cloexec {
             with_cloexec_vec.push(v);
+        } else {
+            without_cloexec_hm.insert(k, v);
         }
-        else{
-            without_cloexec_hm.insert(k,v);
-        }
-
     }
 
     let newhighest = fdtable.get(&cageid).unwrap().highestneverusedfd;
     let newfdtable = FDTable {
-        highestneverusedfd:newhighest,
-        thisfdtable:without_cloexec_hm,
+        highestneverusedfd: newhighest,
+        thisfdtable: without_cloexec_hm,
     };
 
     // Put the ones without_cloexec back in the hashmap since they shouldn't
     // be closed...
-    fdtable.insert(cageid,newfdtable);
+    fdtable.insert(cageid, newfdtable);
     // Release the lock...
     drop(fdtable);
 
     // Now call the close handlers on the others...
     for v in with_cloexec_vec {
-        if v.realfd == NO_REAL_FD {
-            // Let their code know this has been closed...  I get the handler
-            // repeatedly in case they change it during execution of another
-            // handler...
-            let closehandlerunreal = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-            (closehandlerunreal)(v.optionalinfo);
-        }
-        else {
-            // Let the helper tell the user and decrement the count
-            _decrement_realfd(v.realfd);
-        }
+        _decrement_fdcount(v);
     }
-
 }
 
 // returns a copy of the fdtable for a cage.  Useful helper function for a
 // caller that needs to examine the table.  Likely could be more efficient by
 // letting the caller borrow this...
 #[doc = include_str!("../docs/return_fdtable_copy.md")]
+#[must_use] // must use the return value if you call it.
 pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
     let fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -512,20 +444,39 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
     fdtable.get(&cageid).unwrap().thisfdtable.clone()
 }
 
-
 /******************* CLOSE SPECIFIC FUNCTIONALITY *******************/
 
-// Helper for close.  Returns a tuple of realfd, number of references
-// remaining.
-#[doc = include_str!("../docs/close_virtualfd.md")]
-pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
+// These indicate what functions should be called upon a virtualfd closing.
+// The handler which is called depends on number of (fdkind,underfd) tuples
+// that are used across *all instances managed by this library including in
+// other cages*.
+struct CloseHandlers {
+    // Called when close is called, but at least one (fdkind,underfd)
+    // reference still remains.  Called with (FDTableEntry,count)
+    intermediate: fn(FDTableEntry, u64),
+    // Called when close is called, and no (fdkind,underfd)
+    // references remain. Called with (FDTableEntry,0)
+    last: fn(FDTableEntry, u64),
+}
 
+lazy_static! {
+    // This holds the user registered handlers they want to have called when
+    // a close occurs.  I did this rather than return messy data structures
+    // from the close, exec, and exit handlers because it seemed cleaner...
+    #[derive(Debug)]
+    static ref CLOSEHANDLERTABLE: Mutex<HashMap<u32,CloseHandlers>> = {
+        Mutex::new(HashMap::new())
+    };
+}
+
+#[doc = include_str!("../docs/close_virtualfd.md")]
+pub fn close_virtualfd(cageid: u64, virtfd: u64) -> Result<(), threei::RetVal> {
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
-    
+
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {
@@ -533,340 +484,431 @@ pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
     }
 
     // remove the closed item from the fdtable (and inspect it)
-    let thisoption = fdtable.get_mut(&cageid).unwrap().thisfdtable.remove(&virtfd);
+    let thisoption = fdtable
+        .get_mut(&cageid)
+        .unwrap()
+        .thisfdtable
+        .remove(&virtfd);
     drop(fdtable);
 
     match thisoption {
-        Some(entry) =>
-            if entry.realfd == NO_REAL_FD {
-                // Let their code know this has been closed...
-                let closehandlerunreal = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-                let optionalinfo = entry.optionalinfo;
-                (closehandlerunreal)(optionalinfo);
-                Ok(())
-            }
-            else {
-                _decrement_realfd(entry.realfd);
-                Ok(())
-            }
+        Some(entry) => {
+            _decrement_fdcount(entry);
+            Ok(())
+        }
         None => Err(threei::Errno::EBADFD as u64),
     }
 }
 
-
 // Register a series of helpers to be called for close.  Can be called
 // multiple times to override the older helpers.
 #[doc = include_str!("../docs/register_close_handlers.md")]
-pub fn register_close_handlers(intermediate_handler: fn(u64), final_handler: fn(u64), unreal_handler: fn(u64)) {
+pub fn register_close_handlers(
+    fdkind: u32,
+    intermediate: fn(FDTableEntry, u64),
+    last: fn(FDTableEntry, u64),
+) {
     // Unlock the table and set the handlers...
-    // TODO: I made a serious attempt to try to keep closehandlers that call
-    // close, etc. from deadlocking the system.  More testing, etc. is needed.
-    let mut closehandlers = CLOSEHANDLERTABLE.lock().unwrap();
-    closehandlers.intermediate_handler = intermediate_handler;
-    closehandlers.final_handler = final_handler;
-    closehandlers.unreal_handler = unreal_handler;
+    let mut closehandlertable = CLOSEHANDLERTABLE.lock().unwrap();
+    let closehandler = CloseHandlers { intermediate, last };
+    // overwrite whatever is in there...
+    closehandlertable.insert(fdkind, closehandler);
 }
 
-// Helpers to track the count of times each realfd is used
+// Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _decrement_realfd(realfd:u64) -> u64 {
-    // Do nothing if it's not a realfd...
-    assert!(realfd != NO_REAL_FD, "Called _decrement_realfd with NO_REAL_FD");
+fn _decrement_fdcount(entry: FDTableEntry) {
+    let mytuple = (entry.fdkind, entry.underfd);
 
-    // Get this table's lock...
-    let mut realfdcount = GLOBALREALFDCOUNT.lock().unwrap();
+    let intermediatech;
+    let lastch;
 
-    let newcount:u64 = realfdcount.get(&realfd).unwrap() - 1;
     let closehandlers = CLOSEHANDLERTABLE.lock().unwrap();
-    let intermediateclosehandler = closehandlers.intermediate_handler;
-    let finalclosehandler = closehandlers.final_handler;
-    // release the lock...
+    if let Some(closehandlerentry) = closehandlers.get(&entry.fdkind) {
+        intermediatech = closehandlerentry.intermediate;
+        lastch = closehandlerentry.last;
+    } else {
+        intermediatech = NULL_FUNC;
+        lastch = NULL_FUNC;
+    }
     drop(closehandlers);
 
-    if newcount > 0 {
-        realfdcount.insert(realfd,newcount);
-        // Need to drop locks to call the handlers or else will deadlock...
-        drop(realfdcount);
+    let newcount;
+    let call_last;
 
-        (intermediateclosehandler)(realfd);
+    let mut fdcount = GLOBALFDCOUNT.lock().unwrap();
+    if let Some(count) = fdcount.get_mut(&mytuple) {
+        let old = *count;
+        newcount = old.checked_sub(1).unwrap_or_else(|| {
+            panic!("FDCOUNT underflow for key {:?}", mytuple);
+        });
+
+        if newcount > 0 {
+            *count = newcount;
+            call_last = false;
+        } else {
+            fdcount.remove(&mytuple);
+            call_last = true;
+        }
+    } else {
+        panic!("FDCOUNT get failed. FDCOUNT missing key {:?}", mytuple);
     }
-    else {
-        // Remove before calling their close handler in case they do operations
-        // inside the close handler which create / close fds...
-        realfdcount.remove(&realfd);
-        // Need to drop locks to call the handlers or else will deadlock...
-        drop(realfdcount);
+    drop(fdcount);
 
-        (finalclosehandler)(realfd);
-
+    if !call_last {
+        (intermediatech)(entry, newcount);
+    } else {
+        (lastch)(entry, 0);
     }
-    newcount
 }
 
-// Helpers to track the count of times each realfd is used
+// Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _increment_realfd(realfd:u64) -> u64 {
-    if realfd == NO_REAL_FD {
-        return 0
-    }
+fn _increment_fdcount(entry: FDTableEntry) {
+    let mytuple = (entry.fdkind, entry.underfd);
 
-    // Get this table's lock...
-    let mut realfdcount = GLOBALREALFDCOUNT.lock().unwrap();
+    let mut fdcount = GLOBALFDCOUNT.lock().unwrap();
 
     // Get a mutable reference to the entry so we can update it.
-    return match realfdcount.get_mut(&realfd) {
-        Some(count) => {
-            *count += 1;
-            *count
-        }
-        None => {
-            realfdcount.insert(realfd, 1);
-            1
-        }
+    if let Some(count) = fdcount.get_mut(&mytuple) {
+        *count += 1;
+    } else {
+        fdcount.insert(mytuple, 1);
     }
 }
 
 /***************   Code for handling select() ****************/
 
 use libc::fd_set;
-use std::collections::HashSet;
 use std::cmp;
+use std::collections::HashSet;
 use std::mem;
 
 // Helper to get an empty fd_set.  Helper function to isolate unsafe code,
 // etc.
 #[doc(hidden)]
+#[must_use] // must use the return value if you call it.
 pub fn _init_fd_set() -> fd_set {
-    let raw_fd_set:fd_set;
+    let raw_fd_set: fd_set;
     unsafe {
         let mut this_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
         libc::FD_ZERO(this_fd_set.as_mut_ptr());
-        raw_fd_set = this_fd_set.assume_init()
+        raw_fd_set = this_fd_set.assume_init();
     }
     raw_fd_set
 }
 
 #[doc(hidden)]
-pub fn _fd_set(fd:u64, thisfdset:&mut fd_set) {
-    unsafe{libc::FD_SET(fd as i32,thisfdset)}
+pub fn _fd_set(fd: u64, thisfdset: &mut fd_set) {
+    unsafe { libc::FD_SET(fd as i32, thisfdset) }
 }
 
 #[doc(hidden)]
-pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
-    unsafe{libc::FD_ISSET(fd as i32,thisfdset)}
+#[must_use] // must use the return value if you call it.
+pub fn _fd_isset(fd: u64, thisfdset: &fd_set) -> bool {
+    unsafe { libc::FD_ISSET(fd as i32, thisfdset) }
 }
 
-// Computes the bitmodifications and returns a (maxnfds, unrealset) tuple...
-#[doc(hidden)]
-fn _do_bitmods(myfdmap:HashMap<u64,FDTableEntry>, nfds:u64, infdset: fd_set, thisfdset: &mut fd_set, mappingtable: &mut HashMap<u64,u64>) -> Result<(u64,HashSet<(u64,u64)>),threei::RetVal> {
-    let mut unrealhashset:HashSet<(u64,u64)> = HashSet::new();
-    // Iterate through the infdset and set those values as is appropriate
-    let mut highestpos = 0;
-
-    // Clippy is somehow missing how pos is using bit.
-    #[allow(clippy::needless_range_loop)]
-    for bit in 0..nfds as usize {
-        let pos = bit as u64;
-        if _fd_isset(pos,&infdset) {
-            if let Some(entry) = myfdmap.get(&pos) {
-                if entry.realfd == NO_REAL_FD {
-                    unrealhashset.insert((pos,entry.optionalinfo));
-                }
-                else {
-                    mappingtable.insert(entry.realfd, pos);
-                    _fd_set(entry.realfd,thisfdset);
-                    // I add one because select expects nfds to be the max+1
-                    highestpos = cmp::max(highestpos, entry.realfd+1);
-                }
-            }
-            else {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-        }
-    }
-    Ok((highestpos,unrealhashset))
-}
+// This is a helper that just does a single type (r/w/e) and returns:
+//    bithashmap: HashMap<fdkind, (nfds, fd_set)>
+//    unhandledhashmap: HashMap<fdkind, HashSet<FDTableEntry>>
+//    mappingtable: HashMap<FDTableEntry, virt_fd>
+//
+// With this we trivially build the whole function...
 
 // helper to call before calling select beneath you.  Translates your virtfds
-// to realfds.
+// into a bitmask you may use for select.
 // See: https://man7.org/linux/man-pages/man2/select.2.html for details /
 // corner cases about the arguments.
+//
 
-// I hate doing these, but don't know how to make this interface better...
+// I hate doing this, but don't know how to make this interface better...
 #[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-#[doc = include_str!("../docs/get_real_bitmasks_for_select.md")]
-pub fn get_real_bitmasks_for_select(cageid:u64, nfds:u64, readbits:Option<fd_set>, writebits:Option<fd_set>, exceptbits:Option<fd_set>) -> Result<(u64, Option<fd_set>, Option<fd_set>, Option<fd_set>, [HashSet<(u64,u64)>;3], HashMap<u64,u64>),threei::RetVal> {
-
+#[allow(clippy::implicit_hasher)]
+#[doc = include_str!("../docs/get_bitmask_for_select.md")]
+pub fn get_bitmask_for_select(
+    cageid: u64,
+    nfds: u64,
+    bits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        HashMap<u32, (u64, fd_set)>,
+        HashMap<u32, HashSet<FDTableEntry>>,
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
     if nfds >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EINVAL as u64);
     }
 
-    let globfdtable = GLOBALFDTABLE.lock().unwrap();
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-    if !globfdtable.contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    let mut unrealarray:[HashSet<(u64,u64)>;3] = [HashSet::new(),HashSet::new(),HashSet::new()];
-    let mut mappingtable:HashMap<u64,u64> = HashMap::new();
-    let mut newnfds = 0;
+    // The three things I will return...
+    let mut retbittable: HashMap<u32, (u64, fd_set)> = HashMap::new();
+    let mut retunparsedtable: HashMap<u32, HashSet<FDTableEntry>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
 
-    // putting results in a vec was the cleanest way I found to do this..
-    let mut resultvec = Vec::new();
+    // If we were asked to do this on nothing, return empty mappings...
+    if bits.is_none() {
+        return Ok((retbittable, retunparsedtable, mappingtable));
+    }
 
-    for (unrealoffset, inset) in [readbits,writebits, exceptbits].into_iter().enumerate() {
-        match inset {
-            Some(virtualbits) => {
-                let mut retset = _init_fd_set();
-                let (thisnfds,myunrealhashset) = _do_bitmods(globfdtable.get(&cageid).unwrap().clone().thisfdtable,nfds,virtualbits, &mut retset,&mut mappingtable)?;
-                resultvec.push(Some(retset));
-                newnfds = cmp::max(thisnfds, newnfds);
-                unrealarray[unrealoffset] = myunrealhashset;
-            }
-            None => {
-                // This item is null.  No unreal items
-                resultvec.push(None);
-                unrealarray[unrealoffset] = HashSet::new();
+    let infdset = bits.unwrap();
+
+    let myfdmap = &fdtable.get(&cageid).unwrap().thisfdtable;
+
+    // Clippy is somehow missing how the virtualfd is being used throughout
+    // here.  It's not just a range value
+    #[allow(clippy::needless_range_loop)]
+    // iterate through the set bits...
+    for bit in 0..nfds as usize {
+        let pos = bit as u64;
+        if _fd_isset(pos, &infdset) {
+            if let Some(entry) = myfdmap.get(&pos) {
+                // I like to do the shorter case first rather than having
+                // it later.
+                #[allow(clippy::if_not_else)]
+                // Which return set do I go in?
+                if !fdkinds.contains(&entry.fdkind) {
+                    // Is unparsed...  Clippy's suggestion to insert if missing
+                    retunparsedtable.entry(entry.fdkind).or_default();
+                    retunparsedtable
+                        .get_mut(&entry.fdkind)
+                        .unwrap()
+                        .insert(*entry);
+                    // and update the mappingtable to have the bit from the
+                    // original fd...
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+                } else {
+                    let startingnfds;
+                    let mut startingfdset;
+
+                    // Either initialize it or use what exists
+                    if retbittable.contains_key(&entry.fdkind) {
+                        (startingnfds, startingfdset) = *retbittable.get(&entry.fdkind).unwrap();
+                    } else {
+                        startingnfds = 1;
+                        // I don't init this above because a fd_set is a large
+                        // data structure and would be costly.
+                        startingfdset = _init_fd_set();
+                    }
+
+                    // Update the table and the nfds
+                    _fd_set(entry.underfd, &mut startingfdset);
+                    let newnfds = cmp::max(startingnfds, entry.underfd + 1);
+
+                    // and update the mappingtable to have the bit from the
+                    // original fd...
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+
+                    // insert the item
+                    retbittable.insert(entry.fdkind, (newnfds, startingfdset));
+                }
+            } else {
+                return Err(threei::Errno::EBADF as u64);
             }
         }
     }
-
-    Ok((newnfds, resultvec[0], resultvec[1], resultvec[2], unrealarray, mappingtable))
-
+    Ok((retbittable, retunparsedtable, mappingtable))
 }
 
+#[allow(clippy::type_complexity)]
+#[allow(clippy::implicit_hasher)]
+#[doc = include_str!("../docs/prepare_bitmasks_for_select.md")]
+pub fn prepare_bitmasks_for_select(
+    cageid: u64,
+    nfds: u64,
+    rbits: Option<fd_set>,
+    wbits: Option<fd_set>,
+    ebits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        [HashMap<u32, (u64, fd_set)>; 3],
+        [HashMap<u32, HashSet<FDTableEntry>>; 3],
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
+    // This is a pretty simple function.  Calls get_bitmask_for_select
+    // repeatedly and combines the results...
 
-// helper to call after calling select beneath you.  returns the fd_sets you
+    // return the error, if need be
+    let rresult = get_bitmask_for_select(cageid, nfds, rbits, fdkinds)?;
+    let wresult = get_bitmask_for_select(cageid, nfds, wbits, fdkinds)?;
+    let eresult = get_bitmask_for_select(cageid, nfds, ebits, fdkinds)?;
+
+    let mut mappingtable = rresult.2;
+    mappingtable.extend(wresult.2);
+    mappingtable.extend(eresult.2);
+
+    Ok((
+        [rresult.0, wresult.0, eresult.0],
+        [rresult.1, wresult.1, eresult.1],
+        mappingtable,
+    ))
+}
+
+// helper to call after calling select beneath you.  returns the fd_set you
 // need for your return from a select call and the number of unique flags
 // set...
 
-// I hate doing these, but don't know how to make this interface better...
-#[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-#[doc = include_str!("../docs/get_virtual_bitmasks_from_select_result.md")]
-pub fn get_virtual_bitmasks_from_select_result(nfds:u64, readbits:Option<fd_set>, writebits:Option<fd_set>, exceptbits:Option<fd_set>,unrealreadset:HashSet<u64>, unrealwriteset:HashSet<u64>, unrealexceptset:HashSet<u64>, mappingtable:&HashMap<u64,u64>) -> Result<(u64, Option<fd_set>, Option<fd_set>, Option<fd_set>),threei::RetVal> {
-
+// I given them the hashmap, so don't need flexibility in what they return...
+#[allow(clippy::implicit_hasher)]
+#[must_use] // must use the return value if you call it.
+#[doc = include_str!("../docs/get_one_virtual_bitmask_from_select_result.md")]
+pub fn get_one_virtual_bitmask_from_select_result(
+    fdkind: u32,
+    nfds: u64,
+    bits: Option<fd_set>,
+    unprocessedset: HashSet<u64>,
+    startingbits: Option<fd_set>,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> (u64, Option<fd_set>) {
     // Note, I don't need the cage_id here because I have the mappingtable...
 
-    if nfds >= FD_PER_PROCESS_MAX {
-        panic!("This shouldn't be possible because we shouldn't have returned this previously")
-    }
+    assert!(
+        nfds < FD_PER_PROCESS_MAX,
+        "This shouldn't be possible because we shouldn't have returned this previously"
+    );
 
     let mut flagsset = 0;
-    let mut retvec = Vec::new();
 
-    for (insetoption,unrealset) in [(readbits,unrealreadset), (writebits,unrealwriteset), (exceptbits,unrealexceptset)] {
-        // If I don't have any data, just return None (NULL) and skip...
-        if insetoption.is_none()&&unrealset.is_empty() {
-            retvec.push(None);
-            continue;
-        }
-
-        let mut retbits = _init_fd_set();
-        if let Some(inset) = insetoption {
-            for bit in 0..nfds as usize {
-                let pos = bit as u64;
-                if _fd_isset(pos,&inset)&& !_fd_isset(*mappingtable.get(&pos).unwrap(),&retbits) {
-                    flagsset+=1;
-                    _fd_set(*mappingtable.get(&pos).unwrap(),&mut retbits);
-                }
-            }
-        }
-        for virtfd in unrealset {
-            if !_fd_isset(virtfd,&retbits) {
-                flagsset+=1;
-                _fd_set(virtfd,&mut retbits);
-            }
-        }
-        retvec.push(Some(retbits));
+    if bits.is_none() && unprocessedset.is_empty() {
+        return (flagsset, None);
     }
 
-    Ok((flagsset,retvec[0],retvec[1],retvec[2]))
+    // I probably should pass a reference to startingbits to avoid copying the
+    // bit structure...
+    let mut retbits = match startingbits {
+        Some(val) => val,
+        None => _init_fd_set(),
+    };
 
+    if let Some(inset) = bits {
+        for bit in 0..nfds as usize {
+            let pos = bit as u64;
+            if _fd_isset(pos, &inset)
+                && !_fd_isset(*mappingtable.get(&(fdkind, pos)).unwrap(), &retbits)
+            {
+                flagsset += 1;
+                _fd_set(*mappingtable.get(&(fdkind, pos)).unwrap(), &mut retbits);
+            }
+        }
+    }
+    for virtfd in unprocessedset {
+        if !_fd_isset(virtfd, &retbits) {
+            flagsset += 1;
+            _fd_set(virtfd, &mut retbits);
+        }
+    }
+
+    (flagsset, Some(retbits))
 }
-
-
 
 /********************** POLL SPECIFIC FUNCTIONS **********************/
 
 // helper to call before calling poll beneath you.  replaces the fds in
 // the poll struct with virtual versions and returns the items you need
 // to check yourself...
+#[allow(clippy::implicit_hasher)]
 #[allow(clippy::type_complexity)]
-#[doc = include_str!("../docs/convert_virtualfds_to_real.md")]
-pub fn convert_virtualfds_to_real(cageid:u64, virtualfds:Vec<u64>) -> (Vec<u64>, Vec<(u64,u64)>, Vec<u64>, HashMap<u64,u64>) {
+#[doc = include_str!("../docs/convert_virtualfds_for_poll.md")]
+#[must_use] // must use the return value if you call it.
+pub fn convert_virtualfds_for_poll(
+    cageid: u64,
+    virtualfds: HashSet<u64>,
+) -> (
+    HashMap<u32, HashSet<(u64, FDTableEntry)>>,
+    HashMap<(u32, u64), u64>,
+) {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-    let globfdtable = GLOBALFDTABLE.lock().unwrap();
-
-    if !globfdtable.contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    let mut unrealvec = Vec::new();
-    let mut realvec = Vec::new();
-    let mut invalidvec = Vec::new();
-    let thefdhm = globfdtable.get(&cageid).unwrap();
-    let mut mappingtable:HashMap<u64,u64> = HashMap::new();
+    let myfdmap = &fdtable.get(&cageid).unwrap().thisfdtable;
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
+    let mut rethashmap: HashMap<u32, HashSet<(u64, FDTableEntry)>> = HashMap::new();
 
     // BUG?: I'm ignoring the fact that virtualfds can show up multiple times.
     // I'm not sure this actually matters, but I didn't think hard about it.
     for virtfd in virtualfds {
-        match thefdhm.thisfdtable.get(&virtfd) {
-            Some(entry) => {
-                // always append the value here.  NO_REAL_FD will be added
-                // in the appropriate places to tell them to handle those calls
-                // themself.
-                realvec.push(entry.realfd);
-                if entry.realfd == NO_REAL_FD {
-                    unrealvec.push((virtfd,entry.optionalinfo));
-                }
-                else{
-                    mappingtable.insert(entry.realfd, virtfd);
-                }
-            }
-            None => {
-                // Add this because they need to handle it if POLLNVAL is set.
-                // An exception should not be raised!!!
-                realvec.push(INVALID_FD);
-                invalidvec.push(virtfd);
-            }
+        if let Some(entry) = myfdmap.get(&virtfd) {
+            // Insert an empty HashSet, if needed
+            rethashmap.entry(entry.fdkind).or_default();
+            mappingtable
+                .entry((entry.fdkind, entry.underfd))
+                .or_default();
+
+            rethashmap
+                .get_mut(&entry.fdkind)
+                .unwrap()
+                .insert((virtfd, *entry));
+            mappingtable.insert((entry.fdkind, entry.underfd), virtfd);
+        } else {
+            let myentry = FDTableEntry {
+                fdkind: FDT_INVALID_FD,
+                underfd: virtfd,
+                should_cloexec: false,
+                perfdinfo: u64::from(FDT_INVALID_FD),
+            };
+
+            // Insert an empty HashSet, if needed
+            rethashmap.entry(FDT_INVALID_FD).or_default();
+            mappingtable.entry((FDT_INVALID_FD, virtfd)).or_default();
+
+            rethashmap
+                .get_mut(&FDT_INVALID_FD)
+                .unwrap()
+                .insert((virtfd, myentry));
+            // Add this because they need to handle it if POLLNVAL is set.
+            // An exception should not be raised!!!
+
+            // I will add this to the mapping table, because I do think they
+            // may want to raise an exception, etc. based upon this and signal
+            // back.  I am setting the underfd to be the virtfd, so I can
+            // reverse this process, if multiple entries like this occur.
+            mappingtable.insert((FDT_INVALID_FD, virtfd), virtfd);
         }
     }
 
-    (realvec, unrealvec, invalidvec, mappingtable)
+    (rethashmap, mappingtable)
 }
 
-
-
-// helper to call after calling poll.  replaces the realfds the vector
+// helper to call after calling poll.  replaces the fds in the vector
 // with virtual ones...
-#[doc = include_str!("../docs/convert_realfds_back_to_virtual.md")]
-pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u64,u64>) -> Vec<u64> {
-
+#[doc = include_str!("../docs/convert_poll_result_back_to_virtual.md")]
+// I give them the hashmap, so don't need flexibility in what they return...
+#[allow(clippy::implicit_hasher)]
+#[must_use] // must use the return value if you call it.
+pub fn convert_poll_result_back_to_virtual(
+    fdkind: u32,
+    underfd: u64,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> Option<u64> {
     // I don't care what cage was used, and don't need to lock anything...
     // I have the mappingtable!
 
-    let mut virtvec = Vec::new();
-
-    for realfd in realfds {
-        virtvec.push(*mappingtable.get(&realfd).unwrap());
-    }
-
-    virtvec
+    // Should this even be a function?
+    mappingtable.get(&(fdkind, underfd)).copied()
 }
-
 
 /********************** EPOLL SPECIFIC FUNCTIONS **********************/
 
-
-// Okay this adds a big wrinkle, epollfds.  The reason these are complex is
-// multi-fold:
-// 1) they themselves are file descriptors and take up a slot.
-// 2) a epollfd can point to any number of other fds
+// Supporting epollfds is done by a fdkind which is not set by the user.
+// There are a few complexities here:
+// 1) an epollfd gets a virtual file descriptor
+// 2) a epollfd can point to any number of other fds of different kinds
 // 3) an epollfd can point to epollfds, which can point to other epollfds, etc.
 //    and possibly cause a loop to occur (which is an error)
-// 4) an epollfd can point to a mix of virtual and realfds.
 //
 // My thinking is this is handled as similarly to poll as possible.  We push
 // off the problem of understanding what the event types are to the implementer
@@ -877,21 +919,13 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 // types, which they may need to poll themselves.  After this, they handle the
 // call.
 //
-// epoll_create makes a new fd type, which really is unfortunate.  To this
-// point, I haven't had to care about anything except in-memory fds (unreal),
-// and doing the virtual <-> real mappings.  The caller can decide whether to
-// create an underlying epollfd when this is called, when epoll_ctl is called
-// to add a realfd, etc.
-//
 // epoll_ctl is complex, but really has the same fundamental problem as
 // epoll_create: the epollfd.
 //
-// What if I just ignore the epollfd problem by just making another table
-// for epoll information?  Then what I do is set the realfd to EPOLLFD and
-// have optionalinfo point into the epollfd table.  If I do this, then when
-// epoll_create is called, if it contains realfds, those need to be passed
-// down to the underlying epoll_create.  Similarly, when epoll_ctl is called,
-// we either modify our data or return the realfd...
+// I'll create a new fdkind for epoll.  When epoll_create is called, the
+// caller can decide which fdkinds need to be passed down to the underlying
+// epoll_create call(s).  Similarly, when epoll_ctl is called, one either
+// handles the call internally or uses the underfd for the fdkind...
 //
 // Interestingly, this actually would be just as easy to build on top of the
 // fdtables library as into it.
@@ -905,9 +939,20 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 // them on systems that don't support epoll and I want to be able to build
 // the code anywhere.  See commonconstants.rs for more info.
 
-// Design notes: I'm not adding realfds.  I return them when you do a epoll_ctl
-// operation that tries to add them.  So, I only have unrealfds in my epoll
-// structures.
+// a structure that exists for each epoll descriptor to track the underfd(s)
+// and parts the user will handle
+#[derive(Clone, Debug, Default)]
+struct EPollDescriptorInfo {
+    // I didn't combine these two hashmaps into one because they are used
+    // separately and the resulting value type would be too messy...
+    underfdhashmap: HashMap<u32, u64>, // The underfd for a specific fdkind.
+    // Used only when an epoll call will
+    // call down beneath it.
+    userhandledhashmap: HashMap<u32, HashMap<u64, epoll_event>>,
+    // This has all of the things the user
+    // will virtualize and handle.  The key
+    // is the fdkind.
+}
 
 // TODO: I don't clean up this table yet.  I probably should when the last
 // reference to a fd is closed, but this bookkeeping seems excessive at this
@@ -915,13 +960,8 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 #[derive(Clone, Debug)]
 struct EPollTable {
     highestneverusedentry: u64, // Never resets (even after close).  Used to
-                                // let us quickly get an unused entry
-    thisepolltable: HashMap<u64,HashMap<u64,epoll_event>>, // the epollentry ->
-                                                           // virtfd ->
-                                                           // event map
-   realfdtable: HashMap<u64,u64>, // the epollentry -> realfd map.  I need
-                                   // this because the realfd field in the
-                                   // main data structure is EPOLLFD
+    // let us quickly get an unused entry
+    thisepolltable: HashMap<u64, EPollDescriptorInfo>,
 }
 
 lazy_static! {
@@ -929,42 +969,123 @@ lazy_static! {
     #[derive(Debug)]
     static ref EPOLLTABLE: Mutex<EPollTable> = {
         let newetable = HashMap::new();
-        let newrealfdtable = HashMap::new();
         let m = EPollTable {
             highestneverusedentry:0,
             thisepolltable:newetable,
-            realfdtable:newrealfdtable,
         };
         Mutex::new(m)
     };
 }
 
+fn _get_epoll_entrynum_or_error(
+    fdtable: &HashMap<u64, FDTable>,
+    cageid: u64,
+    epfd: u64,
+) -> Result<u64, threei::RetVal> {
+    // Is the epfd ok?
+    match fdtable.get(&cageid).unwrap().thisfdtable.get(&epfd) {
+        None => Err(threei::Errno::EBADF as u64),
+        Some(tableentry) => {
+            // You must call this on an epoll fd
+            if tableentry.fdkind == FDT_KINDEPOLL {
+                Ok(tableentry.underfd)
+            } else {
+                Err(threei::Errno::EINVAL as u64)
+            }
+        }
+    }
+}
 
-#[doc = include_str!("../docs/epoll_create_helper.md")]
-pub fn epoll_create_helper(cageid:u64, realfd:u64, should_cloexec:bool) -> Result<u64,threei::RetVal> {
+#[doc = include_str!("../docs/epoll_create_empty.md")]
+pub fn epoll_create_empty(cageid: u64, should_cloexec: bool) -> Result<u64, threei::RetVal> {
+    let mut ept = EPOLLTABLE.lock().unwrap();
+
+    // return the same errno (EMFile), if we get one
+    let newepollfd = get_unused_virtual_fd(
+        cageid,
+        FDT_KINDEPOLL,
+        ept.highestneverusedentry,
+        should_cloexec,
+        0,
+    )?;
+
+    let newentrynum = ept.highestneverusedentry;
+    ept.highestneverusedentry += 1;
+
+    // Create a new entry with empty values
+    ept.thisepolltable.entry(newentrynum).or_default();
+    Ok(newepollfd)
+}
+
+#[doc = include_str!("../docs/epoll_add_underfd.md")]
+pub fn epoll_add_underfd(
+    cageid: u64,
+    virtepollfd: u64,
+    fdkind: u32,
+    underfd: u64,
+) -> Result<(), threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
+
+    if !fdtable.contains_key(&cageid) {
+        panic!("Unknown cageid in fdtable access");
+    }
 
     let mut ept = EPOLLTABLE.lock().unwrap();
 
-    // I'll use my other functions to make this easier.
-    // return the same errno (EMFile), if we get one
-    let newepollfd = get_unused_virtual_fd(cageid, EPOLLFD, should_cloexec, ept.highestneverusedentry)?;
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, virtepollfd)?;
 
-    let newentry = ept.highestneverusedentry;
-    // add in my realfd.
-    ept.realfdtable.insert(newentry,realfd);
-    ept.highestneverusedentry+=1;
-    // if it errored out above that is okay. I haven't changed any state yet.
-    ept.thisepolltable.insert(newentry, HashMap::new());
-    Ok(newepollfd)
+    let myhm = &mut ept
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .underfdhashmap;
 
+    assert!(
+        !myhm.contains_key(&fdkind),
+        "Adding duplicate underfd to epollfd"
+    );
+
+    myhm.insert(fdkind, underfd);
+
+    Ok(())
 }
 
+#[doc = include_str!("../docs/epoll_get_underfd_hashmap.md")]
+pub fn epoll_get_underfd_hashmap(
+    cageid: u64,
+    virtepollfd: u64,
+) -> Result<HashMap<u32, u64>, threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
+    if !fdtable.contains_key(&cageid) {
+        panic!("Unknown cageid in fdtable access");
+    }
 
-#[doc = include_str!("../docs/try_epoll_ctl.md")]
-pub fn try_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epoll_event) -> Result<(u64,u64),threei::RetVal> {
+    let ept = EPOLLTABLE.lock().unwrap();
 
-    if !GLOBALFDTABLE.lock().unwrap().contains_key(&cageid) {
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, virtepollfd)?;
+
+    Ok(ept
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .underfdhashmap
+        .clone())
+}
+
+#[doc = include_str!("../docs/virtualize_epoll_ctl.md")]
+pub fn virtualize_epoll_ctl(
+    cageid: u64,
+    epfd: u64,
+    op: i32,
+    virtfd: u64,
+    event: epoll_event,
+) -> Result<(), threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
+
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
@@ -972,113 +1093,103 @@ pub fn try_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epoll_event
         return Err(threei::Errno::EINVAL as u64);
     }
 
-    // Is the epfd ok?
-    let epollentrynum:u64 = match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().thisfdtable.get(&epfd) {
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != EPOLLFD {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-            tableentry.optionalinfo
-        },
-    };
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, epfd)?;
 
-    // Okay, I know which table entry and verified the virtfd...
+    // Okay, I know which table entry, now verify the virtfd...
 
-    let mut epttable = EPOLLTABLE.lock().unwrap();
-    let realepollfd = epttable.realfdtable.get(&epollentrynum).unwrap().clone();
-    let eptentry = epttable.thisepolltable.get_mut(&epollentrynum).unwrap();
+    let virtfdkind: u32;
 
-    // check if the virtfd is real and error...
-    // I don't care about its contents except to ensure it isn't real...
-    match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().thisfdtable.get(&virtfd) {
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != NO_REAL_FD {
-                // Return realfds because the caller should handle them instead
-                // I only track unrealfds.
-                if tableentry.realfd == EPOLLFD {
-                    // BUG: How should I be doing this, really!?!
-                    println!("epollfds acting on epollfds is not supported!");
-                }
-                return Ok((realepollfd,tableentry.realfd));
-            }
-        },
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-    };
+    if let Some(tableentry) = fdtable.get(&cageid).unwrap().thisfdtable.get(&virtfd) {
+        // Right now, I don't support this, so error...
+        if tableentry.fdkind == FDT_KINDEPOLL {
+            // TODO: support EPOLLFDs...
+            return Err(threei::Errno::ENOSYS as u64);
+        }
+        virtfdkind = tableentry.fdkind;
+    } else {
+        // The virtual Fd doesn't exist -- error...
+        return Err(threei::Errno::EBADF as u64);
+    }
 
-    // okay, virtfd is real...
+    let mut eptable = EPOLLTABLE.lock().unwrap();
+    let userhm = &mut eptable
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .userhandledhashmap;
 
     match op {
         EPOLL_CTL_ADD => {
-            if eptentry.contains_key(&virtfd) {
+            let thisuserhm = userhm.entry(virtfdkind).or_default();
+            if thisuserhm.contains_key(&virtfd) {
                 return Err(threei::Errno::EEXIST as u64);
             }
-            // BUG: Need to check for ELOOP here...
+            // BUG: Need to check for ELOOP here once I support EPOLLFDs
+            // referencing each other...
 
-            eptentry.insert(virtfd, event);
-        },
+            thisuserhm.insert(virtfd, event);
+        }
         EPOLL_CTL_MOD => {
-            if !eptentry.contains_key(&virtfd) {
+            if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
             }
-            eptentry.insert(virtfd, event);
-        },
+            let thisuserhm: &mut HashMap<u64, epoll_event> = userhm.get_mut(&virtfdkind).unwrap();
+            if !thisuserhm.contains_key(&virtfd) {
+                return Err(threei::Errno::ENOENT as u64);
+            }
+            thisuserhm.insert(virtfd, event);
+        }
         EPOLL_CTL_DEL => {
-            if !eptentry.contains_key(&virtfd) {
+            if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
             }
-            eptentry.remove(&virtfd);
-        },
+            let thisuserhm: &mut HashMap<u64, epoll_event> = userhm.get_mut(&virtfdkind).unwrap();
+            if !thisuserhm.contains_key(&virtfd) {
+                return Err(threei::Errno::ENOENT as u64);
+            }
+            thisuserhm.remove(&virtfd);
+            // If this was the last entry, delete the key altogether...
+            if thisuserhm.is_empty() {
+                userhm.remove(&virtfdkind);
+            }
+        }
         _ => {
             return Err(threei::Errno::EINVAL as u64);
-        },
+        }
     };
-    Ok((realepollfd,NO_REAL_FD))
+    Ok(())
 }
 
+#[doc = include_str!("../docs/get_virtual_epoll_wait_data.md")]
+pub fn get_virtual_epoll_wait_data(
+    cageid: u64,
+    epfd: u64,
+) -> Result<HashMap<u32, HashMap<u64, epoll_event>>, threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-#[doc = include_str!("../docs/get_epoll_wait_data.md")]
-pub fn get_epoll_wait_data(cageid:u64, epfd:u64) -> Result<(u64,HashMap<u64,epoll_event>),threei::RetVal> {
-
-    if !GLOBALFDTABLE.lock().unwrap().contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Note that because I don't track realfds or deal with epollfds, I just
-    // return the epolltable...
-    let epollentrynum:u64 = match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().thisfdtable.get(&epfd) {
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != EPOLLFD {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-            tableentry.optionalinfo
-        },
-    };
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, epfd)?;
 
-    let epttable = EPOLLTABLE.lock().unwrap();
-    Ok((*epttable.realfdtable.get(&epollentrynum).unwrap(),epttable.thisepolltable[&epollentrynum].clone()))
+    let eptable = EPOLLTABLE.lock().unwrap();
+    Ok(eptable
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .userhandledhashmap
+        .clone())
 }
-
-
-
-
 
 /********************** TESTING HELPER FUNCTION **********************/
 
 // Helper to initialize / empty out state so we can test with a clean system...
 // only used when testing...
 //
-// I'm cleaning up "poisoned" mutexes here so that I can handle tests that 
+// I'm cleaning up "poisoned" mutexes here so that I can handle tests that
 // panic
 #[doc(hidden)]
 pub fn refresh() {
@@ -1090,9 +1201,9 @@ pub fn refresh() {
     fdtable.clear();
 
     let newmap = HashMap::new();
-    let emptytab = FDTable{
-        highestneverusedfd:0,
-        thisfdtable:newmap,
+    let emptytab = FDTable {
+        highestneverusedfd: 0,
+        thisfdtable: newmap,
     };
 
     fdtable.insert(threei::TESTING_CAGEID, emptytab);
@@ -1100,13 +1211,10 @@ pub fn refresh() {
         CLOSEHANDLERTABLE.clear_poison();
         e.into_inner()
     });
+    closehandlers.clear();
 
-    closehandlers.intermediate_handler = NULL_FUNC;
-    closehandlers.final_handler = NULL_FUNC;
-    closehandlers.unreal_handler = NULL_FUNC;
-
-    let mut _realfdcount = GLOBALREALFDCOUNT.lock().unwrap_or_else(|e| {
-        GLOBALREALFDCOUNT.clear_poison();
+    let mut _fdcount = GLOBALFDCOUNT.lock().unwrap_or_else(|e| {
+        GLOBALFDCOUNT.clear_poison();
         e.into_inner()
     });
 }

--- a/src/fdtables/src/vanillaglobal.rs
+++ b/src/fdtables/src/vanillaglobal.rs
@@ -2,13 +2,12 @@ use crate::threei;
 
 use lazy_static::lazy_static;
 
-use std::sync::Mutex;
-
 use std::collections::HashMap;
+
+use std::sync::Mutex;
 
 // This is a basic fdtables library.  The purpose is to allow a cage to have
 // a set of virtual fds which is translated into real fds.
-
 
 // Get constants about the fd table sizes, etc.
 pub use super::commonconstants::*;
@@ -18,8 +17,7 @@ pub use super::commonconstants::*;
 pub const ALGONAME: &str = "VanillaGlobal";
 
 // It's fairly easy to check the fd count on a per-process basis (I just check
-// when I would
-// add a new fd).
+// when I would add a new fd).
 //
 // BUG: I will ignore the total limit for now.  I would ideally do this on
 // every creation, close, fork, etc. but it's a PITA to track this.
@@ -31,8 +29,7 @@ pub const ALGONAME: &str = "VanillaGlobal";
 
 // In order to store this information, I'm going to use a HashMap which
 // has keys of (cageid:u64) and values that are another HashMap.  The second
-// HashMap has keys of (virtualfd:64) and values of (realfd:u64,
-// should_cloexec:bool, optionalinfo:u64).
+// HashMap has keys of (virtualfd:64) and values of FDTableEntry.
 //
 // To speed up lookups, I could have used arrays instead of HashMaps.  In
 // theory, that space is far too large, but likely each could be bounded to
@@ -48,7 +45,7 @@ lazy_static! {
 
     #[derive(Debug)]
     static ref GLOBALFDTABLE: Mutex<HashMap<u64, HashMap<u64,FDTableEntry>>> = {
-        let mut m = HashMap::new();
+        let m = HashMap::new();
         // Insert a cage so that I have something to fork / test later, if need
         // be. Otherwise, I'm not sure how I get this started. I think this
         // should be invalid from a 3i standpoint, etc. Could this mask an
@@ -60,34 +57,16 @@ lazy_static! {
 
 lazy_static! {
     // This is needed for close and similar functionality.  I need track the
-    // number of times a realfd is open
+    // number of times a (fdkind,underfd) is open.  Note that this is across
+    // cages in order to enable a library to have situations where two cages
+    // have the same fd open.  The (fdkind,underfd) tuple is the key and the
+    // number of times it appears is the value.  If it reaches 0, the entry
+    // is removed.
     #[derive(Debug)]
-    static ref GLOBALREALFDCOUNT: Mutex<HashMap<u64, u64>> = {
+    static ref GLOBALFDCOUNT: Mutex<HashMap<(u32,u64), u64>> = {
         Mutex::new(HashMap::new())
     };
 
-}
-
-// Internal helper to hold the close handlers...
-struct CloseHandlers {
-    intermediate_handler: fn(u64),
-    final_handler: fn(u64),
-    unreal_handler: fn(u64),
-}
-
-lazy_static! {
-    // This holds the user registered handlers they want to have called when
-    // a close occurs.  I did this rather than return messy data structures
-    // from the close, exec, and exit handlers because it seemed cleaner...
-    #[derive(Debug)]
-    static ref CLOSEHANDLERTABLE: Mutex<CloseHandlers> = {
-        let c = CloseHandlers {
-            intermediate_handler:NULL_FUNC,
-            final_handler:NULL_FUNC,
-            unreal_handler:NULL_FUNC,
-        };
-        Mutex::new(c)
-    };
 }
 
 #[doc = include_str!("../docs/check_cage_exists.md")]
@@ -98,18 +77,17 @@ pub fn check_cage_exists(cageid: u64) -> bool {
 
 #[doc = include_str!("../docs/init_empty_cage.md")]
 pub fn init_empty_cage(cageid: u64) {
-
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if fdtable.contains_key(&cageid) {
         panic!("Known cageid in fdtable access");
     }
 
-    fdtable.insert(cageid,HashMap::new());
+    fdtable.insert(cageid, HashMap::new());
 }
 
 #[doc = include_str!("../docs/translate_virtual_fd.md")]
-pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::RetVal> {
+pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<FDTableEntry, threei::RetVal> {
     // Get the lock on the fdtable...  I'm not handling "poisoned locks" now
     // where a thread holding the lock died...
     let fdtable = GLOBALFDTABLE.lock().unwrap();
@@ -122,13 +100,13 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
     }
 
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtualfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
 
     return match fdtable.get(&cageid).unwrap().get(&virtualfd) {
-        Some(tableentry) => Ok(tableentry.realfd),
+        Some(tableentry) => Ok(*tableentry),
         None => Err(threei::Errno::EBADFD as u64),
     };
 }
@@ -143,9 +121,10 @@ pub fn translate_virtual_fd(cageid: u64, virtualfd: u64) -> Result<u64, threei::
 #[doc = include_str!("../docs/get_unused_virtual_fd.md")]
 pub fn get_unused_virtual_fd(
     cageid: u64,
-    realfd: u64,
+    fdkind: u32,
+    underfd: u64,
     should_cloexec: bool,
-    optionalinfo: u64,
+    perfdinfo: u64,
 ) -> Result<u64, threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -156,9 +135,10 @@ pub fn get_unused_virtual_fd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
     let myfdmap = fdtable.get_mut(&cageid).unwrap();
@@ -169,7 +149,8 @@ pub fn get_unused_virtual_fd(
         // it in).
         if let std::collections::hash_map::Entry::Vacant(e) = myfdmap.entry(fdcandidate) {
             e.insert(myentry);
-            _increment_realfd(realfd);
+            drop(fdtable);
+            _increment_fdcount(myentry);
             return Ok(fdcandidate);
         }
     }
@@ -178,8 +159,8 @@ pub fn get_unused_virtual_fd(
     Err(threei::Errno::EMFILE as u64)
 }
 
-/// This is used to request an unused fd from specific starting position. This is 
-/// similar to `get_unused_virtual_fd` except this function starts from a specific 
+/// This is used to request an unused fd from specific starting position. This is
+/// similar to `get_unused_virtual_fd` except this function starts from a specific
 /// starting position mentioned by `arg` arguments. This will be used for `fcntl`.
 #[doc = include_str!("../docs/get_unused_virtual_fd_from_startfd.md")]
 pub fn get_unused_virtual_fd_from_startfd(
@@ -199,9 +180,10 @@ pub fn get_unused_virtual_fd_from_startfd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
     let myfdmap = fdtable.get_mut(&cageid).unwrap();
@@ -212,7 +194,8 @@ pub fn get_unused_virtual_fd_from_startfd(
         // it in).
         if let std::collections::hash_map::Entry::Vacant(e) = myfdmap.entry(fdcandidate) {
             e.insert(myentry);
-            _increment_realfd(realfd);
+            drop(fdtable);
+            _increment_fdcount(myentry);
             return Ok(fdcandidate);
         }
     }
@@ -227,9 +210,10 @@ pub fn get_unused_virtual_fd_from_startfd(
 pub fn get_specific_virtual_fd(
     cageid: u64,
     requested_virtualfd: u64,
-    realfd: u64,
+    fdkind: u32,
+    underfd: u64,
     should_cloexec: bool,
-    optionalinfo: u64,
+    perfdinfo: u64,
 ) -> Result<(), threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -249,29 +233,26 @@ pub fn get_specific_virtual_fd(
     // Note, a HashMap stores its data on the heap!  No need to box it...
     // https://doc.rust-lang.org/book/ch08-03-hash-maps.html#creating-a-new-hash-map
     let myentry = FDTableEntry {
-        realfd,
+        fdkind,
+        underfd,
         should_cloexec,
-        optionalinfo,
+        perfdinfo,
     };
 
-    // I moved this up so that if I decrement the same realfd, it calls
-    // the intermediate handler instead of the final one.
-    _increment_realfd(realfd);
+    // This is before the FDTABLE action, so if I decrement the same fd, it
+    // calls the intermediate handler instead of the last one.
+    _increment_fdcount(myentry);
 
     // always add the new entry.  insert returns the old entry.
-    let myoptionentry = fdtable.get_mut(&cageid).unwrap().insert(requested_virtualfd,myentry);
+    let myoptionentry = fdtable
+        .get_mut(&cageid)
+        .unwrap()
+        .insert(requested_virtualfd, myentry);
     drop(fdtable);
 
-    // Close the old entry, if I need to...
+    // Update the fdcount / close the old entry, if existed
     if let Some(entry) = myoptionentry {
-        if entry.realfd != NO_REAL_FD {
-            _decrement_realfd(entry.realfd);
-        }
-        else {
-            // Let their code know this has been closed...
-            let unrealclosehandler = (*CLOSEHANDLERTABLE.lock().unwrap()).unreal_handler;
-            (unrealclosehandler)(entry.optionalinfo);
-        }
+        _decrement_fdcount(entry);
     }
 
     Ok(())
@@ -296,37 +277,19 @@ pub fn set_cloexec(cageid: u64, virtualfd: u64, is_cloexec: bool) -> Result<(), 
     };
 }
 
-// Super easy, just return the optionalinfo field...
-#[doc = include_str!("../docs/get_optionalinfo.md")]
-pub fn get_optionalinfo(cageid: u64, virtualfd: u64) -> Result<u64, threei::RetVal> {
-    let fdtable = GLOBALFDTABLE.lock().unwrap();
-    if !fdtable.contains_key(&cageid) {
-        panic!("Unknown cageid in fdtable access");
-    }
-
-    return match fdtable.get(&cageid).unwrap().get(&virtualfd) {
-        Some(tableentry) => Ok(tableentry.optionalinfo),
-        None => Err(threei::Errno::EBADFD as u64),
-    };
-}
-
 // We're setting an opaque value here. This should be pretty straightforward.
-#[doc = include_str!("../docs/set_optionalinfo.md")]
-pub fn set_optionalinfo(
-    cageid: u64,
-    virtualfd: u64,
-    optionalinfo: u64,
-) -> Result<(), threei::RetVal> {
+#[doc = include_str!("../docs/set_perfdinfo.md")]
+pub fn set_perfdinfo(cageid: u64, virtualfd: u64, perfdinfo: u64) -> Result<(), threei::RetVal> {
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Set optionalinfo or return EBADFD, if that's missing...
+    // Set perfdinfo or return EBADFD, if that's missing...
     return match fdtable.get_mut(&cageid).unwrap().get_mut(&virtualfd) {
         Some(tableentry) => {
-            tableentry.optionalinfo = optionalinfo;
+            tableentry.perfdinfo = perfdinfo;
             Ok(())
         }
         None => Err(threei::Errno::EBADFD as u64),
@@ -350,9 +313,7 @@ pub fn copy_fdtable_for_cage(srccageid: u64, newcageid: u64) -> Result<(), three
 
     // increment the reference to items in the fdtable appropriately...
     for v in fdtable.get(&srccageid).unwrap().values() {
-        if v.realfd != NO_REAL_FD {
-            _increment_realfd(v.realfd);
-        }
+        _increment_fdcount(*v);
     }
 
     // insert the new table...
@@ -378,16 +339,8 @@ pub fn remove_cage_from_fdtable(cageid: u64) {
 
     // decrement the reference to items in the fdtable appropriately...
     for v in cagetable.values() {
-        if v.realfd != NO_REAL_FD {
-            _decrement_realfd(v.realfd);
-        }
-        else {
-            // Let their code know this has been closed...
-            let unrealclosehandler = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-            (unrealclosehandler)(v.optionalinfo);
-        }
+        _decrement_fdcount(*v);
     }
-
 }
 
 // This removes all fds with the should_cloexec flag set.  They are returned
@@ -400,62 +353,41 @@ pub fn empty_fds_for_exec(cageid: u64) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Create this hashmap through an lambda that checks should_cloexec...
-    // See: https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.extract_if
-
-/*    fdtable
-        .get_mut(&cageid)
-        .unwrap()
-        .extract_if(|_k, v| v.should_cloexec)
-        .collect()*/
-
-    // I'm writing the below code to avoid using the extract_if experimental 
+    // I'm writing the below code to avoid using the extract_if experimental
     // nightly function...
     let thiscagefdtable = fdtable.get_mut(&cageid).unwrap();
 
-    let mut without_cloexec_hm:HashMap<u64,FDTableEntry> = HashMap::new();
-    // I bother to put this in a hashmap so I can call the closehandlers
+    let mut without_cloexec_hm: HashMap<u64, FDTableEntry> = HashMap::new();
+    // I bother to put this in a vec so I can call the closehandlers
     // all after I have re-inserted everything.  This ensures the state
     // is consistent.  I only need the values, not the keys...
-    let mut with_cloexec_vec:Vec<FDTableEntry> = Vec::new();
+    let mut with_cloexec_vec: Vec<FDTableEntry> = Vec::new();
 
-    for (k,v) in thiscagefdtable.drain() {
+    for (k, v) in thiscagefdtable.drain() {
         if v.should_cloexec {
             with_cloexec_vec.push(v);
+        } else {
+            without_cloexec_hm.insert(k, v);
         }
-        else{
-            without_cloexec_hm.insert(k,v);
-        }
-
     }
 
-    // Put the ones without_cloexec back in the hashmap since they shouldn't 
+    // Put the ones without_cloexec back in the hashmap since they shouldn't
     // be closed...
-    fdtable.insert(cageid,without_cloexec_hm);
+    fdtable.insert(cageid, without_cloexec_hm);
     // Release the lock...
     drop(fdtable);
 
     // Now call the close handlers on the others...
     for v in with_cloexec_vec {
-        if v.realfd == NO_REAL_FD {
-            // Let their code know this has been closed...  I get the handler
-            // repeatedly in case they change it during execution of another
-            // handler...
-            let closehandlerunreal = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-            (closehandlerunreal)(v.optionalinfo);
-        }
-        else {
-            // Let the helper tell the user and decrement the count
-            _decrement_realfd(v.realfd);
-        }
+        _decrement_fdcount(v);
     }
-
 }
 
 // returns a copy of the fdtable for a cage.  Useful helper function for a
 // caller that needs to examine the table.  Likely could be more efficient by
 // letting the caller borrow this...
 #[doc = include_str!("../docs/return_fdtable_copy.md")]
+#[must_use] // must use the return value if you call it.
 pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
     let fdtable = GLOBALFDTABLE.lock().unwrap();
 
@@ -468,356 +400,465 @@ pub fn return_fdtable_copy(cageid: u64) -> HashMap<u64, FDTableEntry> {
 
 /******************* CLOSE SPECIFIC FUNCTIONALITY *******************/
 
-// Helper for close.  Returns a tuple of realfd, number of references
-// remaining.
-#[doc = include_str!("../docs/close_virtualfd.md")]
-pub fn close_virtualfd(cageid:u64, virtfd:u64) -> Result<(),threei::RetVal> {
+// These indicate what functions should be called upon a virtualfd closing.
+// The handler which is called depends on number of (fdkind,underfd) tuples
+// that are used across *all instances managed by this library including in
+// other cages*.
+struct CloseHandlers {
+    // Called when close is called, but at least one (fdkind,underfd)
+    // reference still remains.  Called with (FDTableEntry,count)
+    intermediate: fn(FDTableEntry, u64),
+    // Called when close is called, and no (fdkind,underfd)
+    // references remain. Called with (FDTableEntry,0)
+    last: fn(FDTableEntry, u64),
+}
 
+lazy_static! {
+    // This holds the user registered handlers they want to have called when
+    // a close occurs.  I did this rather than return messy data structures
+    // from the close, exec, and exit handlers because it seemed cleaner...
+    #[derive(Debug)]
+    static ref CLOSEHANDLERTABLE: Mutex<HashMap<u32,CloseHandlers>> = {
+        Mutex::new(HashMap::new())
+    };
+}
+
+#[doc = include_str!("../docs/close_virtualfd.md")]
+pub fn close_virtualfd(cageid: u64, virtfd: u64) -> Result<(), threei::RetVal> {
     // Below condition checks if the virtualfd is out of bounds and if yes it throws an error
-    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX 
+    // Note that this assumes that all virtualfd numbers returned < FD_PER_PROCESS_MAX
     if virtfd >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EBADFD as u64);
     }
-    
+
     let mut fdtable = GLOBALFDTABLE.lock().unwrap();
 
     if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Remove this item from the table (and inspect it)
+    // remove the closed item from the fdtable (and inspect it)
     let thisoption = fdtable.get_mut(&cageid).unwrap().remove(&virtfd);
     drop(fdtable);
 
     match thisoption {
-        Some(entry) =>
-            if entry.realfd == NO_REAL_FD {
-                // Let their code know this has been closed...
-                let closehandlerunreal = CLOSEHANDLERTABLE.lock().unwrap().unreal_handler;
-                let optionalinfo = entry.optionalinfo;
-                (closehandlerunreal)(optionalinfo);
-                Ok(())
-            }
-            else {
-                _decrement_realfd(entry.realfd);
-                Ok(())
-            }
+        Some(entry) => {
+            _decrement_fdcount(entry);
+            Ok(())
+        }
         None => Err(threei::Errno::EBADFD as u64),
     }
 }
 
-
 // Register a series of helpers to be called for close.  Can be called
 // multiple times to override the older helpers.
 #[doc = include_str!("../docs/register_close_handlers.md")]
-pub fn register_close_handlers(intermediate_handler: fn(u64), final_handler: fn(u64), unreal_handler: fn(u64)) {
+pub fn register_close_handlers(
+    fdkind: u32,
+    intermediate: fn(FDTableEntry, u64),
+    last: fn(FDTableEntry, u64),
+) {
     // Unlock the table and set the handlers...
-    // TODO: I made a serious attempt to try to keep closehandlers that call
-    // close, etc. from deadlocking the system.  More testing, etc. is needed.
-    let mut closehandlers = CLOSEHANDLERTABLE.lock().unwrap();
-    closehandlers.intermediate_handler = intermediate_handler;
-    closehandlers.final_handler = final_handler;
-    closehandlers.unreal_handler = unreal_handler;
+    let mut closehandlertable = CLOSEHANDLERTABLE.lock().unwrap();
+    let closehandler = CloseHandlers { intermediate, last };
+    // overwrite whatever is in there...
+    closehandlertable.insert(fdkind, closehandler);
 }
 
-// Helpers to track the count of times each realfd is used
+// Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _decrement_realfd(realfd:u64) -> u64 {
-    // Do nothing if it's not a realfd...
-    assert!(realfd != NO_REAL_FD, "Called _decrement_realfd with NO_REAL_FD");
+fn _decrement_fdcount(entry: FDTableEntry) {
+    let mytuple = (entry.fdkind, entry.underfd);
 
-    // Get this table's lock...
-    let mut realfdcount = GLOBALREALFDCOUNT.lock().unwrap();
+    let intermediatech;
+    let lastch;
 
-    let newcount:u64 = realfdcount.get(&realfd).unwrap() - 1;
     let closehandlers = CLOSEHANDLERTABLE.lock().unwrap();
-    let intermediateclosehandler = closehandlers.intermediate_handler;
-    let finalclosehandler = closehandlers.final_handler;
-    // release the lock...
+    if let Some(closehandlerentry) = closehandlers.get(&entry.fdkind) {
+        intermediatech = closehandlerentry.intermediate;
+        lastch = closehandlerentry.last;
+    } else {
+        intermediatech = NULL_FUNC;
+        lastch = NULL_FUNC;
+    }
     drop(closehandlers);
 
-    if newcount > 0 {
-        realfdcount.insert(realfd,newcount);
-        // Need to drop locks to call the handlers or else will deadlock...
-        drop(realfdcount);
+    let newcount;
+    let call_last;
 
-        (intermediateclosehandler)(realfd);
-    }
-    else {
-        // Remove before calling their close handler in case they do operations
-        // inside the close handler which create / close fds...
-        realfdcount.remove(&realfd);
-        // Need to drop locks to call the handlers or else will deadlock...
-        drop(realfdcount);
+    let mut fdcount = GLOBALFDCOUNT.lock().unwrap();
+    if let Some(count) = fdcount.get_mut(&mytuple) {
+        let old = *count;
+        newcount = old.checked_sub(1).unwrap_or_else(|| {
+            panic!("FDCOUNT underflow for key {:?}", mytuple);
+        });
 
-        (finalclosehandler)(realfd);
+        if newcount > 0 {
+            *count = newcount;
+            call_last = false;
+        } else {
+            fdcount.remove(&mytuple);
+            call_last = true;
+        }
+    } else {
+        panic!("FDCOUNT get failed. FDCOUNT missing key {:?}", mytuple);
     }
-    newcount
+    drop(fdcount);
+
+    if !call_last {
+        (intermediatech)(entry, newcount);
+    } else {
+        (lastch)(entry, 0);
+    }
 }
 
-// Helpers to track the count of times each realfd is used
+// Helpers to track the count of times each (fdkind,underfd) is used
 #[doc(hidden)]
-fn _increment_realfd(realfd:u64) -> u64 {
-    if realfd == NO_REAL_FD {
-        return 0
-    }
+fn _increment_fdcount(entry: FDTableEntry) {
+    let mytuple = (entry.fdkind, entry.underfd);
 
-    // Get this table's lock...
-    let mut realfdcount = GLOBALREALFDCOUNT.lock().unwrap();
+    let mut fdcount = GLOBALFDCOUNT.lock().unwrap();
 
     // Get a mutable reference to the entry so we can update it.
-    return match realfdcount.get_mut(&realfd) {
-        Some(count) => {
-            *count += 1;
-            *count
-        }
-        None => {
-            realfdcount.insert(realfd, 1);
-            1
-        }
+    if let Some(count) = fdcount.get_mut(&mytuple) {
+        *count += 1;
+    } else {
+        fdcount.insert(mytuple, 1);
     }
 }
 
 /***************   Code for handling select() ****************/
 
 use libc::fd_set;
-use std::collections::HashSet;
 use std::cmp;
+use std::collections::HashSet;
 use std::mem;
 
 // Helper to get an empty fd_set.  Helper function to isolate unsafe code,
 // etc.
 #[doc(hidden)]
+#[must_use] // must use the return value if you call it.
 pub fn _init_fd_set() -> fd_set {
-    let raw_fd_set:fd_set;
+    let raw_fd_set: fd_set;
     unsafe {
         let mut this_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
         libc::FD_ZERO(this_fd_set.as_mut_ptr());
-        raw_fd_set = this_fd_set.assume_init()
+        raw_fd_set = this_fd_set.assume_init();
     }
     raw_fd_set
 }
 
 #[doc(hidden)]
-pub fn _fd_set(fd:u64, thisfdset:&mut fd_set) {
-    unsafe{libc::FD_SET(fd as i32,thisfdset)}
+pub fn _fd_set(fd: u64, thisfdset: &mut fd_set) {
+    unsafe { libc::FD_SET(fd as i32, thisfdset) }
 }
 
 #[doc(hidden)]
-pub fn _fd_isset(fd:u64, thisfdset:&fd_set) -> bool {
-    unsafe{libc::FD_ISSET(fd as i32,thisfdset)}
+#[must_use] // must use the return value if you call it.
+pub fn _fd_isset(fd: u64, thisfdset: &fd_set) -> bool {
+    unsafe { libc::FD_ISSET(fd as i32, thisfdset) }
 }
 
-// Computes the bitmodifications and returns a (maxnfds, unrealset) tuple...
-#[doc(hidden)]
-fn _do_bitmods(myfdmap:HashMap<u64,FDTableEntry>, nfds:u64, infdset: fd_set, thisfdset: &mut fd_set, mappingtable: &mut HashMap<u64,u64>) -> Result<(u64,HashSet<(u64,u64)>),threei::RetVal> {
-    let mut unrealhashset:HashSet<(u64,u64)> = HashSet::new();
-    // Iterate through the infdset and set those values as is appropriate
-    let mut highestpos = 0;
-
-    // Clippy is somehow missing how pos is using bit.
-    #[allow(clippy::needless_range_loop)]
-    for bit in 0..nfds as usize {
-        let pos = bit as u64;
-        if _fd_isset(pos,&infdset) {
-            if let Some(entry) = myfdmap.get(&pos) {
-                if entry.realfd == NO_REAL_FD {
-                    unrealhashset.insert((pos,entry.optionalinfo));
-                }
-                else {
-                    mappingtable.insert(entry.realfd, pos);
-                    _fd_set(entry.realfd,thisfdset);
-                    // I add one because select expects nfds to be the max+1
-                    highestpos = cmp::max(highestpos, entry.realfd+1);
-                }
-            }
-            else {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-        }
-    }
-    Ok((highestpos,unrealhashset))
-}
+// This is a helper that just does a single type (r/w/e) and returns:
+//    bithashmap: HashMap<fdkind, (nfds, fd_set)>
+//    unhandledhashmap: HashMap<fdkind, HashSet<FDTableEntry>>
+//    mappingtable: HashMap<FDTableEntry, virt_fd>
+//
+// With this we trivially build the whole function...
 
 // helper to call before calling select beneath you.  Translates your virtfds
-// to realfds.
+// into a bitmask you may use for select.
 // See: https://man7.org/linux/man-pages/man2/select.2.html for details /
 // corner cases about the arguments.
+//
 
-// I hate doing these, but don't know how to make this interface better...
+// I hate doing this, but don't know how to make this interface better...
 #[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-#[doc = include_str!("../docs/get_real_bitmasks_for_select.md")]
-pub fn get_real_bitmasks_for_select(cageid:u64, nfds:u64, readbits:Option<fd_set>, writebits:Option<fd_set>, exceptbits:Option<fd_set>) -> Result<(u64, Option<fd_set>, Option<fd_set>, Option<fd_set>, [HashSet<(u64,u64)>;3], HashMap<u64,u64>),threei::RetVal> {
-
+#[allow(clippy::implicit_hasher)]
+#[doc = include_str!("../docs/get_bitmask_for_select.md")]
+pub fn get_bitmask_for_select(
+    cageid: u64,
+    nfds: u64,
+    bits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        HashMap<u32, (u64, fd_set)>,
+        HashMap<u32, HashSet<FDTableEntry>>,
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
     if nfds >= FD_PER_PROCESS_MAX {
         return Err(threei::Errno::EINVAL as u64);
     }
 
-    let globfdtable = GLOBALFDTABLE.lock().unwrap();
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-    if !globfdtable.contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    let mut unrealarray:[HashSet<(u64,u64)>;3] = [HashSet::new(),HashSet::new(),HashSet::new()];
-    let mut mappingtable:HashMap<u64,u64> = HashMap::new();
-    let mut newnfds = 0;
+    // The three things I will return...
+    let mut retbittable: HashMap<u32, (u64, fd_set)> = HashMap::new();
+    let mut retunparsedtable: HashMap<u32, HashSet<FDTableEntry>> = HashMap::new();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
 
-    // putting results in a vec was the cleanest way I found to do this..
-    let mut resultvec = Vec::new();
+    // If we were asked to do this on nothing, return empty mappings...
+    if bits.is_none() {
+        return Ok((retbittable, retunparsedtable, mappingtable));
+    }
 
-    for (unrealoffset, inset) in [readbits,writebits, exceptbits].into_iter().enumerate() {
-        match inset {
-            Some(virtualbits) => {
-                let mut retset = _init_fd_set();
-                let (thisnfds,myunrealhashset) = _do_bitmods(globfdtable.get(&cageid).unwrap().clone(),nfds,virtualbits, &mut retset,&mut mappingtable)?;
-                resultvec.push(Some(retset));
-                newnfds = cmp::max(thisnfds, newnfds);
-                unrealarray[unrealoffset] = myunrealhashset;
-            }
-            None => {
-                // This item is null.  No unreal items
-                resultvec.push(None);
-                unrealarray[unrealoffset] = HashSet::new();
+    let infdset = bits.unwrap();
+
+    let myfdmap = fdtable.get(&cageid).unwrap();
+
+    // Clippy is somehow missing how the virtualfd is being used throughout
+    // here.  It's not just a range value
+    #[allow(clippy::needless_range_loop)]
+    // iterate through the set bits...
+    for bit in 0..nfds as usize {
+        let pos = bit as u64;
+        if _fd_isset(pos, &infdset) {
+            if let Some(entry) = myfdmap.get(&pos) {
+                // I like to do the shorter case first rather than having
+                // it later.
+                #[allow(clippy::if_not_else)]
+                // Which return set do I go in?
+                if !fdkinds.contains(&entry.fdkind) {
+                    // Is unparsed...  Clippy's suggestion to insert if missing
+                    retunparsedtable.entry(entry.fdkind).or_default();
+                    retunparsedtable
+                        .get_mut(&entry.fdkind)
+                        .unwrap()
+                        .insert(*entry);
+                    // and update the mappingtable to have the bit from the
+                    // original fd...
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+                } else {
+                    let startingnfds;
+                    let mut startingfdset;
+
+                    // Either initialize it or use what exists
+                    if retbittable.contains_key(&entry.fdkind) {
+                        (startingnfds, startingfdset) = *retbittable.get(&entry.fdkind).unwrap();
+                    } else {
+                        startingnfds = 1;
+                        // I don't init this above because a fd_set is a large
+                        // data structure and would be costly.
+                        startingfdset = _init_fd_set();
+                    }
+
+                    // Update the table and the nfds
+                    _fd_set(entry.underfd, &mut startingfdset);
+                    let newnfds = cmp::max(startingnfds, entry.underfd + 1);
+
+                    // and update the mappingtable to have the bit from the
+                    // original fd...
+                    mappingtable.insert((entry.fdkind, entry.underfd), pos);
+
+                    // insert the item
+                    retbittable.insert(entry.fdkind, (newnfds, startingfdset));
+                }
+            } else {
+                return Err(threei::Errno::EBADF as u64);
             }
         }
     }
-
-    Ok((newnfds, resultvec[0], resultvec[1], resultvec[2], unrealarray, mappingtable))
-
+    Ok((retbittable, retunparsedtable, mappingtable))
 }
 
+#[allow(clippy::type_complexity)]
+#[allow(clippy::implicit_hasher)]
+#[doc = include_str!("../docs/prepare_bitmasks_for_select.md")]
+pub fn prepare_bitmasks_for_select(
+    cageid: u64,
+    nfds: u64,
+    rbits: Option<fd_set>,
+    wbits: Option<fd_set>,
+    ebits: Option<fd_set>,
+    fdkinds: &HashSet<u32>,
+) -> Result<
+    (
+        [HashMap<u32, (u64, fd_set)>; 3],
+        [HashMap<u32, HashSet<FDTableEntry>>; 3],
+        HashMap<(u32, u64), u64>,
+    ),
+    threei::RetVal,
+> {
+    // This is a pretty simple function.  Calls get_bitmask_for_select
+    // repeatedly and combines the results...
 
-// helper to call after calling select beneath you.  returns the fd_sets you
+    // return the error, if need be
+    let rresult = get_bitmask_for_select(cageid, nfds, rbits, fdkinds)?;
+    let wresult = get_bitmask_for_select(cageid, nfds, wbits, fdkinds)?;
+    let eresult = get_bitmask_for_select(cageid, nfds, ebits, fdkinds)?;
+
+    let mut mappingtable = rresult.2;
+    mappingtable.extend(wresult.2);
+    mappingtable.extend(eresult.2);
+
+    Ok((
+        [rresult.0, wresult.0, eresult.0],
+        [rresult.1, wresult.1, eresult.1],
+        mappingtable,
+    ))
+}
+
+// helper to call after calling select beneath you.  returns the fd_set you
 // need for your return from a select call and the number of unique flags
 // set...
 
-// I hate doing these, but don't know how to make this interface better...
-#[allow(clippy::type_complexity)]
-#[allow(clippy::too_many_arguments)]
-#[doc = include_str!("../docs/get_virtual_bitmasks_from_select_result.md")]
-pub fn get_virtual_bitmasks_from_select_result(nfds:u64, readbits:Option<fd_set>, writebits:Option<fd_set>, exceptbits:Option<fd_set>,unrealreadset:HashSet<u64>, unrealwriteset:HashSet<u64>, unrealexceptset:HashSet<u64>, mappingtable:&HashMap<u64,u64>) -> Result<(u64, Option<fd_set>, Option<fd_set>, Option<fd_set>),threei::RetVal> {
-
+// I given them the hashmap, so don't need flexibility in what they return...
+#[allow(clippy::implicit_hasher)]
+#[must_use] // must use the return value if you call it.
+#[doc = include_str!("../docs/get_one_virtual_bitmask_from_select_result.md")]
+pub fn get_one_virtual_bitmask_from_select_result(
+    fdkind: u32,
+    nfds: u64,
+    bits: Option<fd_set>,
+    unprocessedset: HashSet<u64>,
+    startingbits: Option<fd_set>,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> (u64, Option<fd_set>) {
     // Note, I don't need the cage_id here because I have the mappingtable...
 
-    if nfds >= FD_PER_PROCESS_MAX {
-        panic!("This shouldn't be possible because we shouldn't have returned this previously")
-    }
+    assert!(
+        nfds < FD_PER_PROCESS_MAX,
+        "This shouldn't be possible because we shouldn't have returned this previously"
+    );
 
     let mut flagsset = 0;
-    let mut retvec = Vec::new();
 
-    for (insetoption,unrealset) in [(readbits,unrealreadset), (writebits,unrealwriteset), (exceptbits,unrealexceptset)] {
-        // If I don't have any data, just return None (NULL) and skip...
-        if insetoption.is_none()&&unrealset.is_empty() {
-            retvec.push(None);
-            continue;
-        }
-
-        let mut retbits = _init_fd_set();
-        if let Some(inset) = insetoption {
-            for bit in 0..nfds as usize {
-                let pos = bit as u64;
-                if _fd_isset(pos,&inset)&& !_fd_isset(*mappingtable.get(&pos).unwrap(),&retbits) {
-                    flagsset+=1;
-                    _fd_set(*mappingtable.get(&pos).unwrap(),&mut retbits);
-                }
-            }
-        }
-        for virtfd in unrealset {
-            if !_fd_isset(virtfd,&retbits) {
-                flagsset+=1;
-                _fd_set(virtfd,&mut retbits);
-            }
-        }
-        retvec.push(Some(retbits));
+    if bits.is_none() && unprocessedset.is_empty() {
+        return (flagsset, None);
     }
 
-    Ok((flagsset,retvec[0],retvec[1],retvec[2]))
+    // I probably should pass a reference to startingbits to avoid copying the
+    // bit structure...
+    let mut retbits = match startingbits {
+        Some(val) => val,
+        None => _init_fd_set(),
+    };
 
+    if let Some(inset) = bits {
+        for bit in 0..nfds as usize {
+            let pos = bit as u64;
+            if _fd_isset(pos, &inset)
+                && !_fd_isset(*mappingtable.get(&(fdkind, pos)).unwrap(), &retbits)
+            {
+                flagsset += 1;
+                _fd_set(*mappingtable.get(&(fdkind, pos)).unwrap(), &mut retbits);
+            }
+        }
+    }
+    for virtfd in unprocessedset {
+        if !_fd_isset(virtfd, &retbits) {
+            flagsset += 1;
+            _fd_set(virtfd, &mut retbits);
+        }
+    }
+
+    (flagsset, Some(retbits))
 }
-
-
 
 /********************** POLL SPECIFIC FUNCTIONS **********************/
 
 // helper to call before calling poll beneath you.  replaces the fds in
 // the poll struct with virtual versions and returns the items you need
 // to check yourself...
+#[allow(clippy::implicit_hasher)]
 #[allow(clippy::type_complexity)]
-#[doc = include_str!("../docs/convert_virtualfds_to_real.md")]
-pub fn convert_virtualfds_to_real(cageid:u64, virtualfds:Vec<u64>) -> (Vec<u64>, Vec<(u64,u64)>, Vec<u64>, HashMap<u64,u64>) {
+#[doc = include_str!("../docs/convert_virtualfds_for_poll.md")]
+#[must_use] // must use the return value if you call it.
+pub fn convert_virtualfds_for_poll(
+    cageid: u64,
+    virtualfds: HashSet<u64>,
+) -> (
+    HashMap<u32, HashSet<(u64, FDTableEntry)>>,
+    HashMap<(u32, u64), u64>,
+) {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-    let globfdtable = GLOBALFDTABLE.lock().unwrap();
-
-    if !globfdtable.contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    let mut unrealvec = Vec::new();
-    let mut realvec = Vec::new();
-    let mut invalidvec = Vec::new();
-    let thefdhm = globfdtable.get(&cageid).unwrap();
-    let mut mappingtable:HashMap<u64,u64> = HashMap::new();
+    let myfdmap = fdtable.get(&cageid).unwrap();
+    let mut mappingtable: HashMap<(u32, u64), u64> = HashMap::new();
+    let mut rethashmap: HashMap<u32, HashSet<(u64, FDTableEntry)>> = HashMap::new();
 
     // BUG?: I'm ignoring the fact that virtualfds can show up multiple times.
     // I'm not sure this actually matters, but I didn't think hard about it.
     for virtfd in virtualfds {
-        match thefdhm.get(&virtfd) {
-            Some(entry) => {
-                // always append the value here.  NO_REAL_FD will be added
-                // in the appropriate places to tell them to handle those calls
-                // themself.
-                realvec.push(entry.realfd);
-                if entry.realfd == NO_REAL_FD {
-                    unrealvec.push((virtfd,entry.optionalinfo));
-                }
-                else{
-                    mappingtable.insert(entry.realfd, virtfd);
-                }
-            }
-            None => {
-                // Add this because they need to handle it if POLLNVAL is set.
-                // An exception should not be raised!!!
-                realvec.push(INVALID_FD);
-                invalidvec.push(virtfd);
-            }
+        if let Some(entry) = myfdmap.get(&virtfd) {
+            // Insert an empty HashSet, if needed
+            rethashmap.entry(entry.fdkind).or_default();
+            mappingtable
+                .entry((entry.fdkind, entry.underfd))
+                .or_default();
+
+            rethashmap
+                .get_mut(&entry.fdkind)
+                .unwrap()
+                .insert((virtfd, *entry));
+            mappingtable.insert((entry.fdkind, entry.underfd), virtfd);
+        } else {
+            let myentry = FDTableEntry {
+                fdkind: FDT_INVALID_FD,
+                underfd: virtfd,
+                should_cloexec: false,
+                perfdinfo: u64::from(FDT_INVALID_FD),
+            };
+
+            // Insert an empty HashSet, if needed
+            rethashmap.entry(FDT_INVALID_FD).or_default();
+            mappingtable.entry((FDT_INVALID_FD, virtfd)).or_default();
+
+            rethashmap
+                .get_mut(&FDT_INVALID_FD)
+                .unwrap()
+                .insert((virtfd, myentry));
+            // Add this because they need to handle it if POLLNVAL is set.
+            // An exception should not be raised!!!
+
+            // I will add this to the mapping table, because I do think they
+            // may want to raise an exception, etc. based upon this and signal
+            // back.  I am setting the underfd to be the virtfd, so I can
+            // reverse this process, if multiple entries like this occur.
+            mappingtable.insert((FDT_INVALID_FD, virtfd), virtfd);
         }
     }
 
-    (realvec, unrealvec, invalidvec, mappingtable)
+    (rethashmap, mappingtable)
 }
 
-
-
-// helper to call after calling poll.  replaces the realfds the vector
+// helper to call after calling poll.  replaces the fds in the vector
 // with virtual ones...
-#[doc = include_str!("../docs/convert_realfds_back_to_virtual.md")]
-pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u64,u64>) -> Vec<u64> {
-
+#[doc = include_str!("../docs/convert_poll_result_back_to_virtual.md")]
+// I give them the hashmap, so don't need flexibility in what they return...
+#[allow(clippy::implicit_hasher)]
+#[must_use] // must use the return value if you call it.
+pub fn convert_poll_result_back_to_virtual(
+    fdkind: u32,
+    underfd: u64,
+    mappingtable: &HashMap<(u32, u64), u64>,
+) -> Option<u64> {
     // I don't care what cage was used, and don't need to lock anything...
     // I have the mappingtable!
 
-    let mut virtvec = Vec::new();
-
-    for realfd in realfds {
-        virtvec.push(*mappingtable.get(&realfd).unwrap());
-    }
-
-    virtvec
+    // Should this even be a function?
+    mappingtable.get(&(fdkind, underfd)).copied()
 }
 
 /********************** EPOLL SPECIFIC FUNCTIONS **********************/
 
-
-// Okay this adds a big wrinkle, epollfds.  The reason these are complex is
-// multi-fold:
-// 1) they themselves are file descriptors and take up a slot.
-// 2) a epollfd can point to any number of other fds
+// Supporting epollfds is done by a fdkind which is not set by the user.
+// There are a few complexities here:
+// 1) an epollfd gets a virtual file descriptor
+// 2) a epollfd can point to any number of other fds of different kinds
 // 3) an epollfd can point to epollfds, which can point to other epollfds, etc.
 //    and possibly cause a loop to occur (which is an error)
-// 4) an epollfd can point to a mix of virtual and realfds.
 //
 // My thinking is this is handled as similarly to poll as possible.  We push
 // off the problem of understanding what the event types are to the implementer
@@ -828,21 +869,13 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 // types, which they may need to poll themselves.  After this, they handle the
 // call.
 //
-// epoll_create makes a new fd type, which really is unfortunate.  To this
-// point, I haven't had to care about anything except in-memory fds (unreal),
-// and doing the virtual <-> real mappings.  The caller can decide whether to
-// create an underlying epollfd when this is called, when epoll_ctl is called
-// to add a realfd, etc.
-//
 // epoll_ctl is complex, but really has the same fundamental problem as
 // epoll_create: the epollfd.
 //
-// What if I just ignore the epollfd problem by just making another table
-// for epoll information?  Then what I do is set the realfd to EPOLLFD and
-// have optionalinfo point into the epollfd table.  If I do this, then when
-// epoll_create is called, if it contains realfds, those need to be passed
-// down to the underlying epoll_create.  Similarly, when epoll_ctl is called,
-// we either modify our data or return the realfd...
+// I'll create a new fdkind for epoll.  When epoll_create is called, the
+// caller can decide which fdkinds need to be passed down to the underlying
+// epoll_create call(s).  Similarly, when epoll_ctl is called, one either
+// handles the call internally or uses the underfd for the fdkind...
 //
 // Interestingly, this actually would be just as easy to build on top of the
 // fdtables library as into it.
@@ -856,9 +889,20 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 // them on systems that don't support epoll and I want to be able to build
 // the code anywhere.  See commonconstants.rs for more info.
 
-// Design notes: I'm not adding realfds.  I return them when you do a epoll_ctl
-// operation that tries to add them.  So, I only have unrealfds in my epoll
-// structures.
+// a structure that exists for each epoll descriptor to track the underfd(s)
+// and parts the user will handle
+#[derive(Clone, Debug, Default)]
+struct EPollDescriptorInfo {
+    // I didn't combine these two hashmaps into one because they are used
+    // separately and the resulting value type would be too messy...
+    underfdhashmap: HashMap<u32, u64>, // The underfd for a specific fdkind.
+    // Used only when an epoll call will
+    // call down beneath it.
+    userhandledhashmap: HashMap<u32, HashMap<u64, epoll_event>>,
+    // This has all of the things the user
+    // will virtualize and handle.  The key
+    // is the fdkind.
+}
 
 // TODO: I don't clean up this table yet.  I probably should when the last
 // reference to a fd is closed, but this bookkeeping seems excessive at this
@@ -866,13 +910,8 @@ pub fn convert_realfds_back_to_virtual(realfds:Vec<u64>, mappingtable:&HashMap<u
 #[derive(Clone, Debug)]
 struct EPollTable {
     highestneverusedentry: u64, // Never resets (even after close).  Used to
-                                // let us quickly get an unused entry
-    thisepolltable: HashMap<u64,HashMap<u64,epoll_event>>, // the epollentry ->
-                                                           // virtfd ->
-                                                           // event map
-    realfdtable: HashMap<u64,u64>, // the epollentry -> realfd map.  I need 
-                                   // this because the realfd field in the
-                                   // main data structure is EPOLLFD
+    // let us quickly get an unused entry
+    thisepolltable: HashMap<u64, EPollDescriptorInfo>,
 }
 
 lazy_static! {
@@ -880,152 +919,227 @@ lazy_static! {
     #[derive(Debug)]
     static ref EPOLLTABLE: Mutex<EPollTable> = {
         let newetable = HashMap::new();
-        let newrealfdtable = HashMap::new();
         let m = EPollTable {
             highestneverusedentry:0,
-            realfdtable:newrealfdtable,
             thisepolltable:newetable,
         };
         Mutex::new(m)
     };
 }
 
+fn _get_epoll_entrynum_or_error(
+    fdtable: &HashMap<u64, HashMap<u64, FDTableEntry>>,
+    cageid: u64,
+    epfd: u64,
+) -> Result<u64, threei::RetVal> {
+    // Is the epfd ok?
+    match fdtable.get(&cageid).unwrap().get(&epfd) {
+        None => Err(threei::Errno::EBADF as u64),
+        Some(tableentry) => {
+            // You must call this on an epoll fd
+            if tableentry.fdkind == FDT_KINDEPOLL {
+                Ok(tableentry.underfd)
+            } else {
+                Err(threei::Errno::EINVAL as u64)
+            }
+        }
+    }
+}
 
-#[doc = include_str!("../docs/epoll_create_helper.md")]
-pub fn epoll_create_helper(cageid:u64, realfd:u64, should_cloexec:bool) -> Result<u64,threei::RetVal> {
+#[doc = include_str!("../docs/epoll_create_empty.md")]
+pub fn epoll_create_empty(cageid: u64, should_cloexec: bool) -> Result<u64, threei::RetVal> {
+    let mut ept = EPOLLTABLE.lock().unwrap();
+
+    // return the same errno (EMFile), if we get one
+    let newepollfd = get_unused_virtual_fd(
+        cageid,
+        FDT_KINDEPOLL,
+        ept.highestneverusedentry,
+        should_cloexec,
+        0,
+    )?;
+
+    let newentrynum = ept.highestneverusedentry;
+    ept.highestneverusedentry += 1;
+
+    // Create a new entry with empty values
+    ept.thisepolltable.entry(newentrynum).or_default();
+    Ok(newepollfd)
+}
+
+#[doc = include_str!("../docs/epoll_add_underfd.md")]
+pub fn epoll_add_underfd(
+    cageid: u64,
+    virtepollfd: u64,
+    fdkind: u32,
+    underfd: u64,
+) -> Result<(), threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
+
+    if !fdtable.contains_key(&cageid) {
+        panic!("Unknown cageid in fdtable access");
+    }
 
     let mut ept = EPOLLTABLE.lock().unwrap();
 
-    // I'll use my other functions to make this easier.
-    // return the same errno (EMFile), if we get one
-    let newepollfd = get_unused_virtual_fd(cageid, EPOLLFD, should_cloexec, ept.highestneverusedentry)?;
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, virtepollfd)?;
 
-    let newentry = ept.highestneverusedentry;
-    ept.highestneverusedentry+=1;
-    // add in my realfd.
-    ept.realfdtable.insert(newentry,realfd);
-    // if it errored out above that is okay. I haven't changed any state yet.
-    ept.thisepolltable.insert(newentry, HashMap::new());
-    Ok(newepollfd)
+    let myhm = &mut ept
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .underfdhashmap;
 
+    assert!(
+        !myhm.contains_key(&fdkind),
+        "Adding duplicate underfd to epollfd"
+    );
+
+    myhm.insert(fdkind, underfd);
+
+    Ok(())
 }
 
+#[doc = include_str!("../docs/epoll_get_underfd_hashmap.md")]
+pub fn epoll_get_underfd_hashmap(
+    cageid: u64,
+    virtepollfd: u64,
+) -> Result<HashMap<u32, u64>, threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
+    if !fdtable.contains_key(&cageid) {
+        panic!("Unknown cageid in fdtable access");
+    }
 
-#[doc = include_str!("../docs/try_epoll_ctl.md")]
-pub fn try_epoll_ctl(cageid:u64, epfd:u64, op:i32, virtfd:u64, event:epoll_event) -> Result<(u64,u64),threei::RetVal> {
+    let ept = EPOLLTABLE.lock().unwrap();
 
-    if !GLOBALFDTABLE.lock().unwrap().contains_key(&cageid) {
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, virtepollfd)?;
+
+    Ok(ept
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .underfdhashmap
+        .clone())
+}
+
+#[doc = include_str!("../docs/virtualize_epoll_ctl.md")]
+pub fn virtualize_epoll_ctl(
+    cageid: u64,
+    epfd: u64,
+    op: i32,
+    virtfd: u64,
+    event: epoll_event,
+) -> Result<(), threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
+
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
     if epfd == virtfd {
         return Err(threei::Errno::EINVAL as u64);
     }
-    // Is the epfd ok?
-    let epollentrynum:u64 = match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().get(&epfd) {
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != EPOLLFD {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-            tableentry.optionalinfo
-        },
-    };
 
-    // Okay, I know which table entry and verified the virtfd...
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, epfd)?;
 
-    let mut epttable = EPOLLTABLE.lock().unwrap();
-    let realepollfd = epttable.realfdtable.get(&epollentrynum).unwrap().clone();
-    let eptentry = epttable.thisepolltable.get_mut(&epollentrynum).unwrap();
+    // Okay, I know which table entry, now verify the virtfd...
 
-    // check if the virtfd is real and error...
-    // I don't care about its contents except to ensure it isn't real...
-    match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().get(&virtfd) {
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != NO_REAL_FD {
-                // Return realfds because the caller should handle them instead
-                // I only track unrealfds.
-                if tableentry.realfd == EPOLLFD {
-                    // BUG: How should I be doing this, really!?!
-                    println!("epollfds acting on epollfds is not supported!");
-                }
-                return Ok((realepollfd,tableentry.realfd));
-            }
-        },
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-    };
+    let virtfdkind: u32;
 
-    // okay, virtfd is real...
+    if let Some(tableentry) = fdtable.get(&cageid).unwrap().get(&virtfd) {
+        // Right now, I don't support this, so error...
+        if tableentry.fdkind == FDT_KINDEPOLL {
+            // TODO: support EPOLLFDs...
+            return Err(threei::Errno::ENOSYS as u64);
+        }
+        virtfdkind = tableentry.fdkind;
+    } else {
+        // The virtual Fd doesn't exist -- error...
+        return Err(threei::Errno::EBADF as u64);
+    }
+
+    let mut eptable = EPOLLTABLE.lock().unwrap();
+    let userhm = &mut eptable
+        .thisepolltable
+        .get_mut(&epentrynum)
+        .unwrap()
+        .userhandledhashmap;
 
     match op {
         EPOLL_CTL_ADD => {
-            if eptentry.contains_key(&virtfd) {
+            let thisuserhm = userhm.entry(virtfdkind).or_default();
+            if thisuserhm.contains_key(&virtfd) {
                 return Err(threei::Errno::EEXIST as u64);
             }
-            // BUG: Need to check for ELOOP here...
+            // BUG: Need to check for ELOOP here once I support EPOLLFDs
+            // referencing each other...
 
-            eptentry.insert(virtfd, event);
-        },
+            thisuserhm.insert(virtfd, event);
+        }
         EPOLL_CTL_MOD => {
-            if !eptentry.contains_key(&virtfd) {
+            if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
             }
-            eptentry.insert(virtfd, event);
-        },
+            let thisuserhm: &mut HashMap<u64, epoll_event> = userhm.get_mut(&virtfdkind).unwrap();
+            if !thisuserhm.contains_key(&virtfd) {
+                return Err(threei::Errno::ENOENT as u64);
+            }
+            thisuserhm.insert(virtfd, event);
+        }
         EPOLL_CTL_DEL => {
-            if !eptentry.contains_key(&virtfd) {
+            if !userhm.contains_key(&virtfdkind) {
                 return Err(threei::Errno::ENOENT as u64);
             }
-            eptentry.remove(&virtfd);
-        },
+            let thisuserhm: &mut HashMap<u64, epoll_event> = userhm.get_mut(&virtfdkind).unwrap();
+            if !thisuserhm.contains_key(&virtfd) {
+                return Err(threei::Errno::ENOENT as u64);
+            }
+            thisuserhm.remove(&virtfd);
+            // If this was the last entry, delete the key altogether...
+            if thisuserhm.is_empty() {
+                userhm.remove(&virtfdkind);
+            }
+        }
         _ => {
             return Err(threei::Errno::EINVAL as u64);
-        },
+        }
     };
-    Ok((realepollfd,NO_REAL_FD))
+    Ok(())
 }
 
+#[doc = include_str!("../docs/get_virtual_epoll_wait_data.md")]
+pub fn get_virtual_epoll_wait_data(
+    cageid: u64,
+    epfd: u64,
+) -> Result<HashMap<u32, HashMap<u64, epoll_event>>, threei::RetVal> {
+    let fdtable = GLOBALFDTABLE.lock().unwrap();
 
-#[doc = include_str!("../docs/get_epoll_wait_data.md")]
-pub fn get_epoll_wait_data(cageid:u64, epfd:u64) -> Result<(u64,HashMap<u64,epoll_event>),threei::RetVal> {
-
-    if !GLOBALFDTABLE.lock().unwrap().contains_key(&cageid) {
+    if !fdtable.contains_key(&cageid) {
         panic!("Unknown cageid in fdtable access");
     }
 
-    // Note that because I don't track realfds or deal with epollfds, I just
-    // return the epolltable...
-    let epollentrynum:u64 = match GLOBALFDTABLE.lock().unwrap().get(&cageid).unwrap().get(&epfd) {
-        None => {
-            return Err(threei::Errno::EBADF as u64);
-        },
-        // Do I need to have EPOLLFDs here too?
-        Some(tableentry) => {
-            if tableentry.realfd != EPOLLFD {
-                return Err(threei::Errno::EINVAL as u64);
-            }
-            tableentry.optionalinfo
-        },
-    };
+    // get this or error out...
+    let epentrynum = _get_epoll_entrynum_or_error(&fdtable, cageid, epfd)?;
 
-    let epttable = EPOLLTABLE.lock().unwrap();
-    Ok((*epttable.realfdtable.get(&epollentrynum).unwrap(),epttable.thisepolltable[&epollentrynum].clone()))
+    let eptable = EPOLLTABLE.lock().unwrap();
+    Ok(eptable
+        .thisepolltable
+        .get(&epentrynum)
+        .unwrap()
+        .userhandledhashmap
+        .clone())
 }
-
 
 /********************** TESTING HELPER FUNCTION **********************/
 
 // Helper to initialize / empty out state so we can test with a clean system...
 // only used when testing...
 //
-// I'm cleaning up "poisoned" mutexes here so that I can handle tests that 
+// I'm cleaning up "poisoned" mutexes here so that I can handle tests that
 // panic
 #[doc(hidden)]
 pub fn refresh() {
@@ -1039,11 +1153,10 @@ pub fn refresh() {
         CLOSEHANDLERTABLE.clear_poison();
         e.into_inner()
     });
-    closehandlers.intermediate_handler = NULL_FUNC;
-    closehandlers.final_handler = NULL_FUNC;
-    closehandlers.unreal_handler = NULL_FUNC;
-    let mut _realfdcount = GLOBALREALFDCOUNT.lock().unwrap_or_else(|e| {
-        GLOBALREALFDCOUNT.clear_poison();
+    closehandlers.clear();
+
+    let mut _fdcount = GLOBALFDCOUNT.lock().unwrap_or_else(|e| {
+        GLOBALFDCOUNT.clear_poison();
         e.into_inner()
     });
 }


### PR DESCRIPTION
Update muthashmaxglobal.rs and vanillaglobal.rs to match the current dashmaparrayglobal.rs API: FDTableEntry field renames (realfd ->underfd, optionalinfo -> perfdinfo), constant renames (NO_REAL_FD removed, INVALID_FD -> FDT_INVALID_FD, EPOLLFD -> FDT_KINDEPOLL), per-fdkind close handler architecture, updated select/poll/epoll functions, and corrected doc include references.

Apply rustfmt to all four implementation files.

All implementations pass the full test suite (24/24 unit tests).

Fixes #1038
Fixes #971