### PR TITLE
add GRATE_MEMORY_FLAG macro for grate address space pointers

### DIFF
--- a/src/glibc/lind_syscall/lind_syscall.h
+++ b/src/glibc/lind_syscall/lind_syscall.h
@@ -18,6 +18,15 @@
 
 #include <stdint.h> // For uint64_t definition
 
+/*
+ * Flag to mark an argcageid as pointing into the grate's own linear memory
+ * rather than the calling cage's memory. OR this with the cageid when passing
+ * a pointer that lives in the grate's address space.
+ *
+ * Example: arg2cageid = my_cageid | GRATE_MEMORY_FLAG
+ */
+#define GRATE_MEMORY_FLAG ((uint64_t)1 << 63)
+
 int make_threei_call (unsigned int callnumber, 
     uint64_t callname, 
     uint64_t self_cageid, uint64_t target_cageid,

--- a/tests/grate-tests/simple-tests/diff-cage-args_grate.c
+++ b/tests/grate-tests/simple-tests/diff-cage-args_grate.c
@@ -76,7 +76,7 @@ int open_grate(uint64_t cageid, uint64_t arg1, uint64_t arg1cage, uint64_t arg2,
 	    2, 0, self_grate_id, arg1cage,
 	    // We need to modify the cageid here to indicate that we want the
 	    // address translated.
-	    (uint64_t)&new_path, self_grate_id | (1ULL << 63), arg2, arg2cage,
+	    (uint64_t)&new_path, self_grate_id | GRATE_MEMORY_FLAG, arg2, arg2cage,
 	    arg3, arg3cage, arg4, arg4cage, arg5, arg5cage, arg6, arg6cage,
 	    0 // we will handle the errno in this grate instead of translating
 	      // it to


### PR DESCRIPTION
When a grate passes a pointer that lives in its own linear memory (rather than the calling cage's memory), the argcageid must be OR'd with this flag so the address translation layer resolves against the grate's address space.

Adding a MACRO here to avoid magic numbers in this situation.
