### PR TITLE
return EINVAL for MAP_HUGETLB, keep debug panic for other unsupported flags

### DIFF
--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -845,18 +845,25 @@ pub extern "C" fn mmap_syscall(
 
     let mut maxprot = PROT_READ | PROT_WRITE;
 
-    // Validate flags - only these four flags are supported
-    // Note: We explicitly validate rather than silently strip unsupported flags to:
-    // 1. Prevent security issues (e.g., MAP_FIXED_NOREPLACE being ignored)
-    // 2. Maintain program correctness (e.g., MAP_SHARED_VALIDATE expects validation)
-    // 3. Make debugging easier by failing fast rather than having mysterious behavior later
+    // MAP_HUGETLB (and its size encoding in bits 26-31) is not supported.
+    // Return EINVAL to match Linux behavior on systems without huge page support.
+    if flags & libc::MAP_HUGETLB != 0 {
+        return syscall_error(Errno::EINVAL, "mmap", "MAP_HUGETLB not supported");
+    }
+
+    // Validate flags - only these flags are supported.
+    // Unsupported flags trigger a debug panic rather than a silent EINVAL
+    // so they surface during development instead of causing mysterious failures.
     let allowed_flags = MAP_FIXED as i32
         | MAP_SHARED as i32
         | MAP_PRIVATE as i32
         | MAP_ANONYMOUS as i32
         | MAP_POPULATE as i32;
     if flags & !allowed_flags != 0 {
-        return syscall_error(Errno::EINVAL, "mmap", "Unsupported mmap flags");
+        lind_debug_panic(&format!(
+            "mmap: unsupported flags {:#x} (allowed: {:#x})",
+            flags, allowed_flags
+        ));
     }
 
     if prot & PROT_EXEC > 0 {


### PR DESCRIPTION


The previous change (PR #1096) returned EINVAL for all unsupported mmap flags. This caused valid but unimplemented flags like PROT_EXEC to silently fail with EINVAL instead of surfacing during development.

MAP_HUGETLB specifically should return EINVAL to match Linux behavior on systems without huge page support. Other unsupported flags use lind_debug_panic so they're caught during development.

