### PR TITLE
fix guard page for thread creation

### DIFF
--- a/src/glibc/nptl/pthread_create.c
+++ b/src/glibc/nptl/pthread_create.c
@@ -341,7 +341,7 @@ static int create_thread (struct pthread *pd, const struct pthread_attr *attr,
   memset(args, 0, sizeof(struct clone_args));
   args->flags = clone_flags;
   args->stack = real_stack_bottom;
-  args->stack_size = stacksize - sizeof(struct clone_args) - TLS_TCB_SIZE;
+  args->stack_size = stacksize - sizeof(struct clone_args) - TLS_TCB_SIZE - pd->guardsize;
   args->child_tid = &pd->tid;
 
   // do the clone call

--- a/tests/unit-tests/process_tests/deterministic/thread-guard.c
+++ b/tests/unit-tests/process_tests/deterministic/thread-guard.c
@@ -1,0 +1,51 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <stdbool.h>
+
+bool thread_run = false;
+
+void* thread_func(void* arg) {
+    thread_run = true;
+    return NULL;
+}
+
+int main() {
+    pthread_t thread;
+    pthread_attr_t attr;
+
+    // Initialize attributes
+    pthread_attr_init(&attr);
+
+    // Get system page size
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size == -1) {
+        perror("sysconf");
+        return 1;
+    }
+
+    // Set guard size to one page
+    pthread_attr_setguardsize(&attr, (size_t)page_size);
+
+    // (Optional) read it back to confirm
+    size_t guard_size = 0;
+    pthread_attr_getguardsize(&attr, &guard_size);
+
+    assert(page_size == guard_size);
+
+    // Create thread with attributes
+    if (pthread_create(&thread, &attr, thread_func, NULL) != 0) {
+        perror("pthread_create");
+        return 1;
+    }
+
+    // Wait for thread to finish
+    pthread_join(thread, NULL);
+
+    assert(thread_run);
+    // Clean up
+    pthread_attr_destroy(&attr);
+
+    return 0;
+}


### PR DESCRIPTION
fix the issue that when application set the guard page attribute to be non-zero, thread creation will crash

Fixed by doing correct calculation for thread stack size when guard page is not zero 