### PR TITLE
Add vmmap write checks to WASI environ functions

### DIFF
--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -326,8 +326,8 @@ fn add_environ_funcs_to_linker<
             if off_argc + 4 > mem_size || off_buf_size + 4 > mem_size {
                 return 21; // EFAULT
             }
-            if check_addr_write(cageid, ptr_argc as u32 as u64, 4).is_err()
-                || check_addr_write(cageid, ptr_buf_size as u32 as u64, 4).is_err()
+            if check_addr_write(cageid, base_u64 + off_argc as u64, 4).is_err()
+                || check_addr_write(cageid, base_u64 + off_buf_size as u64, 4).is_err()
             {
                 return 21; // EFAULT
             }
@@ -356,8 +356,8 @@ fn add_environ_funcs_to_linker<
                 if ptr_slot + 4 > mem_size || end > mem_size {
                     return 21; // EFAULT
                 }
-                if check_addr_write(cageid, ptr_slot as u64, 4).is_err()
-                    || check_addr_write(cageid, buf_offset as u64, bytes.len() + 1).is_err()
+                if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
+                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1).is_err()
                 {
                     return 21; // EFAULT
                 }
@@ -391,8 +391,8 @@ fn add_environ_funcs_to_linker<
             if off_count + 4 > mem_size || off_buf_size + 4 > mem_size {
                 return 21; // EFAULT
             }
-            if check_addr_write(cageid, ptr_count as u32 as u64, 4).is_err()
-                || check_addr_write(cageid, ptr_buf_size as u32 as u64, 4).is_err()
+            if check_addr_write(cageid, base_u64 + off_count as u64, 4).is_err()
+                || check_addr_write(cageid, base_u64 + off_buf_size as u64, 4).is_err()
             {
                 return 21; // EFAULT
             }
@@ -422,8 +422,8 @@ fn add_environ_funcs_to_linker<
                 if ptr_slot + 4 > mem_size || end > mem_size {
                     return 21; // EFAULT
                 }
-                if check_addr_write(cageid, ptr_slot as u64, 4).is_err()
-                    || check_addr_write(cageid, buf_offset as u64, bytes.len() + 1).is_err()
+                if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
+                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1).is_err()
                 {
                     return 21; // EFAULT
                 }
@@ -451,7 +451,7 @@ fn add_environ_funcs_to_linker<
             if offset + len > mem_size {
                 return 21; // EFAULT
             }
