### PR TITLE
Interrupt blocking host syscalls on signal delivery

### DIFF
--- a/src/cage/src/signal/signal.rs
+++ b/src/cage/src/signal/signal.rs
@@ -337,6 +337,18 @@ pub fn lind_send_signal(cageid: u64, signo: i32) -> bool {
             // we only trigger epoch if the signal is not blocked
             if !signal_check_block(cageid, signo) {
                 signal_epoch_trigger(cageid);
+
+                // If the target thread is blocked in a host syscall (read, write,
+                // futex, etc.), the epoch check will never run because wasm isn't
+                // executing. Send SIGUSR2 to the main thread's OS tid to interrupt
+                // the blocking syscall with EINTR, allowing the thread to return
+                // to wasm and see the epoch change.
+                let main_tid = *cage.main_threadid.read();
+                if let Some(os_tid) = cage.os_tid_map.get(&main_tid) {
+                    unsafe {
+                        libc::syscall(libc::SYS_tkill, *os_tid as i32, libc::SIGUSR2);
+                    }
+                }
             }
         }
 

--- a/tests/unit-tests/signal_tests/deterministic/signal_read_interrupt.c
+++ b/tests/unit-tests/signal_tests/deterministic/signal_read_interrupt.c
@@ -1,0 +1,51 @@
+// Test: SIGUSR1 interrupts a blocking read on an empty pipe.
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <assert.h>
+
+static volatile int sig_fired = 0;
+
+static void handler(int sig) {
+    (void)sig;
+    sig_fired = 1;
+}
+
+static void *sender(void *arg) {
+    pid_t pid = *(pid_t *)arg;
+    usleep(500000);
+    kill(pid, SIGUSR1);
+    return NULL;
+}
+
+int main(void) {
+    struct sigaction sa;
+    sa.sa_handler = handler;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    assert(sigaction(SIGUSR1, &sa, NULL) == 0);
+
+    int pipefd[2];
+    assert(pipe(pipefd) == 0);
+
+    pid_t pid = getpid();
+    pthread_t t;
+    pthread_create(&t, NULL, sender, &pid);
+
+    char buf[1];
+    ssize_t ret = read(pipefd[0], buf, sizeof(buf));
+
+    assert(ret < 0);
+    assert(errno == EINTR);
+    assert(sig_fired == 1);
+
+    pthread_join(t, NULL);
+    close(pipefd[0]);
+    close(pipefd[1]);
+    printf("signal_read_interrupt: all tests passed\n");
+    return 0;
+}

--- a/tests/unit-tests/signal_tests/deterministic/signal_select_interrupt.c
+++ b/tests/unit-tests/signal_tests/deterministic/signal_select_interrupt.c
@@ -1,0 +1,54 @@
+// Test: SIGUSR1 interrupts a blocking select on an empty pipe.
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <sys/select.h>
+#include <assert.h>
+
+static volatile int sig_fired = 0;
+
+static void handler(int sig) {
+    (void)sig;
+    sig_fired = 1;
+}
+
+static void *sender(void *arg) {
+    pid_t pid = *(pid_t *)arg;
+    usleep(500000);
+    kill(pid, SIGUSR1);
+    return NULL;
+}
+
+int main(void) {
+    struct sigaction sa;
+    sa.sa_handler = handler;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    assert(sigaction(SIGUSR1, &sa, NULL) == 0);
+
+    int pipefd[2];
+    assert(pipe(pipefd) == 0);
+
+    pid_t pid = getpid();
+    pthread_t t;
+    pthread_create(&t, NULL, sender, &pid);
+
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(pipefd[0], &rfds);
+    int ret = select(pipefd[0] + 1, &rfds, NULL, NULL, NULL);
+
+    assert(ret < 0);
+    assert(errno == EINTR);
+    assert(sig_fired == 1);
+
+    pthread_join(t, NULL);
+    close(pipefd[0]);
+    close(pipefd[1]);
+    printf("signal_select_interrupt: all tests passed\n");
+    return 0;
+}

--- a/tests/unit-tests/signal_tests/deterministic/signal_write_interrupt.c
+++ b/tests/unit-tests/signal_tests/deterministic/signal_write_interrupt.c
@@ -1,0 +1,59 @@
+// Test: SIGALRM interrupts a blocking write on a full pipe.
+//
+// Expected behavior:
+//   1. alarm(1) fires after 1 second, calling alarm_handler.
+//   2. The blocking write() on the full pipe returns -1 with errno=EINTR.
+//   3. Program prints success and exits 0.
+//
+// If the write is never interrupted the program hangs indefinitely.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+
+static volatile int alarm_fired = 0;
+
+static void alarm_handler(int sig) {
+    (void)sig;
+    alarm_fired = 1;
+}
+
+int main(void) {
+    struct sigaction sa;
+    sa.sa_handler = alarm_handler;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    assert(sigaction(SIGALRM, &sa, NULL) == 0);
+
+    int pipefd[2];
+    assert(pipe(pipefd) == 0);
+
+    // Fill the pipe buffer using O_NONBLOCK so we can detect when it's full.
+    int flags = fcntl(pipefd[1], F_GETFL);
+    fcntl(pipefd[1], F_SETFL, flags | O_NONBLOCK);
+    char buf[4096];
+    memset(buf, 0x42, sizeof(buf));
+    while (write(pipefd[1], buf, sizeof(buf)) > 0)
+        ;
+    // Pipe is full. Restore blocking mode.
+    fcntl(pipefd[1], F_SETFL, flags);
+
+    alarm(1);
+
+    // This write should block until SIGALRM interrupts it.
+    ssize_t ret = write(pipefd[1], buf, 1);
+
+    assert(ret < 0);
+    assert(errno == EINTR);
+    assert(alarm_fired == 1);
+
+    close(pipefd[0]);
+    close(pipefd[1]);
+    printf("signal_write_interrupt: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
When a lind signal is delivered to a cage whose main thread is blocked in a host syscall (read, write, select, futex, etc.), the epoch check never runs because wasm isn't executing. Send SIGUSR2 to the main thread's OS tid to interrupt the blocking syscall with EINTR, allowing the thread to return to wasm and see the pending signal.

Uses the same SIGUSR2/tkill mechanism that epoch_kill_all already uses for exit_group, but applied to general signal delivery in lind_send_signal.

Tests:
- signal_write_interrupt: SIGALRM interrupts blocking write on full pipe
- signal_read_interrupt: SIGUSR1 from thread interrupts blocking read
- signal_select_interrupt: SIGUSR1 from thread interrupts blocking select
