### PR TITLE
add tzdata to Docker image and copy binary timezone files to lindfs

### DIFF
--- a/Docker/Dockerfile.dev
+++ b/Docker/Dockerfile.dev
@@ -56,6 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     gdb \
     linux-tools-common \
     linux-tools-generic \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # Install a pinned WABT version for wasm2wat/wat2wasm/wasm-objdump.

--- a/Docker/Dockerfile.e2e
+++ b/Docker/Dockerfile.e2e
@@ -35,8 +35,8 @@
 # - build-essential, ca-certificates, curl, libxml2 needed by rust and clang
 FROM ubuntu:22.04 AS base
 ARG WABT_VERSION="1.0.38"
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends -qq \
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -qq \
         binutils \
         bison \
         cmake \
@@ -56,6 +56,7 @@ RUN apt-get update && \
         libtool \
         rsync \
         automake \
+        tzdata \
         wget \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ lindfs:
 	cp -rT scripts/lindfs-conf/etc $(LINDFS_ROOT)/etc
 	cp -rT scripts/lindfs-conf/usr/lib/locale $(LINDFS_ROOT)/usr/lib/locale
 	cp -rT scripts/lindfs-conf/usr/share/zoneinfo $(LINDFS_ROOT)/usr/share/zoneinfo
+	@if [ -d /usr/share/zoneinfo ]; then \
+		cp -r /usr/share/zoneinfo/* $(LINDFS_ROOT)/usr/share/zoneinfo/; \
+	fi
 
 .PHONY: lind-debug
 lind-debug: lindfs build-dir


### PR DESCRIPTION
Install tzdata in the Docker build so binary timezone files are available at /usr/share/zoneinfo/. The lindfs target now copies these into the lindfs root alongside the existing text-format tzdata.zi and leap-seconds.list.

Needed by postgres which reads binary timezone files directly.