-            if check_addr_write(cageid, buf as u32 as u64, len).is_err() {
+            if check_addr_write(cageid, base_u64 + offset as u64, len).is_err() {
                 return 21; // EFAULT
             }
 

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use sysdefs::constants::lind_platform_const;
 use sysdefs::constants::lind_platform_const::{UNUSED_ARG, UNUSED_ID};
+use sysdefs::constants::Errno;
 use sysdefs::logging::lind_debug_panic;
 use threei::threei::{
     copy_data_between_cages, copy_handler_table_to_cage, make_syscall, register_handler,
@@ -323,13 +324,14 @@ fn add_environ_funcs_to_linker<
             let base = base_u64 as *mut u8;
             let off_argc = ptr_argc as u32 as usize;
             let off_buf_size = ptr_buf_size as u32 as usize;
-            if off_argc + 4 > mem_size || off_buf_size + 4 > mem_size {
-                return 21; // EFAULT
+            let size_of_u32 = std::mem::size_of::<u32>();
+            if off_argc + size_of_u32 > mem_size || off_buf_size + size_of_u32 > mem_size {
+                return Errno::EFAULT as i32;
             }
-            if check_addr_write(cageid, base_u64 + off_argc as u64, 4).is_err()
-                || check_addr_write(cageid, base_u64 + off_buf_size as u64, 4).is_err()
+            if check_addr_write(cageid, base_u64 + off_argc as u64, size_of_u32).is_err()
+                || check_addr_write(cageid, base_u64 + off_buf_size as u64, size_of_u32).is_err()
             {
-                return 21; // EFAULT
+                return Errno::EFAULT as i32;
             }
             unsafe {
                 write_u32(base, off_argc, argc);
@@ -349,18 +351,19 @@ fn add_environ_funcs_to_linker<
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let mut buf_offset = argv_buf as u32;
+            let size_of_u32 = std::mem::size_of::<u32>();
             for (i, arg) in args.iter().enumerate() {
-                let ptr_slot = argv_ptrs as u32 as usize + i * 4;
+                let ptr_slot = argv_ptrs as u32 as usize + i * size_of_u32;
                 let bytes = arg.as_bytes();
                 let end = buf_offset as usize + bytes.len() + 1;
-                if ptr_slot + 4 > mem_size || end > mem_size {
-                    return 21; // EFAULT
+                if ptr_slot + size_of_u32 > mem_size || end > mem_size {
+                    return Errno::EFAULT as i32;
                 }
-                if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
+                if check_addr_write(cageid, base_u64 + ptr_slot as u64, size_of_u32).is_err()
                     || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1)
                         .is_err()
                 {
-                    return 21; // EFAULT
+                    return Errno::EFAULT as i32;
                 }
                 unsafe {
                     write_u32(base, ptr_slot, buf_offset);
@@ -389,13 +392,14 @@ fn add_environ_funcs_to_linker<
             let base = base_u64 as *mut u8;
             let off_count = ptr_count as u32 as usize;
             let off_buf_size = ptr_buf_size as u32 as usize;
-            if off_count + 4 > mem_size || off_buf_size + 4 > mem_size {
-                return 21; // EFAULT
+            let size_of_u32 = std::mem::size_of::<u32>();
+            if off_count + size_of_u32 > mem_size || off_buf_size + size_of_u32 > mem_size {
+                return Errno::EFAULT as i32;
             }
-            if check_addr_write(cageid, base_u64 + off_count as u64, 4).is_err()
-                || check_addr_write(cageid, base_u64 + off_buf_size as u64, 4).is_err()
+            if check_addr_write(cageid, base_u64 + off_count as u64, size_of_u32).is_err()
+                || check_addr_write(cageid, base_u64 + off_buf_size as u64, size_of_u32).is_err()
             {
-                return 21; // EFAULT
+                return Errno::EFAULT as i32;
             }
             unsafe {
                 write_u32(base, off_count, count);
@@ -415,19 +419,20 @@ fn add_environ_funcs_to_linker<
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let mut buf_offset = env_buf as u32;
+            let size_of_u32 = std::mem::size_of::<u32>();
             for (i, (key, val)) in env.iter().enumerate() {
-                let ptr_slot = env_ptrs as u32 as usize + i * 4;
+                let ptr_slot = env_ptrs as u32 as usize + i * size_of_u32;
                 let entry = format!("{}={}", key, val);
                 let bytes = entry.as_bytes();
                 let end = buf_offset as usize + bytes.len() + 1;
-                if ptr_slot + 4 > mem_size || end > mem_size {
-                    return 21; // EFAULT
+                if ptr_slot + size_of_u32 > mem_size || end > mem_size {
+                    return Errno::EFAULT as i32;
                 }
-                if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
+                if check_addr_write(cageid, base_u64 + ptr_slot as u64, size_of_u32).is_err()
                     || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1)
                         .is_err()
                 {
-                    return 21; // EFAULT
+                    return Errno::EFAULT as i32;
                 }
                 unsafe {
                     write_u32(base, ptr_slot, buf_offset);
@@ -451,10 +456,10 @@ fn add_environ_funcs_to_linker<
             let len = buf_len as u32 as usize;
 
             if offset + len > mem_size {
-                return 21; // EFAULT
+                return Errno::EFAULT as i32;
             }
             if check_addr_write(cageid, base_u64 + offset as u64, len).is_err() {
-                return 21; // EFAULT
+                return Errno::EFAULT as i32;
             }
 
             let mut bytes = vec![0u8; len];

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -357,7 +357,8 @@ fn add_environ_funcs_to_linker<
                     return 21; // EFAULT
                 }
                 if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
-                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1).is_err()
+                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1)
+                        .is_err()
                 {
                     return 21; // EFAULT
                 }
@@ -423,7 +424,8 @@ fn add_environ_funcs_to_linker<
                     return 21; // EFAULT
                 }
                 if check_addr_write(cageid, base_u64 + ptr_slot as u64, 4).is_err()
-                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1).is_err()
+                    || check_addr_write(cageid, base_u64 + buf_offset as u64, bytes.len() + 1)
+                        .is_err()
                 {
                     return 21; // EFAULT
                 }

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
+use cage::memory::check_addr_write;
 use rand::Rng;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -317,11 +318,17 @@ fn add_environ_funcs_to_linker<
             let cx = get_environ(caller.data());
             let argc = cx.args.len() as u32;
             let buf_size: u32 = cx.args.iter().map(|a| a.len() as u32 + 1).sum();
+            let cageid = wasmtime_lind_multi_process::current_cageid(&mut caller) as u64;
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let off_argc = ptr_argc as u32 as usize;
             let off_buf_size = ptr_buf_size as u32 as usize;
             if off_argc + 4 > mem_size || off_buf_size + 4 > mem_size {
+                return 21; // EFAULT
+            }
+            if check_addr_write(cageid, ptr_argc as u32 as u64, 4).is_err()
+                || check_addr_write(cageid, ptr_buf_size as u32 as u64, 4).is_err()
+            {
                 return 21; // EFAULT
             }
             unsafe {
@@ -338,6 +345,7 @@ fn add_environ_funcs_to_linker<
         move |mut caller: Caller<'_, T>, argv_ptrs: i32, argv_buf: i32| -> i32 {
             let cx = get_environ(caller.data());
             let args: Vec<String> = cx.args.clone();
+            let cageid = wasmtime_lind_multi_process::current_cageid(&mut caller) as u64;
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let mut buf_offset = argv_buf as u32;
@@ -346,6 +354,11 @@ fn add_environ_funcs_to_linker<
                 let bytes = arg.as_bytes();
                 let end = buf_offset as usize + bytes.len() + 1;
                 if ptr_slot + 4 > mem_size || end > mem_size {
+                    return 21; // EFAULT
+                }
+                if check_addr_write(cageid, ptr_slot as u64, 4).is_err()
+                    || check_addr_write(cageid, buf_offset as u64, bytes.len() + 1).is_err()
+                {
                     return 21; // EFAULT
                 }
                 unsafe {
@@ -370,11 +383,17 @@ fn add_environ_funcs_to_linker<
                 .iter()
                 .map(|(k, v)| k.len() as u32 + 1 + v.len() as u32 + 1)
                 .sum();
+            let cageid = wasmtime_lind_multi_process::current_cageid(&mut caller) as u64;
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let off_count = ptr_count as u32 as usize;
             let off_buf_size = ptr_buf_size as u32 as usize;
             if off_count + 4 > mem_size || off_buf_size + 4 > mem_size {
+                return 21; // EFAULT
+            }
+            if check_addr_write(cageid, ptr_count as u32 as u64, 4).is_err()
+                || check_addr_write(cageid, ptr_buf_size as u32 as u64, 4).is_err()
+            {
                 return 21; // EFAULT
             }
             unsafe {
@@ -391,6 +410,7 @@ fn add_environ_funcs_to_linker<
         move |mut caller: Caller<'_, T>, env_ptrs: i32, env_buf: i32| -> i32 {
             let cx = get_environ(caller.data());
             let env: Vec<(String, String)> = cx.env.clone();
+            let cageid = wasmtime_lind_multi_process::current_cageid(&mut caller) as u64;
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let mut buf_offset = env_buf as u32;
@@ -400,6 +420,11 @@ fn add_environ_funcs_to_linker<
                 let bytes = entry.as_bytes();
                 let end = buf_offset as usize + bytes.len() + 1;
                 if ptr_slot + 4 > mem_size || end > mem_size {
+                    return 21; // EFAULT
+                }
+                if check_addr_write(cageid, ptr_slot as u64, 4).is_err()
+                    || check_addr_write(cageid, buf_offset as u64, bytes.len() + 1).is_err()
+                {
                     return 21; // EFAULT
                 }
                 unsafe {
@@ -417,12 +442,16 @@ fn add_environ_funcs_to_linker<
         module,
         "random_get",
         move |mut caller: Caller<'_, T>, buf: i32, buf_len: i32| -> i32 {
+            let cageid = wasmtime_lind_multi_process::current_cageid(&mut caller) as u64;
             let (base_u64, mem_size) = get_memory_base_and_size(&mut caller);
             let base = base_u64 as *mut u8;
             let offset = buf as u32 as usize;
             let len = buf_len as u32 as usize;
 
             if offset + len > mem_size {
+                return 21; // EFAULT
+            }
+            if check_addr_write(cageid, buf as u32 as u64, len).is_err() {
                 return 21; // EFAULT
             }
 


### PR DESCRIPTION
## PURPOSE

This PR fixes issue #1087 by adding vmmap write-permission checks to WASI host functions before they write into guest memory.

PR #1086 already added bounds checks against linear memory size, which prevents writes past the 4GB boundary. However, those checks only verify that the target range is in-bounds. They do not verify whether the target guest address is actually writable according to Lind's vmmap protections.

This PR adds `check_addr_write(cageid, addr, length)` before guest-memory writes so that WASI host functions no longer write into `PROT_NONE`, guard-page, or otherwise non-writable regions.

## RELATED ISSUES

- Fixes #1087

## CHANGES

Updated the following functions in `src/wasmtime/crates/lind-common/src/lib.rs`:

- `args_sizes_get`
- `args_get`
- `environ_sizes_get`
- `environ_get`
- `random_get`

Main changes:
- kept the existing linear-memory bounds checks
- added vmmap write-permission validation with `check_addr_write(...)` before each guest-memory write

## TESTING

- Rebuilt successfully with `make lind-boot`

## NOTES FOR REVIEWERS

- This change is intentionally minimal and only updates the WASI host functions listed in the issue.
- The existing linear-memory bounds checks are preserved; this PR adds the missing vmmap permission check on top of them.