### PR TITLE
lint and format fdtables alternative implementations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ md_generation:
 lint:
 	cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
 	cargo fmt --check --all --manifest-path src/lind-boot/Cargo.toml
+	rustfmt --check src/fdtables/src/muthashmaxglobal.rs \
+	    src/fdtables/src/vanillaglobal.rs \
+	    src/fdtables/src/dashmapvecglobal.rs
 	cargo clippy \
 	    --manifest-path src/lind-boot/Cargo.toml \
 	    --all-features \
@@ -149,6 +152,9 @@ lint:
 format:
 	cargo fmt --all --manifest-path src/wasmtime/Cargo.toml
 	cargo fmt --all --manifest-path src/lind-boot/Cargo.toml
+	rustfmt src/fdtables/src/muthashmaxglobal.rs \
+	    src/fdtables/src/vanillaglobal.rs \
+	    src/fdtables/src/dashmapvecglobal.rs
  
 
 .PHONY: docs-serve


### PR DESCRIPTION
The fdtables crate has multiple implementation files that are swapped via the current_impl include trick. Only the active implementation is in the module tree, so cargo fmt misses the others.

Add direct rustfmt calls for muthashmaxglobal.rs, vanillaglobal.rs, and dashmapvecglobal.rs to both the lint and format Makefile targets.

Fixes #971


