### PR TITLE
Implement grate worker execution model with separate stack

### DIFF
--- a/scripts/harnesses/gratetestreport.py
+++ b/scripts/harnesses/gratetestreport.py
@@ -240,7 +240,7 @@ def run_subprocess(cmd: list[str], timeout: int | None = None, cwd: Path | None 
 
 def compile_grate_test(test: GrateTestCase) -> tuple[bool, str]:
     grate_compile_cmd = [GRATE_CLANG, "-s", "--compile-grate", test.grate_source.name]
-    cage_compile_cmd = [GRATE_CLANG, "-s", test.cage_source.name]
+    cage_compile_cmd = [GRATE_CLANG, test.cage_source.name]
 
     try:
         grate_proc = run_subprocess(grate_compile_cmd, cwd=test.grate_source.parent)

--- a/scripts/harnesses/gratetestreport.py
+++ b/scripts/harnesses/gratetestreport.py
@@ -239,8 +239,8 @@ def run_subprocess(cmd: list[str], timeout: int | None = None, cwd: Path | None 
 
 
 def compile_grate_test(test: GrateTestCase) -> tuple[bool, str]:
-    grate_compile_cmd = [GRATE_CLANG, "--compile-grate", test.grate_source.name]
-    cage_compile_cmd = [GRATE_CLANG, test.cage_source.name]
+    grate_compile_cmd = [GRATE_CLANG, "-s", "--compile-grate", test.grate_source.name]
+    cage_compile_cmd = [GRATE_CLANG, "-s", test.cage_source.name]
 
     try:
         grate_proc = run_subprocess(grate_compile_cmd, cwd=test.grate_source.parent)

--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -10,4 +10,3 @@ dylink_tests/deterministic/dlopen_thread.c
 dylink_tests/deterministic/double_fork_dlopen.c
 dylink_tests/deterministic/fork_dlopen.c
 ci/deterministic/ci_intentional_failure_tmp.c
-concurrent-request/thread_race_grate.c

--- a/src/lind-boot/Cargo.toml
+++ b/src/lind-boot/Cargo.toml
@@ -8,6 +8,7 @@ disable_signals = ["cage/disable_signals", "wasmtime-lind-multi-process/disable_
 secure = ["typemap/secure"]
 lind_debug = ["wasmtime-lind-common/lind_debug"]
 debug-dylink = ["wasmtime-lind-dylink/debug-dylink", "wasmtime-lind-multi-process/debug-dylink", "wasmtime-lind-utils/debug-dylink", "wasmtime/debug-dylink"]
+debug-grate-calls = ["wasmtime-lind-3i/debug-grate-calls"]
 
 [dependencies]
 wasmtime-lind-common = { path = "../wasmtime/crates/lind-common" }

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -1,4 +1,7 @@
 use crate::lind_wasmtime::host::DylinkMetadata;
+use crate::lind_wasmtime::host::{
+    cleanup_grate_handler, init_grate_pool, register_grate_handler_for_cage,
+};
 use crate::{cli::CliOptions, lind_wasmtime::host::HostCtx, lind_wasmtime::trampoline::*};
 use anyhow::{Context, Result, anyhow, bail};
 use cage::signal::{lind_signal_init, signal_may_trigger};
@@ -21,7 +24,7 @@ use wasmtime::{
     AsContextMut, Engine, Export, Func, InstantiateType, Linker, Module, Precompiled, SharedMemory,
     Store, Val, ValType, WasmBacktraceDetails,
 };
-use wasmtime_lind_3i::{VmCtxWrapper, init_vmctx_pool, rm_vmctx, set_vmctx, set_vmctx_thread};
+use wasmtime_lind_3i::*;
 use wasmtime_lind_common::LindEnviron;
 use wasmtime_lind_dylink::DynamicLoader;
 use wasmtime_lind_multi_process::{
@@ -66,13 +69,13 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
     // new cage is created
     lind_manager.increment();
 
-    // Initialize vmctx pool
-    init_vmctx_pool();
+    let grate_cleanup_funcptr = cleanup_grate_handler as *const () as usize as u64;
     // Initialize trampoline entry function pointer for wasmtime runtime.
     // This is for grate calls to re-enter wasmtime runtime.
     threei::register_trampoline(
         threei_const::RUNTIME_TYPE_WASMTIME,
         grate_callback_trampoline,
+        grate_cleanup_funcptr,
     );
 
     // Register syscall handlers (clone/exec/exit) with 3i
@@ -570,7 +573,7 @@ fn load_main_module(
     // I don't setup `epoch_handler` since it seems not being used by our previous implementation.
     // Not sure if this is related to our thread exit problem
     let linker = linker_guard.clone();
-    let (instance, cage_instanceid) = linker
+    let (instance, stack_arena_base, cage_instanceid) = linker
         .instantiate_with_lind(
             &mut *store,
             &module,
@@ -653,6 +656,9 @@ fn load_main_module(
     // see comments at signal_may_trigger for more details
     signal_may_trigger(cageid);
 
+    init_grate_pool();
+    init_vmctx_pool();
+
     // The main challenge in enabling dynamic syscall interposition between grates and 3i lies in Rust’s
     // strict lifetime and ownership system, which makes retrieving the Wasmtime runtime context across
     // instance boundaries particularly difficult. To overcome this, the design employs low-level context
@@ -672,32 +678,23 @@ fn load_main_module(
     // This function will be called at either the first cage or exec-ed cages.
     set_vmctx_thread(cageid, THREAD_START_ID as u64, vmctx_wrapper);
 
+    let grate_template = GrateTemplate {
+        engine: module.engine().clone(),
+        module: module.clone(),
+        linker: linker_guard.clone(),
+    };
+
+    let host = store.data().clone();
+
+    // 4) register grate workers for this cage
+    register_grate_handler_for_cage(&grate_template, host, cageid)
+        .with_context(|| format!("failed to register grate workers for cage {}", cageid))?;
+
     // 4) Notify threei of the cage runtime type
     threei::set_cage_runtime(cageid, threei_const::RUNTIME_TYPE_WASMTIME);
 
     let mut linker = linker_guard.clone();
     linker.define_weak_imports_as_traps(&module);
-
-    // 5) Create backup instances to populate the vmctx pool
-    // See more comments in lind-3i/lib.rs
-    for _ in 0..INSTANCE_NUMBER {
-        let (instance, backup_cage_instanceid) = linker
-            .instantiate_with_lind_thread(&mut *store, &module, false)
-            .context(format!("failed to instantiate"))?;
-
-        // Extract vmctx pointer
-        let backup_cage_storeopaque = store.inner_mut();
-        let backup_cage_instancehandler = backup_cage_storeopaque.instance(backup_cage_instanceid);
-        let backup_vmctx_ptr: *mut c_void = backup_cage_instancehandler.vmctx().cast();
-
-        // Put vmctx in a Send+Sync wrapper
-        let backup_vmctx_wrapper = VmCtxWrapper {
-            vmctx: NonNull::new(backup_vmctx_ptr).ok_or_else(|| anyhow!("null vmctx"))?,
-        };
-
-        // Store the vmctx wrapper in the global table for later retrieval during grate calls
-        set_vmctx(cageid, backup_vmctx_wrapper);
-    }
 
     // must drop linker before jump into wasm
     drop(linker);
@@ -707,13 +704,6 @@ fn load_main_module(
         Some(func) => invoke_func(store, func, &args),
         None => Ok(vec![]),
     };
-
-    if !rm_vmctx(cageid) {
-        panic!(
-            "[lind-boot] Failed to remove existing VMContext for cage_id {}",
-            cageid
-        );
-    }
 
     ret
 }
@@ -832,7 +822,7 @@ pub fn precompile_module(cli: &CliOptions) -> Result<()> {
         .with_context(|| format!("failed to read {}", wasm_path.display()))?;
     let cwasm_bytes = engine
         .precompile_module(&wasm_bytes)
-        .context("failed to precompile module")?;
+        .with_context(|| format!("failed to precompile module {}", wasm_path.display()))?;
     std::fs::write(&cwasm_path, cwasm_bytes)
         .with_context(|| format!("failed to write {}", cwasm_path.display()))?;
 
@@ -852,9 +842,14 @@ fn read_wasm_or_cwasm(engine: &Engine, path: &Path) -> Result<Module> {
     // When passing in a .wasm file, the ELF parsing unwinds early. (`ElfFile64::parse(&read_cache)?;`)
     // We can therefore not call .context()? on this function since that would unwind and not run the Module::from_file()
     match engine.detect_precompiled_file(path) {
-        Ok(_) => unsafe { Module::deserialize_file(engine, path) }
-            .context("failed to deserialize precompiled module"),
-        Err(_) => Module::from_file(engine, path).context("failed to compile module"),
+        Ok(_) => unsafe { Module::deserialize_file(engine, path) }.with_context(|| {
+            format!(
+                "failed to deserialize precompiled module {}",
+                path.display()
+            )
+        }),
+        Err(_) => Module::from_file(engine, path)
+            .with_context(|| format!("failed to compile module {}", path.display())),
     }
 }
 

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -1,6 +1,7 @@
 use crate::lind_wasmtime::host::DylinkMetadata;
 use crate::lind_wasmtime::host::{
     cleanup_grate_handler, init_grate_pool, register_grate_handler_for_cage,
+    unregister_grate_handler,
 };
 use crate::{cli::CliOptions, lind_wasmtime::host::HostCtx, lind_wasmtime::trampoline::*};
 use anyhow::{Context, Result, anyhow, bail};
@@ -15,9 +16,7 @@ use sysdefs::constants::lind_platform_const::{
     INSTANCE_NUMBER, RAWPOSIX_CAGEID, UNUSED_ARG, UNUSED_ID, WASMTIME_CAGEID,
 };
 use sysdefs::constants::syscall_const::{CLONE_SYSCALL, EXEC_SYSCALL, EXIT_SYSCALL};
-use sysdefs::constants::{
-    DEFAULT_STACKSIZE, DylinkErrorCode, GUARD_SIZE, LINDFS_ROOT, TABLE_START_INDEX,
-};
+use sysdefs::constants::{DEFAULT_STACKSIZE, DylinkErrorCode, GUARD_SIZE, TABLE_START_INDEX};
 use sysdefs::logging::lind_debug_panic;
 use threei::threei_const;
 use wasmtime::{
@@ -29,7 +28,6 @@ use wasmtime_lind_common::LindEnviron;
 use wasmtime_lind_dylink::DynamicLoader;
 use wasmtime_lind_multi_process::{
     CAGE_START_ID, LindCtx, THREAD_START_ID, attach_shared_memory, early_init_stack,
-    get_memory_base,
 };
 use wasmtime_lind_utils::symbol_table::SymbolMap;
 use wasmtime_lind_utils::{LindCageManager, LindGOT};
@@ -82,6 +80,9 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
     if !register_wasmtime_syscall_entry() {
         panic!("[lind-boot] egister syscall handlers (clone/exec/exit) with 3i failed");
     }
+
+    // initialize the vmctx pool for exit/exec/clone reentry into wasmtime runtime
+    init_vmctx_pool();
 
     // -- Initialize the Wasmtime execution environment --
     let wasm_file_path = Path::new(lindboot_cli.wasm_file());
@@ -656,11 +657,6 @@ fn load_main_module(
     // see comments at signal_may_trigger for more details
     signal_may_trigger(cageid);
 
-    // initialize the grate pool and vmctx pool for later use in grate calls and
-    // other syscalls that require re-entry into wasmtime runtime.
-    init_grate_pool();
-    init_vmctx_pool();
-
     // See more details in [lind-3i/src/lib.rs]
     // 1) Get StoreOpaque & InstanceHandler to extract vmctx pointer
     let cage_storeopaque = store.inner_mut();
@@ -676,17 +672,25 @@ fn load_main_module(
     // This function will be called at either the first cage or exec-ed cages.
     set_vmctx_thread(cageid, THREAD_START_ID as u64, vmctx_wrapper);
 
-    // 4) register grate workers for this cage
-    let grate_template = GrateTemplate {
-        engine: module.engine().clone(),
-        module: module.clone(),
-        linker: linker_guard.clone(),
-    };
+    // Grate calls only supports static linking for now, so we only initialize the grate pool and register
+    // grate workers when dylink is not enabled.
+    if !dylink_metadata.dylink_enabled {
+        // 4) register grate workers for this cage
+        let grate_template = GrateTemplate {
+            engine: module.engine().clone(),
+            module: module.clone(),
+            linker: linker_guard.clone(),
+        };
+        let host = store.data().clone();
 
-    let host = store.data().clone();
+        // initialize the grate pool for later use in grate calls and
+        // other syscalls that require re-entry into wasmtime runtime.
+        init_grate_pool();
+        unregister_grate_handler(cageid);
 
-    register_grate_handler_for_cage(&grate_template, host, cageid)
-        .with_context(|| format!("failed to register grate workers for cage {}", cageid))?;
+        register_grate_handler_for_cage(&grate_template, host, cageid)
+            .with_context(|| format!("failed to register grate workers for cage {}", cageid))?;
+    }
 
     // 5) Notify threei of the cage runtime type
     threei::set_cage_runtime(cageid, threei_const::RUNTIME_TYPE_WASMTIME);

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -78,7 +78,7 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
 
     // Register syscall handlers (clone/exec/exit) with 3i
     if !register_wasmtime_syscall_entry() {
-        panic!("[lind-boot] egister syscall handlers (clone/exec/exit) with 3i failed");
+        panic!("[lind-boot] register syscall handlers (clone/exec/exit) with 3i failed");
     }
 
     // initialize the vmctx pool for exit/exec/clone reentry into wasmtime runtime

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -656,14 +656,12 @@ fn load_main_module(
     // see comments at signal_may_trigger for more details
     signal_may_trigger(cageid);
 
+    // initialize the grate pool and vmctx pool for later use in grate calls and
+    // other syscalls that require re-entry into wasmtime runtime.
     init_grate_pool();
     init_vmctx_pool();
 
-    // The main challenge in enabling dynamic syscall interposition between grates and 3i lies in Rust’s
-    // strict lifetime and ownership system, which makes retrieving the Wasmtime runtime context across
-    // instance boundaries particularly difficult. To overcome this, the design employs low-level context
-    // capture by extracting and storing vmctx pointers from Wasmtime’s internal `StoreOpaque` and `InstanceHandler`
-    // structures. See more details in [lind-3i/src/lib.rs]
+    // See more details in [lind-3i/src/lib.rs]
     // 1) Get StoreOpaque & InstanceHandler to extract vmctx pointer
     let cage_storeopaque = store.inner_mut();
     let cage_instancehandler = cage_storeopaque.instance(cage_instanceid);
@@ -678,6 +676,7 @@ fn load_main_module(
     // This function will be called at either the first cage or exec-ed cages.
     set_vmctx_thread(cageid, THREAD_START_ID as u64, vmctx_wrapper);
 
+    // 4) register grate workers for this cage
     let grate_template = GrateTemplate {
         engine: module.engine().clone(),
         module: module.clone(),
@@ -686,11 +685,10 @@ fn load_main_module(
 
     let host = store.data().clone();
 
-    // 4) register grate workers for this cage
     register_grate_handler_for_cage(&grate_template, host, cageid)
         .with_context(|| format!("failed to register grate workers for cage {}", cageid))?;
 
-    // 4) Notify threei of the cage runtime type
+    // 5) Notify threei of the cage runtime type
     threei::set_cage_runtime(cageid, threei_const::RUNTIME_TYPE_WASMTIME);
 
     let mut linker = linker_guard.clone();

--- a/src/lind-boot/src/lind_wasmtime/host.rs
+++ b/src/lind-boot/src/lind_wasmtime/host.rs
@@ -57,12 +57,46 @@ impl DylinkMetadata {
     }
 }
 
+/// Global grate-handler registry for lind-wasm boot/runtime coordination.
+///
+/// This section manages the process-wide table of registered `GrateHandler`s.
+/// Each grate may register exactly one handler during initialization and later
+/// grate calls resolve that handler through this global table before submitting
+/// work into the handler’s worker pool.
+///
+/// Conceptually, this table is the global entry point from cage/grate identity
+/// to the runtime object that actually executes grate calls. The handler itself
+/// owns the worker pool and concurrency policy, while this registry is
+/// responsible for:
+///
+/// 1. allocating the global per-cage handler table,
+/// 2. registering a handler for a newly initialized grate,
+/// 3. retrieving the handler during grate-call dispatch, and
+/// 4. unregistering / shutting down the handler during cleanup.
+///
+/// This logic lives in `lind-boot`, rather than in `lind-3i` or Wasmtime,
+/// because the global table stores concrete `GrateHandler<HostCtx>` values.
+/// The worker-local `Store<T>` type is parameterized by the host state `T`,
+/// and in this build that `T` is the boot/runtime-specific `HostCtx` defined
+/// in `lind-boot`.
+///
+/// As a result, the global registry must be instantiated at a layer where the
+/// concrete host context type is known. If this table were moved into a lower
+/// layer such as `lind-3i`, that layer would only see the generic `T` carried
+/// by `Store<T>` and would not be able to materialize a global table of
+/// handlers with a concrete type at compile time. In practice, that would make
+/// the handler registry ill-typed unless the entire lower layer were also
+/// parameterized around the concrete host context.
 static GRATE_POOL: OnceLock<Vec<Mutex<Option<Arc<GrateHandler<HostCtx>>>>>> = OnceLock::new();
 
-/// Initialize the global `GrateHandler` pool.
+/// Initialize the global `GrateHandler` registry.
 ///
-/// This function must be called exactly once during lind-wasm startup, before any `GrateHandler` is
-/// pushed to or retrieved from the pool. It eagerly allocates one empty queue per possible `cage_id`.
+/// This function must be called exactly once during lind-wasm startup before
+/// any handler is registered or retrieved. It eagerly allocates one table slot
+/// per possible `cage_id`, with each slot initially empty.
+///
+/// The registry is indexed by cage / grate id and later stores the
+/// `Arc<GrateHandler<HostCtx>>` associated with that id.
 pub fn init_grate_pool() {
     GRATE_POOL.get_or_init(|| {
         (0..lind_platform_const::MAX_CAGEID)
@@ -71,13 +105,25 @@ pub fn init_grate_pool() {
     });
 }
 
+/// Create and register the grate handler for one cage.
+///
+/// This function constructs a new `GrateHandler` for the given `cageid` and
+/// installs it into the global registry. Registration fails if the registry
+/// has not been initialized, if the cage id is out of range, or if a handler
+/// has already been registered for that cage.
+///
+/// After successful registration, future grate calls targeting this cage can
+/// retrieve the handler through the global table and submit requests into its
+/// worker pool.
 pub fn register_grate_handler_for_cage(
     template: &GrateTemplate<HostCtx>,
     host: HostCtx,
     cageid: u64,
 ) -> anyhow::Result<()> {
+    // Create worker pool and handler for this cage's grate
     let handler = create_handler_for_cage(template, host, cageid, ConcurrencyMode::Parallel)?;
 
+    // Register the handler in the global pool
     let pool = GRATE_POOL
         .get()
         .ok_or_else(|| anyhow::anyhow!("GRATE_POOL is not initialized"))?;
@@ -96,6 +142,15 @@ pub fn register_grate_handler_for_cage(
     Ok(())
 }
 
+/// Look up the registered grate handler for a given grate id.
+///
+/// This is the internal retrieval path used by grate-call dispatch. The
+/// function resolves the target slot in the global registry, verifies that a
+/// handler is present, and returns a cloned `Arc` to the caller.
+///
+/// Returning an `Arc` allows the submission path to hold a stable reference to
+/// the handler even if another thread later begins cleanup or unregisters the
+/// slot from the global table.
 fn get_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandler<HostCtx>>> {
     #[cfg(feature = "debug-grate-calls")]
     println!(
@@ -125,12 +180,26 @@ fn get_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandler<HostCtx>>
         .ok_or_else(|| anyhow::anyhow!("grate handler {} not found", grate_id))
 }
 
+/// Submit one grate request to the handler registered for `grate_id` and
+/// run it to completion, returning the result code.
+///
+/// This is the global dispatch entry point used by the grate-call path.
+/// It first resolves the target handler from the global registry and then
+/// forwards the request into that handler’s submission logic, where worker
+/// acquisition, concurrency policy, and shutdown checks are enforced.
+///
+/// In other words, this function bridges the global grate-id lookup layer and
+/// the per-handler execution layer.
+///
+/// This function is used on the trampoline path for all grate calls
 pub fn submit_grate_request(grate_id: u64, req: GrateRequest) -> anyhow::Result<i32> {
     #[cfg(feature = "debug-grate-calls")]
     println!(
         "[lind-boot] Submitting grate request to cage {}, handler_addr: {:#x}",
         req.cageid, req.handler_addr
     );
+
+    // Look up the handler for this grate id
     let handler = match get_grate_handler(grate_id) {
         Ok(handler) => {
             #[cfg(feature = "debug-grate-calls")]
@@ -141,9 +210,19 @@ pub fn submit_grate_request(grate_id: u64, req: GrateRequest) -> anyhow::Result<
             panic!("[lind-boot] get_grate_handler failed: {:?}", e);
         }
     };
+
+    // Submit the request into the handler's worker pool and return the result
     handler.submit(req)
 }
 
+/// Remove the registered grate handler for `grate_id` from the global table.
+///
+/// This function detaches the handler from the global registry and returns the
+/// owned `Arc` to the caller. After unregistration, new lookups for the same
+/// grate id will fail, but any thread already holding a cloned `Arc` may still
+/// continue interacting with that handler until shutdown logic completes.
+///
+/// todo: not integrated with actual grate teardown yet
 pub fn unregister_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandler<HostCtx>>> {
     let pool = GRATE_POOL
         .get()
@@ -160,6 +239,19 @@ pub fn unregister_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandle
         .ok_or_else(|| anyhow::anyhow!("grate handler {} not found", grate_id))
 }
 
+/// Gracefully shut down and clean up the handler registered for `grate_id`.
+///
+/// Cleanup proceeds in two phases:
+///
+/// 1. unregister the handler from the global registry so no new global lookups
+///    can find it,
+/// 2. begin handler shutdown and wait until all in-flight grate calls have
+///    completed.
+///
+/// This ensures that no new work is admitted while allowing already-running
+/// grate calls to drain before cleanup finishes.
+///
+/// todo: not integrated with actual grate teardown yet
 pub fn cleanup_grate_handler(grate_id: u64) -> anyhow::Result<()> {
     let handler = unregister_grate_handler(grate_id)?;
 

--- a/src/lind-boot/src/lind_wasmtime/host.rs
+++ b/src/lind-boot/src/lind_wasmtime/host.rs
@@ -1,42 +1,19 @@
 use crate::cli::CliOptions;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
+use sysdefs::constants::lind_platform_const;
 use wasmtime::{Table, TypedFunc};
+use wasmtime_lind_3i::*;
 use wasmtime_lind_common::LindEnviron;
 use wasmtime_lind_multi_process::{LindCtx, LindHost};
 use wasmtime_lind_utils::LindGOT;
 
-/// Function type for the `pass_fptr_to_wt` function used as an entry point for grate-run syscalls.
-pub type PassFptrTyped = TypedFunc<
-    (
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-        u64,
-    ),
-    i32,
->;
-
 /// The HostCtx host structure stores all relevant execution context objects:
 /// `lind_environ`: argv/environ data served by the 4 host functions in lind-common;
 /// `lind_fork_ctx`: the multi-process management structure, encapsulating fork/exec state;
-/// `wasi_threads`: which manages WASI thread-related capabilities.
-/// `pass_fptr_func`: the dispatcher function defined in the grate's WASM module. Cached after the
-/// first invocation.
 #[derive(Default, Clone)]
 pub struct HostCtx {
     pub lind_environ: Option<LindEnviron>,
     pub lind_fork_ctx: Option<LindCtx<HostCtx, CliOptions>>,
-    pub pass_fptr_func: Option<PassFptrTyped>,
 }
 
 impl HostCtx {
@@ -52,7 +29,6 @@ impl HostCtx {
         Self {
             lind_environ: forked_lind_environ,
             lind_fork_ctx: forked_lind_fork_ctx,
-            pass_fptr_func: None,
         }
     }
 }
@@ -79,4 +55,120 @@ impl DylinkMetadata {
             epoch_handler: None,
         }
     }
+}
+
+static GRATE_POOL: OnceLock<Vec<Mutex<Option<Arc<GrateHandler<HostCtx>>>>>> = OnceLock::new();
+
+/// Initialize the global `GrateHandler` pool.
+///
+/// This function must be called exactly once during lind-wasm startup, before any `GrateHandler` is
+/// pushed to or retrieved from the pool. It eagerly allocates one empty queue per possible `cage_id`.
+pub fn init_grate_pool() {
+    GRATE_POOL.get_or_init(|| {
+        (0..lind_platform_const::MAX_CAGEID)
+            .map(|_| Mutex::new(None))
+            .collect()
+    });
+}
+
+pub fn register_grate_handler_for_cage(
+    template: &GrateTemplate<HostCtx>,
+    host: HostCtx,
+    cageid: u64,
+) -> anyhow::Result<()> {
+    let handler = create_handler_for_cage(template, host, cageid, ConcurrencyMode::Parallel)?;
+
+    let pool = GRATE_POOL
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("GRATE_POOL is not initialized"))?;
+
+    let slot = pool
+        .get(cageid as usize)
+        .ok_or_else(|| anyhow::anyhow!("invalid cageid {}", cageid))?;
+
+    let mut guard = slot.lock().unwrap();
+
+    if guard.is_some() {
+        anyhow::bail!("GrateHandler for cageid {} already exists", cageid);
+    }
+
+    *guard = Some(Arc::new(handler));
+    Ok(())
+}
+
+fn get_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandler<HostCtx>>> {
+    #[cfg(feature = "debug-grate-calls")]
+    println!(
+        "[lind-boot] Retrieving grate handler for grate_id {}",
+        grate_id
+    );
+    let pool = GRATE_POOL
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("GRATE_POOL is not initialized"))?;
+
+    let slot = pool
+        .get(grate_id as usize)
+        .ok_or_else(|| anyhow::anyhow!("invalid grate_id {}", grate_id))?;
+
+    let guard = slot.lock().unwrap();
+
+    #[cfg(feature = "debug-grate-calls")]
+    println!(
+        "[lind-boot] Grate handler for grate_id {} is {}",
+        grate_id,
+        if guard.is_some() { "present" } else { "absent" }
+    );
+
+    guard
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("grate handler {} not found", grate_id))
+}
+
+pub fn submit_grate_request(grate_id: u64, req: GrateRequest) -> anyhow::Result<i32> {
+    #[cfg(feature = "debug-grate-calls")]
+    println!(
+        "[lind-boot] Submitting grate request to cage {}, handler_addr: {:#x}",
+        req.cageid, req.handler_addr
+    );
+    let handler = match get_grate_handler(grate_id) {
+        Ok(handler) => {
+            #[cfg(feature = "debug-grate-calls")]
+            println!("[lind-boot] got handler");
+            handler
+        }
+        Err(e) => {
+            panic!("[lind-boot] get_grate_handler failed: {:?}", e);
+        }
+    };
+    handler.submit(req)
+}
+
+pub fn unregister_grate_handler(grate_id: u64) -> anyhow::Result<Arc<GrateHandler<HostCtx>>> {
+    let pool = GRATE_POOL
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("GRATE_POOL is not initialized"))?;
+
+    let slot = pool
+        .get(grate_id as usize)
+        .ok_or_else(|| anyhow::anyhow!("invalid grate_id {}", grate_id))?;
+
+    let mut guard = slot.lock().unwrap();
+
+    guard
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("grate handler {} not found", grate_id))
+}
+
+pub fn cleanup_grate_handler(grate_id: u64) -> anyhow::Result<()> {
+    let handler = unregister_grate_handler(grate_id)?;
+
+    // 1. Deactivate the handler to prevent new requests from being accepted
+    // and interrupt other running stores
+    handler.begin_shutdown();
+
+    // 2. Wait for the handler to finish processing any in-flight requests and become idle.
+    handler.wait_for_idle();
+
+    Ok(())
 }

--- a/src/lind-boot/src/lind_wasmtime/host.rs
+++ b/src/lind-boot/src/lind_wasmtime/host.rs
@@ -1,7 +1,7 @@
 use crate::cli::CliOptions;
 use std::sync::{Arc, Mutex, OnceLock};
 use sysdefs::constants::lind_platform_const;
-use wasmtime::{Table, TypedFunc};
+use wasmtime::Table;
 use wasmtime_lind_3i::*;
 use wasmtime_lind_common::LindEnviron;
 use wasmtime_lind_multi_process::{LindCtx, LindHost};

--- a/src/lind-boot/src/lind_wasmtime/trampoline.rs
+++ b/src/lind-boot/src/lind_wasmtime/trampoline.rs
@@ -2,7 +2,6 @@ use crate::lind_wasmtime::host::submit_grate_request;
 use crate::{cli::CliOptions, lind_wasmtime::host::HostCtx};
 use anyhow::anyhow;
 use threei::threei_const;
-// use wasmtime::vm::{VMContext, VMOpaqueContext};
 use wasmtime::{Caller, Instance};
 use wasmtime_lind_3i::*;
 use wasmtime_lind_multi_process;
@@ -10,26 +9,10 @@ use wasmtime_lind_multi_process;
 /// The callback function registered with 3i uses a unified Wasm entry
 /// function as the single re-entry point into the Wasm executable.
 ///
-/// When invoked, this function first uses the provided grateid to
-/// retrieve the corresponding `VMContext` pointer from lind-3i’s global
-/// runtime-state table. The `VMContext` identifies the Wasmtime store and
-/// instance associated with the target grate and allows execution to
-/// re-enter the correct runtime context.
-///
 /// This function receives an address inside grate that identifies the target handler.
-/// When invoked, the callback calls the entry function inside the Wasm
-/// module, passing this address as an argument. The entry function then
-/// dispatches control to the corresponding per-syscall implementation
-/// based on the address provided by `register_handler`.
-///
-/// To complete the bridge between host and guest, the system uses
-/// `Caller::with()` to re-enter the  Wasmtime runtime context from the
-/// host side.
-///
-/// This function is called by 3i when a syscall is routed to a grate.
-///
-/// todo: Currently this function is sent to 3i from [run::execute] function.
-/// This will be updated to be sent from lind-boot in the future.
+/// When invoked, the callback submits the request to lower layer, passing this address
+/// as an argument. The entry function then dispatches control to the corresponding
+/// per-syscall implementation based on the address provided by `register_handler`.
 pub extern "C" fn grate_callback_trampoline(
     in_grate_fn_ptr_u64: u64,
     cageid: u64,
@@ -46,6 +29,7 @@ pub extern "C" fn grate_callback_trampoline(
     arg6: u64,
     arg6cageid: u64,
 ) -> i32 {
+    // Form the grate request with the provided arguments and the handler address
     let req = GrateRequest {
         handler_addr: in_grate_fn_ptr_u64,
         cageid: cageid,
@@ -63,6 +47,7 @@ pub extern "C" fn grate_callback_trampoline(
         arg6cageid,
     };
 
+    // Submit the request to the host-side grate handler and return the result.
     match submit_grate_request(cageid, req) {
         Ok(ret) => ret,
         Err(_) => threei_const::GRATE_ERR,

--- a/src/lind-boot/src/lind_wasmtime/trampoline.rs
+++ b/src/lind-boot/src/lind_wasmtime/trampoline.rs
@@ -1,8 +1,6 @@
 use crate::lind_wasmtime::host::submit_grate_request;
 use crate::{cli::CliOptions, lind_wasmtime::host::HostCtx};
-use anyhow::anyhow;
 use threei::threei_const;
-use wasmtime::{Caller, Instance};
 use wasmtime_lind_3i::*;
 use wasmtime_lind_multi_process;
 

--- a/src/lind-boot/src/lind_wasmtime/trampoline.rs
+++ b/src/lind-boot/src/lind_wasmtime/trampoline.rs
@@ -1,10 +1,10 @@
-use crate::lind_wasmtime::host::PassFptrTyped;
+use crate::lind_wasmtime::host::submit_grate_request;
 use crate::{cli::CliOptions, lind_wasmtime::host::HostCtx};
 use anyhow::anyhow;
 use threei::threei_const;
-use wasmtime::vm::{VMContext, VMOpaqueContext};
+// use wasmtime::vm::{VMContext, VMOpaqueContext};
 use wasmtime::{Caller, Instance};
-use wasmtime_lind_3i::{VmCtxWrapper, get_vmctx, set_vmctx};
+use wasmtime_lind_3i::*;
 use wasmtime_lind_multi_process;
 
 /// The callback function registered with 3i uses a unified Wasm entry
@@ -46,77 +46,27 @@ pub extern "C" fn grate_callback_trampoline(
     arg6: u64,
     arg6cageid: u64,
 ) -> i32 {
-    let vmctx_wrapper: VmCtxWrapper = match get_vmctx(cageid) {
-        Some(v) => v,
-        None => {
-            panic!(
-                "[grate_trampoline] no VMContext found for cage_id {}",
-                cageid
-            );
-        }
+    let req = GrateRequest {
+        handler_addr: in_grate_fn_ptr_u64,
+        cageid: cageid,
+        arg1,
+        arg1cageid,
+        arg2,
+        arg2cageid,
+        arg3,
+        arg3cageid,
+        arg4,
+        arg4cageid,
+        arg5,
+        arg5cageid,
+        arg6,
+        arg6cageid,
     };
 
-    // Convert back to VMContext
-    let opaque: *mut VMOpaqueContext = vmctx_wrapper.as_ptr() as *mut VMOpaqueContext;
-
-    let vmctx_raw: *mut VMContext = unsafe { VMContext::from_opaque(opaque) };
-
-    // Re-enter Wasmtime using the stored vmctx pointer
-    let grate_ret = unsafe {
-        Caller::with(vmctx_raw, |caller: Caller<'_, HostCtx>| {
-            let Caller {
-                mut store,
-                caller: instance,
-            } = caller;
-
-            let typed_func: PassFptrTyped = match store.data().pass_fptr_func.clone() {
-                // Check if the dispatcher function is already cached.
-                Some(f) => f,
-                // Retrieve and store the dispatcher function. Done on the first syscall
-                // invocation.
-                None => {
-                    let entry_func = instance
-                        .host_state()
-                        .downcast_ref::<Instance>()
-                        .ok_or_else(|| anyhow!("bad host_state Instance"))?
-                        .get_export(&mut store, "pass_fptr_to_wt")
-                        .and_then(|f| f.into_func())
-                        .ok_or_else(|| anyhow!("missing export `pass_fptr_to_wt`"))?;
-
-                    let typed = entry_func.typed(&mut store)?;
-
-                    store.data_mut().pass_fptr_func = Some(typed.clone());
-
-                    typed
-                }
-            };
-
-            // Call the entry function with all arguments and in grate function pointer
-            typed_func.call(
-                &mut store,
-                (
-                    in_grate_fn_ptr_u64,
-                    cageid,
-                    arg1,
-                    arg1cageid,
-                    arg2,
-                    arg2cageid,
-                    arg3,
-                    arg3cageid,
-                    arg4,
-                    arg4cageid,
-                    arg5,
-                    arg5cageid,
-                    arg6,
-                    arg6cageid,
-                ),
-            )
-        })
-        .unwrap_or(threei_const::GRATE_ERR)
-    };
-    // Push the vmctx back to the global pool
-    set_vmctx(cageid, vmctx_wrapper);
-    grate_ret
+    match submit_grate_request(cageid, req) {
+        Ok(ret) => ret,
+        Err(_) => threei_const::GRATE_ERR,
+    }
 }
 
 /// Entry points for Wasmtime-backed multi-process syscalls.

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -125,13 +125,60 @@ pub enum DylinkErrorCode {
 
 pub const FPCAST_FUNC_SIGNATURE: &str = "$fpcast_emu$";
 
+/// Maximum number of grate workers that may exist for one grate handler.
+///
+/// This is a platform-wide configuration constant. lind-wasm preallocates
+/// execution capacity for at most `MAX_GRATE_WORKERS` concurrent grate-call
+/// workers, and the stack arena is sized accordingly.
+///
+/// Because this value is global rather than per-instance, every grate-enabled
+/// instance reserves the same number of worker stack slots in linear memory.
 pub const MAX_GRATE_WORKERS: usize = 32;
+
+/// Size in bytes of the usable stack region assigned to one grate worker.
+///
+/// Each worker executes in its own `Store + Instance` context, but workers may
+/// still attach to the same underlying linear memory. Therefore, every worker
+/// must be given a disjoint stack slot inside the shared stack arena.
+///
+/// This constant specifies the usable portion of that per-worker slot.
 pub const GRATE_STACK_SLOT_SIZE: u32 = 8 * 1024 * 1024;
+
+/// Size in bytes of the guard region placed before each grate-worker stack slot.
+///
+/// The stack arena is laid out as repeated
+///
+/// `guard + usable stack slot`
+///
+/// segments, one per worker. The guard region exists to separate adjacent
+/// worker stacks inside shared linear memory and to reduce the risk that stack
+/// growth or stack corruption in one worker silently overlaps another worker’s
+/// usable stack region.
 pub const GRATE_STACK_GUARD_SIZE: u32 = 4 * 1024;
 
 use std::sync::OnceLock;
+
+/// Global base address of the grate stack arena in linear memory.
+///
+/// The stack arena is reserved once during instance initialization and then
+/// reused by grate-worker creation logic to derive each worker’s stack slot:
+///
+/// `worker_stack_base(i) = STACK_ARENA_BASE + (i - 1) * (guard + slot) + guard`
+///
+/// This value is stored globally because the worker stack layout is defined by
+/// a single shared arena formula rather than being recomputed independently by
+/// each worker from instance-local metadata.
+///
+/// This value is placed in `sysdefs` as a shared low-level platform constant
+/// rather than being owned by `lind-3i`, `lind-multi-process`, or Wasmtime
+/// directly. The main reason is dependency hygiene: all three components need
+/// to agree on the same stack-arena base, but placing it in any one of those
+/// layers would introduce circular dependency pressure between runtime,
+/// interposition, and process-management code.
 pub static STACK_ARENA_BASE: OnceLock<u32> = OnceLock::new();
 
+/// See [wasmtime/src/runtime/instance.rs] for the design and rationale
+/// behind this constant and its initialization.
 pub fn init_stack_arena_base(val: u32) {
     let _ = STACK_ARENA_BASE.set(val);
 }

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -156,7 +156,8 @@ pub const GRATE_STACK_SLOT_SIZE: u32 = 8 * 1024 * 1024;
 /// usable stack region.
 pub const GRATE_STACK_GUARD_SIZE: u32 = 4 * 1024;
 
-use std::sync::OnceLock;
+/// ------------------------------------------------------------------
+use std::sync::{OnceLock, RwLock};
 
 /// Global base address of the grate stack arena in linear memory.
 ///
@@ -165,9 +166,12 @@ use std::sync::OnceLock;
 ///
 /// `worker_stack_base(i) = STACK_ARENA_BASE + (i - 1) * (guard + slot) + guard`
 ///
-/// This value is stored globally because the worker stack layout is defined by
-/// a single shared arena formula rather than being recomputed independently by
-/// each worker from instance-local metadata.
+/// One additional reason this base is recorded explicitly is that although the
+/// static worker-stack layout is retrieved from module metadata during instance
+/// construction, the underlying stack size is still a compile-time parameter.
+/// In other words, the arena geometry is not an immutable universal runtime
+/// constant: different compiled modules may encode different stack sizing
+/// choices.
 ///
 /// This value is placed in `sysdefs` as a shared low-level platform constant
 /// rather than being owned by `lind-3i`, `lind-multi-process`, or Wasmtime
@@ -175,10 +179,80 @@ use std::sync::OnceLock;
 /// to agree on the same stack-arena base, but placing it in any one of those
 /// layers would introduce circular dependency pressure between runtime,
 /// interposition, and process-management code.
-pub static STACK_ARENA_BASE: OnceLock<u32> = OnceLock::new();
+///
+/// ------------------------------------------------------------------
+///
+/// Global per-cage storage for grate stack-arena base addresses.
+///
+/// The vector index is the cage ID. Each entry is `Some(base)` once that
+/// cage's stack arena has been initialized, or `None` if it has not been
+/// initialized yet.
+///
+/// [`OnceLock`] initializes the container only once, and [`RwLock`] provides
+/// synchronized shared access to the per-cage entries.
+pub static STACK_ARENA_BASES: OnceLock<RwLock<Vec<Option<u32>>>> = OnceLock::new();
 
+/// Returns the global per-grate storage for stack-arena base addresses,
+/// initializing the container on first use.
+///
+/// The outer [`OnceLock`] ensures that the storage itself is created only once,
+/// while the inner [`RwLock<Vec<Option<u32>>>`] allows concurrent readers and
+/// serialized updates as grates are initialized over time.
+///
+/// Each vector index corresponds to a grate ID. A value of `None` means that
+/// the stack-arena base for that grate has not been initialized yet.
+///
 /// See [wasmtime/src/runtime/instance.rs] for the design and rationale
 /// behind this constant and its initialization.
-pub fn init_stack_arena_base(val: u32) {
-    let _ = STACK_ARENA_BASE.set(val);
+fn stack_arena_bases() -> &'static RwLock<Vec<Option<u32>>> {
+    STACK_ARENA_BASES.get_or_init(|| RwLock::new(Vec::new()))
+}
+
+/// Records the stack-arena base address for `grate_id`.
+///
+/// The vector is grown as needed so that `grate_id` can be used directly as an
+/// index. This function preserves one-time initialization semantics per grate:
+/// if the given grate already has a recorded base, the function returns an
+/// error instead of overwriting the existing value.
+///
+/// This is intended to be called once during instance initialization, after the
+/// stack arena has been reserved and its resolved base address is known.
+pub fn init_stack_arena_base(grate_id: usize, val: u32) -> Result<(), &'static str> {
+    let mut bases = stack_arena_bases().write().unwrap();
+
+    if bases.len() <= grate_id {
+        bases.resize(grate_id + 1, None);
+    }
+
+    if bases[grate_id].is_some() {
+        return Err("stack arena base already initialized for this grate");
+    }
+
+    bases[grate_id] = Some(val);
+    Ok(())
+}
+
+/// Returns the recorded stack-arena base address for `cage_id`, if one exists.
+///
+/// `None` indicates that the grate has no initialized stack-arena base, either
+/// because the grate has not been initialized yet or because the requested grate
+/// ID is outside the current bounds of the global storage.
+pub fn get_stack_arena_base(grate_id: usize) -> Option<u32> {
+    let bases = stack_arena_bases().read().unwrap();
+    bases.get(grate_id).copied().flatten()
+}
+
+/// Copies the parent's recorded stack-arena base to a child cage during fork.
+///
+/// This preserves the same resolved stack-arena layout across the fork
+/// boundary, rather than requiring the child to reconstruct it independently.
+/// The operation fails if the parent has no initialized base or if the child
+/// already has one recorded.
+pub fn fork_stack_arena_base_for_child(
+    parent_grate_id: usize,
+    child_grate_id: usize,
+) -> Result<(), &'static str> {
+    let parent_base = get_stack_arena_base(parent_grate_id)
+        .ok_or("parent grate stack arena base not initialized")?;
+    init_stack_arena_base(child_grate_id, parent_base)
 }

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -124,3 +124,14 @@ pub enum DylinkErrorCode {
 }
 
 pub const FPCAST_FUNC_SIGNATURE: &str = "$fpcast_emu$";
+
+pub const MAX_GRATE_WORKERS: usize = 32;
+pub const GRATE_STACK_SLOT_SIZE: u32 = 8 * 1024 * 1024;
+pub const GRATE_STACK_GUARD_SIZE: u32 = 4 * 1024;
+
+use std::sync::OnceLock;
+pub static STACK_ARENA_BASE: OnceLock<u32> = OnceLock::new();
+
+pub fn init_stack_arena_base(val: u32) {
+    let _ = STACK_ARENA_BASE.set(val);
+}

--- a/src/threei/src/threei.rs
+++ b/src/threei/src/threei.rs
@@ -58,24 +58,30 @@ pub type GrateTrampolineFn = extern "C" fn(
     arg6cageid: u64,
 ) -> i32;
 
+#[derive(Clone, Copy, Debug)]
+pub struct TrampolineEntry {
+    pub trampoline: GrateTrampolineFn,
+    pub cleanup_funcptr: u64,
+}
+
 /// This table stores trampoline functions associated with runtime identifiers, where a
-/// runtime identifier denotes the execution environment of the executable (e.g., Wasmtime)
+/// runtime identifier denotes the execution environment of the executable (e.g., Wasmtime).
 ///
-/// `TRAMPOLINE_TABLE` is a global map from `runtime_id` to `GrateTrampolineFn`.
-/// DashMap is used to allow concurrent registration and lookup without a global lock.
+/// Each runtime may also carry an associated cleanup function pointer.
 lazy_static! {
-    // <runtime_id, GrateTrampolineFn>
-    pub static ref TRAMPOLINE_TABLE: DashMap<u64, GrateTrampolineFn> = DashMap::new();
+    // <runtime_id, TrampolineEntry>
+    pub static ref TRAMPOLINE_TABLE: DashMap<u64, TrampolineEntry> = DashMap::new();
 }
 
 /// `register_trampoline` registers a trampoline function for the given runtime ID.
-///
-/// todo: In the current implementation, trampolines are registered during runtime
-/// initialization in [wasmtime/run.rs]. This registration logic is expected to move
-/// into lind-boot in the future so that trampoline setup is handled as part of the
-/// system bootstrap process rather than runtime startup.
-pub fn register_trampoline(runtime: u64, f: GrateTrampolineFn) {
-    TRAMPOLINE_TABLE.insert(runtime, f);
+pub fn register_trampoline(runtime: u64, f: GrateTrampolineFn, cleanup_funcptr: u64) {
+    TRAMPOLINE_TABLE.insert(
+        runtime,
+        TrampolineEntry {
+            trampoline: f,
+            cleanup_funcptr,
+        },
+    );
 }
 
 /// `get_runtime_trampoline` retrieves the trampoline function associated with the given runtime ID.
@@ -84,7 +90,13 @@ pub fn register_trampoline(runtime: u64, f: GrateTrampolineFn) {
 ///
 /// This function is used when performing a grate call in `_call_grate_func`.
 pub fn get_runtime_trampoline(runtime: u64) -> Option<GrateTrampolineFn> {
-    TRAMPOLINE_TABLE.get(&runtime).map(|f| *f)
+    TRAMPOLINE_TABLE.get(&runtime).map(|f| f.trampoline)
+}
+
+pub fn get_runtime_cleanup_funcptr(runtime: u64) -> Option<u64> {
+    TRAMPOLINE_TABLE
+        .get(&runtime)
+        .map(|entry| entry.cleanup_funcptr)
 }
 
 /// This table maintains a mapping from cage IDs to runtime IDs.

--- a/src/wasmtime/crates/lind-3i/Cargo.toml
+++ b/src/wasmtime/crates/lind-3i/Cargo.toml
@@ -18,3 +18,7 @@ anyhow = { version = "1.0.22", default-features = false }
 threei = { path = "../threei" }
 lazy_static = "1.4"
 dashmap = { version = "6" }
+
+[features]
+default = []
+debug-grate-calls = []

--- a/src/wasmtime/crates/lind-3i/src/lib.rs
+++ b/src/wasmtime/crates/lind-3i/src/lib.rs
@@ -1,125 +1,418 @@
-//! This module provides a global runtime-state lookup mechanism for lind-3i and lind-wasm, enabling
-//! controlled transfers of execution across cages, grates, and threads.
-//!
-//! In lind-wasm, runtime control is not always confined to a single Wasmtime instance or a single
-//! linear call stack. There are two primary scenarios in which lind-3i must explicitly locate and
-//! re-enter a different runtime state.
-//!
-//! Importantly, not all re-entries into Wasmtime are equivalent. Some operations require resuming
-//! execution in the *same continuation context* (i.e., the same instance and asyncify state),
-//! while others only require access to a compatible instance that shares the same linear memory.
-//!
-//! The mechanisms in this module distinguish between these cases explicitly.
-//!
-//! ---
-//! ## Scenario 1: Process-like operations (`fork`, `exec`, `exit`)
-//!
-//! The first scenario occurs during process-like operations such as `fork`, `exec`, and `exit`. These
-//! operations require Wasmtime to create, clone, or destroy existing Wasm instances. After RawPOSIX
-//! completes the semantic handling of a `fork`, `exec`, or `exit` operation, execution must return to
-//! Wasmtime to continue running Wasm code. Importantly, the cage that performs the `fork`, `exec`, or
-//! `exit` logic is not necessarily the same cage or grate that originally issued the system call. As
-//! a result, lind-3i cannot rely on an implicit “current” runtime state. Instead, it must be able to
-//! retrieve the Wasmtime execution context.
-//!
-//! These operations are also continuation-sensitive, which means that the execution must resume in
-//! the *same Wasmtime instance* that originally issued the syscall.
-//!
-//! In particular, `fork` / `exit` rely on Asyncify to suspend and later resume execution via paired
-//! `start_unwind` / `stop_unwind` and `start_rewind` / `stop_rewind` operations. These transitions
-//! must occur within the same continuation context, which is the same Wasmtime instance and
-//! associated asyncify runtime state. Resuming execution in a different instance, even one that
-//! shares linear memory, breaks this invariant and can result in missed callbacks or incorrect
-//! return values.
-//!
-//! As a result, lind-3i must be able to retrieve *the active execution context* corresponding
-//! to a specific `(cage_id, tid)` when handling these operations.
-//!
-//! ---
-//! ## Scenario 2: Grate calls (cross-module execution transfers)
-//!
-//! The second scenario arises during grate calls. Grate calls involve cross-module execution transfers,
-//! where control jumps from one Wasm module to another (for example, from a cage into a grate, or between
-//! grates). Supporting these jumps similarly requires the ability to locate and enter the runtime state
-//! of a different module than the one currently executing.
-//!
-//! ---
-//! To support both scenarios, lind-3i leverages a key property of lind-wasm’s execution model: each Wasmtime
-//! `Store` contains exactly one Wasm `Instance`, and each thread executes within its own independent
-//! store / instance pair.
-//!
-//! ---
-//! ## VMContext storage model
-//!
-//! VMContext pointers are stored globally and indexed by `cage_id`. Two distinct
-//! structures are used:
-//!
-//! 1. Backup VMContext pools (`VMCTX_QUEUES`)
-//! - Indexed by `cage_id`.
-//! - Store pools of *backup* instances created during module instantiation.
-//! - Used exclusively for continuation-insensitive operations, such as grate calls.
-//! - Instances in this pool may share linear memory but must never be used to resume a suspended
-//!   asyncify continuation.
-//!
-//! At module creation time, lind-3i extracts the `VMContext` pointer associated with the newly created instance.
-//! This `VMContext` uniquely identifies the execution state of that `Store` / `Instance`. The pointer is
-//! stored in a global table indexed by `cage_id`. When lind-3i needs to transfer execution to
-//! another cage or grate, it looks up the corresponding `VMContext` pointer using the target `cage_id`.
-//! Using Wasmtime’s internal mechanisms, the `VMContext` pointer can be used to recover the associated
-//! `Store` and `Instance`, allowing execution to resume in the correct runtime context.
-//!
-//! These instances enable concurrent execution over shared memory without duplicating address
-//! space state.
-//!
-//! 2. Active per-thread VMContext table (`VMCTX_THREADS`)
-//! - Indexed by `(cage_id, tid)`.
-//! - Stores exactly one active instance per thread.
-//! - Used exclusively for continuation-sensitive operations, including:
-//!   - `fork`
-//!   - `exec`
-//!   - `exit`
-//!   - thread creation and termination
-//!
-//! Grate calls never consult the thread table and always acquire execution
-//! contexts from the main per-cage queue.
-//!
-//! The tables intentionally store raw `VMContext` pointers rather than typed store or instance handles.
-//! This design avoids Rust lifetime constraints that would otherwise prevent cross-store and cross-instance
-//! execution transfers. Correctness instead relies on higher-level invariants enforced by lind-wasm, including
-//! the guarantee that `VMContext` pointers remain valid for the lifetime of their associated threads.
-//!
-//! For each pool, a single instance performs full initialization, including lind-specific memory setup,
-//! while additional instances attach to the same linear memory. This design allows a grate to process multiple
-//! concurrent requests to the same Wasm linear memory without duplicating address space state.
-//!
-//! ---
-//! ## Concurrency note
-//!
-//! This module provides *execution routing*, not synchronization. Multiple
-//! VMContext instances may share the same linear memory. Grate developers are
-//! responsible for ensuring proper synchronization when mutating shared state.
-use std::collections::{HashMap, VecDeque};
+use anyhow::{anyhow, Context, Result};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use sysdefs::constants::lind_platform_const;
+use sysdefs::constants::lind_platform_const::*;
+use threei::threei_const;
+use wasmtime::{Engine, Instance, Linker, Module, Store, TypedFunc, Val};
+
+type PassFptrTyped = TypedFunc<
+    (
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+        u64,
+    ),
+    i32,
+>;
+
+type WorkerId = u64;
+
+pub struct GrateTemplate<T> {
+    pub engine: Engine,
+    pub module: Module,
+    pub linker: Linker<T>,
+}
+
+pub struct GrateRequest {
+    pub handler_addr: u64,
+    pub cageid: u64,
+    pub arg1: u64,
+    pub arg1cageid: u64,
+    pub arg2: u64,
+    pub arg2cageid: u64,
+    pub arg3: u64,
+    pub arg3cageid: u64,
+    pub arg4: u64,
+    pub arg4cageid: u64,
+    pub arg5: u64,
+    pub arg5cageid: u64,
+    pub arg6: u64,
+    pub arg6cageid: u64,
+}
+
+struct SerialExecutor {
+    lock: Mutex<()>,
+}
+
+impl SerialExecutor {
+    fn new() -> Self {
+        Self {
+            lock: Mutex::new(()),
+        }
+    }
+
+    fn enter(&self) -> MutexGuard<'_, ()> {
+        match self.lock.lock() {
+            Ok(guard) => {
+                #[cfg(feature = "debug-grate-calls")]
+                {
+                    println!("SerialExecutor: acquired lock");
+                }
+
+                guard
+            }
+            Err(poisoned) => {
+                #[cfg(feature = "debug-grate-calls")]
+                {
+                    println!("SerialExecutor: lock poisoned, but continuing anyway");
+                }
+
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
+struct GrateWorker<T> {
+    worker_id: WorkerId,
+    store: Store<T>,
+    instance: Instance,
+    pass_fptr_func: Option<PassFptrTyped>,
+    stack_base: u32,
+    stack_top: u32,
+}
+
+fn worker_stack_base(workerid: WorkerId) -> u32 {
+    let stack_arena_base = STACK_ARENA_BASE.get().copied().unwrap_or_else(|| {
+        panic!("STACK_ARENA_BASE is not initialized");
+    });
+    stack_arena_base
+        + (workerid as u32 - 1) * (GRATE_STACK_GUARD_SIZE + GRATE_STACK_SLOT_SIZE)
+        + GRATE_STACK_GUARD_SIZE
+}
+
+fn worker_stack_top(workerid: WorkerId) -> u32 {
+    worker_stack_base(workerid) + GRATE_STACK_SLOT_SIZE
+}
+
+struct WorkerLease<'a, T> {
+    owner: &'a GrateHandler<T>,
+    worker: Option<GrateWorker<T>>,
+}
+
+impl<'a, T> WorkerLease<'a, T> {
+    fn new(owner: &'a GrateHandler<T>, worker: GrateWorker<T>) -> Self {
+        Self {
+            owner,
+            worker: Some(worker),
+        }
+    }
+
+    fn worker_mut(&mut self) -> &mut GrateWorker<T> {
+        self.worker.as_mut().unwrap()
+    }
+}
+
+impl<'a, T> Drop for WorkerLease<'a, T> {
+    fn drop(&mut self) {
+        if let Some(worker) = self.worker.take() {
+            self.owner.return_worker(worker);
+        }
+    }
+}
+
+pub enum ConcurrencyMode {
+    Parallel,
+    Serialized,
+}
+
+pub struct GrateHandler<T> {
+    grate_id: u64,
+    main_worker: WorkerId,
+    concurrency_mode: ConcurrencyMode,
+    serial_executor: SerialExecutor,
+
+    inner: Mutex<GrateHandlerInner<T>>,
+    cv: Condvar,
+
+    shutting_down: AtomicBool,
+    active_calls: AtomicUsize,
+}
+
+struct GrateHandlerInner<T> {
+    workers: VecDeque<GrateWorker<T>>,
+}
+
+impl<T: Clone> GrateHandler<T> {
+    fn init_ten_workers(
+        &mut self,
+        template: &GrateTemplate<T>,
+        host: &T,
+        cageid: u64,
+    ) -> anyhow::Result<()> {
+        for handler_id in 1_u64..=MAX_GRATE_WORKERS as u64 {
+            let worker = create_worker(template, host.clone(), handler_id).with_context(|| {
+                format!(
+                    "failed to create worker {} for cageid {}",
+                    handler_id, cageid
+                )
+            })?;
+
+            self.inner.lock().unwrap().workers.push_back(worker);
+        }
+
+        self.main_worker = 1;
+        Ok(())
+    }
+}
+
+impl<T> GrateHandler<T> {
+    fn take_worker_blocking(&self) -> GrateWorker<T> {
+        let mut inner = self.inner.lock().unwrap();
+
+        loop {
+            if let Some(worker) = inner.workers.pop_front() {
+                return worker;
+            }
+            inner = self.cv.wait(inner).unwrap();
+        }
+    }
+
+    fn return_worker(&self, worker: GrateWorker<T>) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.workers.push_back(worker);
+        self.cv.notify_one();
+    }
+
+    pub fn begin_shutdown(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+        self.cv.notify_all();
+    }
+
+    pub fn wait_for_idle(&self) {
+        let mut guard = self.inner.lock().unwrap();
+        while self.active_calls.load(Ordering::Acquire) != 0 {
+            guard = self.cv.wait(guard).unwrap();
+        }
+    }
+
+    fn submit_serialized(&self, req: GrateRequest) -> anyhow::Result<i32> {
+        let _serial_guard = self.serial_executor.enter();
+        let worker = self.take_worker_blocking();
+        let mut lease = WorkerLease::new(self, worker);
+        lease.worker_mut().run(req)
+    }
+
+    fn submit_parallel(&self, req: GrateRequest) -> anyhow::Result<i32> {
+        let worker = self.take_worker_blocking();
+        let mut lease = WorkerLease::new(self, worker);
+        lease.worker_mut().run(req)
+    }
+
+    pub fn submit(&self, req: GrateRequest) -> anyhow::Result<i32> {
+        let _active_guard = ActiveCallGuard::new(self)?;
+
+        match self.concurrency_mode {
+            ConcurrencyMode::Serialized => self.submit_serialized(req),
+            ConcurrencyMode::Parallel => self.submit_parallel(req),
+        }
+    }
+}
+
+struct ActiveCallGuard<'a, T> {
+    owner: &'a GrateHandler<T>,
+}
+
+impl<'a, T> ActiveCallGuard<'a, T> {
+    fn new(owner: &'a GrateHandler<T>) -> anyhow::Result<Self> {
+        if owner.shutting_down.load(Ordering::Acquire) {
+            anyhow::bail!("grate handler {} is shutting down", owner.grate_id);
+        }
+
+        owner.active_calls.fetch_add(1, Ordering::AcqRel);
+
+        // double-check, avoid shutdown between fetch_add and return
+        if owner.shutting_down.load(Ordering::Acquire) {
+            owner.active_calls.fetch_sub(1, Ordering::AcqRel);
+            owner.cv.notify_all();
+            anyhow::bail!("grate handler {} is shutting down", owner.grate_id);
+        }
+
+        Ok(Self { owner })
+    }
+}
+
+impl<'a, T> Drop for ActiveCallGuard<'a, T> {
+    fn drop(&mut self) {
+        self.owner.active_calls.fetch_sub(1, Ordering::AcqRel);
+        self.owner.cv.notify_all();
+    }
+}
+
+impl<T> GrateWorker<T> {
+    fn reset_worker_stack(&mut self) {
+        let sp = self.stack_top;
+        let stack_global = self
+            .instance
+            .get_global(&mut self.store, "__stack_pointer")
+            .expect("missing __stack_pointer");
+
+        stack_global
+            .set(&mut self.store, Val::I32(sp as i32))
+            .expect("failed to set __stack_pointer");
+    }
+
+    fn run(&mut self, req: GrateRequest) -> anyhow::Result<i32> {
+        #[cfg(feature = "debug-grate-calls")]
+        {
+            println!(
+                "Worker {} handling grate request for cage {}, handler_addr: {:#x}",
+                self.worker_id, req.cageid, req.handler_addr
+            );
+        }
+
+        self.reset_worker_stack();
+
+        let func = self.pass_fptr_func.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("no pass_fptr_func found in worker {}", self.worker_id)
+        })?;
+
+        let ret = func
+            .call(
+                &mut self.store,
+                (
+                    req.handler_addr,
+                    req.cageid,
+                    req.arg1,
+                    req.arg1cageid,
+                    req.arg2,
+                    req.arg2cageid,
+                    req.arg3,
+                    req.arg3cageid,
+                    req.arg4,
+                    req.arg4cageid,
+                    req.arg5,
+                    req.arg5cageid,
+                    req.arg6,
+                    req.arg6cageid,
+                ),
+            )
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "pass_fptr_to_wt trapped in worker {}: {:#}",
+                    self.worker_id,
+                    e
+                )
+            })?;
+
+        #[cfg(feature = "debug-grate-calls")]
+        println!(
+            "Worker {} got result {} from pass_fptr_to_wt",
+            self.worker_id, ret
+        );
+        Ok(ret)
+    }
+}
+
+pub fn create_worker<T>(
+    template: &GrateTemplate<T>,
+    host: T,
+    worker_id: WorkerId,
+) -> anyhow::Result<GrateWorker<T>>
+where
+    T: Clone,
+{
+    let mut store = Store::new(&template.engine, host);
+
+    let mut linker: Linker<T> = template.linker.clone();
+
+    let stack_arena_base = STACK_ARENA_BASE.get().copied().unwrap_or_else(|| {
+        panic!("STACK_ARENA_BASE is not initialized");
+    });
+
+    let (instance, _, _) = linker
+        .instantiate_with_lind_thread(&mut store, &template.module, false)
+        .context("failed to instantiate grate module")?;
+
+    let pass_fptr_func = match instance.get_export(&mut store, "pass_fptr_to_wt") {
+        Some(_) => Some(instance.get_typed_func::<(
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+            u64,
+        ), i32>(&mut store, "pass_fptr_to_wt")?),
+        None => None,
+    };
+
+    let stack_base = worker_stack_base(worker_id);
+    let stack_top = worker_stack_top(worker_id);
+
+    Ok(GrateWorker {
+        worker_id,
+        store,
+        instance,
+        pass_fptr_func,
+        stack_base,
+        stack_top,
+    })
+}
+
+pub fn create_handler_for_cage<T: Clone>(
+    template: &GrateTemplate<T>,
+    host: T,
+    cageid: u64,
+    concurrency_mode: ConcurrencyMode,
+) -> anyhow::Result<GrateHandler<T>> {
+    let mut handler = GrateHandler {
+        grate_id: cageid,
+        main_worker: 1,
+        concurrency_mode,
+        serial_executor: SerialExecutor::new(),
+        inner: Mutex::new(GrateHandlerInner {
+            workers: VecDeque::new(),
+        }),
+        cv: Condvar::new(),
+        shutting_down: AtomicBool::new(false),
+        active_calls: AtomicUsize::new(0),
+    };
+
+    handler.init_ten_workers(template, &host, cageid)?;
+
+    Ok(handler)
+}
+
+use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::ptr::NonNull;
-use std::sync::{Mutex, OnceLock};
-use sysdefs::constants::lind_platform_const;
+use std::sync::OnceLock;
 
-/// The [`VMContext`](wasmtime_runtime::VMContext) pointer originates from Wasmtime internals and
-/// represents the execution state of a Wasm instance. It includes the instance’s memories, tables,
-/// globals, and other execution state needed when entering or re-entering Wasm code. Because `VMContext`
-/// is an opaque runtime structure, it is stored as a raw pointer (`*mut c_void`) wrapped in a safer
-/// abstraction.  For more details, see the documentation in `wasmtime_runtime::vmcontext`.
-///
-/// `VmCtxWrapper` is a lightweight wrapper around a non-null raw pointer to a `VMContext`.
-/// It uses `NonNull<c_void>` to express the invariant that the pointer must never be null.
-/// The wrapper is `Copy` and `Clone` so it can be cheaply passed around without ownership transfer.
 #[derive(Clone, Copy)]
 pub struct VmCtxWrapper {
     pub vmctx: NonNull<c_void>,
 }
 
-/// The `VmCtxWrapper` is assumed to be valid for concurrent access according to lind-wasm’s execution
-/// model.
 unsafe impl Send for VmCtxWrapper {}
 unsafe impl Sync for VmCtxWrapper {}
 
@@ -131,33 +424,9 @@ impl VmCtxWrapper {
     }
 }
 
-/// Global per-cage `VMContext` execution pools.
-///
-/// Each cage owns a dedicated FIFO queue of `VMContext` entries. This queue represents the default
-/// execution pool and is conceptually associated with the main thread (`tid == 1`).
-///
-/// Normal execution paths and all grate calls acquire `VMContexts` exclusively
-/// from this pool.
-static VMCTX_QUEUES: OnceLock<Vec<Mutex<VecDeque<VmCtxWrapper>>>> = OnceLock::new();
-
-/// Per-cage, per-thread *active* `VMContext` table.
-///
-/// This table stores the *currently active* Wasmtime execution context for each thread and is
-/// used exclusively for **continuation-sensitive operations** that must resume execution in the
-/// same Wasmtime instance that originally issued the syscall.
 static VMCTX_THREADS: OnceLock<Vec<Mutex<HashMap<u64, VmCtxWrapper>>>> = OnceLock::new();
 
-/// Initialize the global `VMContext` pool.
-///
-/// This function must be called exactly once during lind-wasm startup, before any `VMContext` is
-/// pushed to or retrieved from the pool. It eagerly allocates one empty queue per possible `cage_id`.
 pub fn init_vmctx_pool() {
-    VMCTX_QUEUES.get_or_init(|| {
-        (0..lind_platform_const::MAX_CAGEID)
-            .map(|_| Mutex::new(VecDeque::new()))
-            .collect()
-    });
-
     VMCTX_THREADS.get_or_init(|| {
         (0..lind_platform_const::MAX_CAGEID)
             .map(|_| Mutex::new(HashMap::new()))
@@ -165,100 +434,6 @@ pub fn init_vmctx_pool() {
     });
 }
 
-/// `get_vmctx`
-///
-/// Retrieve a VMContext from the specified cage.
-///
-/// This performs a FIFO pop from the main-thread (`tid == 1`) execution queue.
-///
-/// # Note on concurrency semantics:
-/// Because `VmCtxWrapper` is `Copy`, each caller receives an independent wrapper value. Modifying
-/// the returned wrapper itself (for example, reassigning the pointer) does not affect other copies
-/// associated with the same `(cage_id, thread_id)` entry. However, this copy semantics applies only
-/// to the wrapper, not to the underlying execution state. All copies still reference the same underlying
-/// `VMContext` and the same cage / grate memory regions.
-///
-/// As a result, concurrent requests that mutate shared cage or grate memory can still introduce data races,
-/// even though each request holds its own `VMContext` copy.
-///
-/// For example, if a grate defines shared mutable state such as: `UID_CONST = 10;` and exposes a function:
-///
-/// ```C
-/// update_by_one() {
-///    UID_CONST++;
-/// }
-/// ```
-///
-/// then multiple concurrent invocations of `update_by_one()` will race on `UID_CONST`, despite each invocation
-/// operating through a separate `VmCtxWrapper` copy.
-///
-/// At present, lind-wasm does not enforce synchronization at this level. Grate developers are responsible for
-/// ensuring proper concurrency control whenever their grate code mutates shared memory, for example by using
-/// explicit locking, atomic operations, or other synchronization mechanisms appropriate to their execution model.
-pub fn get_vmctx(cage_id: u64) -> Option<VmCtxWrapper> {
-    let queues = VMCTX_QUEUES.get().expect("VMCTX_QUEUES not initialized");
-    let q = queues.get(cage_id as usize).expect("invalid cage_id");
-    q.lock().unwrap().pop_front()
-}
-
-/// `set_vmctx`
-///
-/// Inserts a `VMContext` into the global per-cage execution pool. Each call registers one executable Wasmtime
-/// instance associated with the given cageid.
-///
-/// In lind-wasm, `VMContext` are preallocated in pools to enable concurrent request handling within a single
-/// cage or grate. At instance execution startup, a fixed number of Wasmtime instances (currently 10) are created
-/// for each cage. One instance is fully initialized using `instantiate_with_lind`, which performs lind-specific
-/// memory setup. The remaining instances are created using `instantiate_with_lind_thread`, and attach to the same
-/// linear memory as the primary instance, serving as backup execution contexts. This is typically called when the
-/// `VMContext` becomes available.
-///
-/// All instances created during this initialization phase are registered through `set_vmctx` and pushed into the
-/// global `VMContext` table. At runtime, execution paths acquire an available context from this pool.
-///
-/// After a grate call finishes execution, the `VMContext` used for that execution is returned to the same pool
-/// and made available for subsequent requests.
-///
-/// The implementation of instance creation and pool population is handled externally, primarily in `run.rs` and
-/// the multi-process initialization logic under `lind-multi-process`.
-pub fn set_vmctx(cage_id: u64, vmctx: VmCtxWrapper) {
-    // Insert the `VMContext` entry in the global table
-    let queues = VMCTX_QUEUES.get().expect("VMCTX_QUEUES not initialized");
-    let q = queues.get(cage_id as usize).expect("invalid cage_id");
-    q.lock().unwrap().push_back(vmctx);
-}
-
-/// `rm_vmctx`
-///
-/// Removes the `VMContext` entry for a given cage and thread.
-///
-/// It returns the removed `VmCtxWrapper` if one was present.
-/// This is typically called when a thread exits or its execution context is torn down.
-pub fn rm_vmctx(cage_id: u64) -> bool {
-    // Get the global `VMContext` pooling table
-    let Some(queues) = VMCTX_QUEUES.get() else {
-        // Return false if not initialized
-        return false;
-    };
-
-    let idx = cage_id as usize;
-
-    // Get the queue for the given cage_id
-    let Some(q) = queues.get(idx) else {
-        // Return false if invalid cage_id or no queue
-        return false;
-    };
-
-    // Clear the queue for the given cage_id
-    let mut guard = q.lock().unwrap();
-    guard.clear();
-    true
-}
-
-/// Register a VMContext according to `(cage_id, tid)` in the per-thread active table.
-///
-/// This is used exclusively for pthread-related syscalls and thread exit.
-/// Grate calls and normal execution never consult this table.
 pub fn set_vmctx_thread(cage_id: u64, tid: u64, vmctx: VmCtxWrapper) {
     let tables = VMCTX_THREADS.get().expect("VMCTX_THREADS not initialized");
     let t = tables.get(cage_id as usize).expect("invalid cage_id");
@@ -274,13 +449,27 @@ pub fn get_vmctx_thread(cage_id: u64, tid: u64) -> Option<VmCtxWrapper> {
     t.lock().unwrap().get(&tid).copied()
 }
 
-/// Remove a single thread entry
+/// Remove a single thread entry.
+///
+/// Special case:
+/// - if `tid == 0`, remove all VMContext entries under `cage_id`.
 pub fn rm_vmctx_thread(cage_id: u64, tid: u64) -> bool {
     let Some(tables) = VMCTX_THREADS.get() else {
+        println!("rm_vmctx_thread: VMCTX_THREADS not initialized");
         return false;
     };
     let Some(t) = tables.get(cage_id as usize) else {
+        println!("rm_vmctx_thread: invalid cage_id {}", cage_id);
         return false;
     };
-    t.lock().unwrap().remove(&tid).is_some()
+
+    let mut guard = t.lock().unwrap();
+
+    if tid == 0 {
+        let had_entries = !guard.is_empty();
+        guard.clear();
+        had_entries
+    } else {
+        guard.remove(&tid).is_some()
+    }
 }

--- a/src/wasmtime/crates/lind-3i/src/lib.rs
+++ b/src/wasmtime/crates/lind-3i/src/lib.rs
@@ -70,12 +70,12 @@
 //! a given (cage_id, tid), because execution must resume in the same continuation. For grate calls, by
 //! contrast, lind-3i only needs to obtain some available worker for the target grate, because correctness
 //! depends on entering a compatible grate instance, not on resuming a previously suspended continuation.
-use anyhow::{anyhow, Context, Result};
+use anyhow::Context;
 use std::collections::{HashMap, VecDeque};
 use std::ffi::c_void;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock};
+use std::sync::{Condvar, Mutex, MutexGuard, OnceLock};
 use sysdefs::constants::lind_platform_const;
 use sysdefs::constants::lind_platform_const::*;
 use wasmtime::{Engine, Instance, Linker, Module, Store, TypedFunc, Val};
@@ -671,11 +671,7 @@ where
 {
     let mut store = Store::new(&template.engine, host);
 
-    let mut linker: Linker<T> = template.linker.clone();
-
-    let stack_arena_base = STACK_ARENA_BASE.get().copied().unwrap_or_else(|| {
-        panic!("STACK_ARENA_BASE is not initialized");
-    });
+    let linker: Linker<T> = template.linker.clone();
 
     let (instance, _, _) = linker
         .instantiate_with_lind_thread(&mut store, &template.module, false)

--- a/src/wasmtime/crates/lind-3i/src/lib.rs
+++ b/src/wasmtime/crates/lind-3i/src/lib.rs
@@ -1,10 +1,83 @@
+//! This module provides a global runtime-state lookup mechanism for lind-3i and lind-wasm, enabling
+//! controlled transfers of execution across cages, grates, and threads.
+//!
+//! In lind-wasm, runtime control is not always confined to a single Wasmtime instance or a single
+//! linear call stack. There are two primary scenarios in which lind-3i must explicitly locate and
+//! re-enter a different runtime state.
+//!
+//! Importantly, not all re-entries into Wasmtime are equivalent. Some operations require resuming
+//! execution in the *same continuation context* (i.e., the same instance and asyncify state),
+//! while others only require access to a compatible instance that shares the same linear memory.
+//!
+//! The mechanisms in this module distinguish between these cases explicitly.
+//!
+//! ---
+//! ## Scenario 1: Process-like operations (`fork`, `exec`, `exit`)
+//!
+//! The first scenario occurs during process-like operations such as `fork`, `exec`, and `exit`. These
+//! operations require Wasmtime to create, clone, or destroy existing Wasm instances. After RawPOSIX
+//! completes the semantic handling of a `fork`, `exec`, or `exit` operation, execution must return to
+//! Wasmtime to continue running Wasm code. Importantly, the cage that performs the `fork`, `exec`, or
+//! `exit` logic is not necessarily the same cage or grate that originally issued the system call. As
+//! a result, lind-3i cannot rely on an implicit “current” runtime state. Instead, it must be able to
+//! retrieve the Wasmtime execution context.
+//!
+//! These operations are also continuation-sensitive, which means that the execution must resume in
+//! the *same Wasmtime instance* that originally issued the syscall.
+//!
+//! In particular, `fork` / `exit` rely on Asyncify to suspend and later resume execution via paired
+//! `start_unwind` / `stop_unwind` and `start_rewind` / `stop_rewind` operations. These transitions
+//! must occur within the same continuation context, which is the same Wasmtime instance and
+//! associated asyncify runtime state. Resuming execution in a different instance, even one that
+//! shares linear memory, breaks this invariant and can result in missed callbacks or incorrect
+//! return values.
+//!
+//! As a result, lind-3i must be able to retrieve *the active execution context* corresponding
+//! to a specific `(cage_id, tid)` when handling these operations.
+//!
+//! ---
+//! ## Scenario 2: Grate calls (cross-module execution transfers)
+//!
+//! The second scenario arises during grate calls. Grate calls involve cross-module execution transfers,
+//! where control jumps from one Wasm module to another (for example, from a cage into a grate, or between
+//! grates). Supporting these jumps similarly requires the ability to locate and enter the runtime state
+//! of a different module than the one currently executing.
+//!
+//! Unlike fork, exec, and exit, grate calls are not continuation-sensitive. A grate call does not need
+//! to resume execution in the exact Wasmtime instance that originally issued the transfer. Instead, it
+//! only needs to enter a compatible execution context for the target grate. In lind-3i, this compatible
+//! context is represented not as a single shared runtime state, but as a pool of independent grate workers.
+//! Each worker consists of:
+//! - its own Wasmtime `Store`,
+//! - its own instantiated grate `Instance`, and
+//! - its own independent Wasm call stack region.
+//!
+//! Operationally, a grate call is executed by leasing one worker from the target grate’s worker pool,
+//! invoking the grate entry function inside that worker, and returning the worker to the pool when the
+//! call finishes. This means that a grate call should be understood as a transfer into an available worker
+//! context, rather than as a re-entry into one globally shared grate instance. This worker-based
+//! structure is what makes grate-call concurrency possible.
+//!
+//! A Wasmtime `Store` is an execution boundary: it owns the runtime state associated with a particular
+//! instance execution, including stack state and other mutable execution-local state. By giving each
+//! worker its own `Store` and `Instance`, lind-3i ensures that concurrent grate calls do not execute
+//! inside the same Wasmtime runtime context. As a result, parallel grate calls do not contend on a shared
+//! Wasm call stack, do not overwrite each other’s instance-local execution state, and do not require
+//! continuation matching of the kind needed by Asyncify-based process operations.
+//!
+//! This design also explains why grate calls use a different lookup mechanism from continuation-sensitive
+//! operations. For fork / exit, lind-3i must recover the specific active execution context associated with
+//! a given (cage_id, tid), because execution must resume in the same continuation. For grate calls, by
+//! contrast, lind-3i only needs to obtain some available worker for the target grate, because correctness
+//! depends on entering a compatible grate instance, not on resuming a previously suspended continuation.
 use anyhow::{anyhow, Context, Result};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::ffi::c_void;
+use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, OnceLock};
 use sysdefs::constants::lind_platform_const;
 use sysdefs::constants::lind_platform_const::*;
-use threei::threei_const;
 use wasmtime::{Engine, Instance, Linker, Module, Store, TypedFunc, Val};
 
 type PassFptrTyped = TypedFunc<
@@ -29,14 +102,59 @@ type PassFptrTyped = TypedFunc<
 
 type WorkerId = u64;
 
+/// Concurrency policy for a grate handler.
+///
+/// This determines whether multiple submitted grate calls may execute
+/// concurrently on different workers, or whether entry must be serialized.
+pub enum ConcurrencyMode {
+    /// Allow multiple calls to execute concurrently as long as distinct
+    /// workers are available in the pool.
+    Parallel,
+
+    /// Allow multiple calls to execute concurrently as long as distinct
+    /// workers are available in the pool.
+    Serialized,
+}
+
+/// Template used to instantiate grate workers.
+///
+/// A `GrateTemplate` contains the shared, immutable ingredients needed to
+/// construct worker-local execution contexts for the same grate module.
+/// Each worker clones or reuses these components to create its own
+/// `Store + Instance` runtime state.
 pub struct GrateTemplate<T> {
+    /// The Wasmtime engine used to create worker-local stores and instances.
+    ///
+    /// This is shared across all workers for the same grate.
     pub engine: Engine,
+
+    /// The compiled grate module that each worker instantiates.
+    ///
+    /// All workers created from the same template execute this same module,
+    /// but do so inside independent stores / instances.
     pub module: Module,
+
+    /// The linker used to instantiate the grate module and attach its imports.
+    ///
+    /// Each worker starts from this template linker and clones it during
+    /// worker creation so that instantiation can proceed independently.
     pub linker: Linker<T>,
 }
 
+/// Marshalled arguments for one grate call.
+///
+/// A `GrateRequest` represents one cross-module execution transfer into a
+/// grate worker. It includes the callee function pointer together with the
+/// calling cage identity and up to six `(value, cageid)` argument pairs.
+///
+/// The `argNcageid` fields identify the ownership / address-space context
+/// associated with pointer-like arguments, allowing the callee side to
+/// interpret cross-cage values correctly.
 pub struct GrateRequest {
+    /// Address of the function ptr argument passed by the caller,
+    /// used for indirect dispatch inside the grate.
     pub handler_addr: u64,
+    /// Identity of the calling cage, used for invoking the correct handler.
     pub cageid: u64,
     pub arg1: u64,
     pub arg1cageid: u64,
@@ -57,12 +175,23 @@ struct SerialExecutor {
 }
 
 impl SerialExecutor {
+    /// Create a serialization gate for grate calls.
+    ///
+    /// This executor is used when a grate handler runs in `Serialized` mode.
+    /// In that mode, callers may still submit requests concurrently, but only
+    /// one request is allowed to enter the grate at a time.
     fn new() -> Self {
         Self {
             lock: Mutex::new(()),
         }
     }
 
+    /// Enter the serialized execution region.
+    ///
+    /// This acquires the internal mutex and returns a guard that keeps the
+    /// grate in exclusive-execution mode for the duration of the call.
+    /// If the mutex has been poisoned, execution continues by recovering the
+    /// inner guard, since poisoning does not invalidate the grate runtime state.
     fn enter(&self) -> MutexGuard<'_, ()> {
         match self.lock.lock() {
             Ok(guard) => {
@@ -85,15 +214,53 @@ impl SerialExecutor {
     }
 }
 
+/// One reusable grate execution worker.
+///
+/// A `GrateWorker` is the concrete execution unit for grate calls. Each worker
+/// owns its own Wasmtime `Store` and `Instance`, but may still be attached to
+/// the same underlying linear memory as other workers. To preserve isolation,
+/// each worker is assigned a dedicated stack slot inside the shared stack arena.
 struct GrateWorker<T> {
+    /// Logical identifier of this worker within the handler’s pool.
+    ///
+    /// The worker id is also used to derive the worker’s private stack slot.
     worker_id: WorkerId,
+
+    /// Worker-local Wasmtime store.
+    ///
+    /// This store holds the execution state for this worker and isolates its
+    /// runtime context from other concurrently executing workers.
     store: Store<T>,
+
+    /// Worker-local instance of the grate module.
+    ///
+    /// Calls submitted to this worker execute inside this instance.
     instance: Instance,
+
+    /// Typed handle to the grate entry export, if present.
+    ///
+    /// This is usually the `pass_fptr_to_wt` trampoline used to enter the
+    /// grate from the handler. It is cached here to avoid resolving the export
+    /// on every call.
     pass_fptr_func: Option<PassFptrTyped>,
+
+    /// Base address of this worker’s assigned stack slot in the stack arena.
+    ///
+    /// This marks the first usable byte of the worker’s dedicated stack region.
     stack_base: u32,
+
+    /// Top address of this worker’s assigned stack slot.
+    ///
+    /// Before each call, the worker resets its `__stack_pointer` to this value
+    /// so execution starts from a clean stack state within its own slot.
     stack_top: u32,
 }
 
+/// Compute the base address of the stack region assigned to a specific worker.
+///
+/// Each grate worker owns a dedicated stack slot inside the global stack arena.
+/// This function maps a logical `worker_id` to the first usable byte of that
+/// worker’s stack, skipping over the guard region placed before the slot.
 fn worker_stack_base(workerid: WorkerId) -> u32 {
     let stack_arena_base = STACK_ARENA_BASE.get().copied().unwrap_or_else(|| {
         panic!("STACK_ARENA_BASE is not initialized");
@@ -103,16 +270,39 @@ fn worker_stack_base(workerid: WorkerId) -> u32 {
         + GRATE_STACK_GUARD_SIZE
 }
 
+/// Compute the top address of the stack region assigned to a specific worker.
+///
+/// The returned address is used to reset the worker’s `__stack_pointer` before
+/// starting a new grate call, ensuring that each invocation begins with a clean
+/// stack state inside that worker’s private stack slot.
 fn worker_stack_top(workerid: WorkerId) -> u32 {
     worker_stack_base(workerid) + GRATE_STACK_SLOT_SIZE
 }
 
+/// Scoped ownership of a borrowed worker.
+///
+/// A `WorkerLease` represents a worker temporarily checked out from a
+/// `GrateHandler`. When the lease is dropped, the worker is automatically
+/// returned to the handler’s pool.
 struct WorkerLease<'a, T> {
+    /// The handler that owns the leased worker.
+    ///
+    /// This is used to return the worker to the pool on drop.
     owner: &'a GrateHandler<T>,
+
+    /// The leased worker, if still held by this lease.
+    ///
+    /// The worker is wrapped in `Option` so it can be taken during drop and
+    /// returned exactly once.
     worker: Option<GrateWorker<T>>,
 }
 
 impl<'a, T> WorkerLease<'a, T> {
+    /// Create a scoped lease for a grate worker borrowed from a handler.
+    ///
+    /// A `WorkerLease` ensures that the worker is automatically returned to the
+    /// owning handler when the lease is dropped, even if the grate call exits
+    /// early due to an error or trap.
     fn new(owner: &'a GrateHandler<T>, worker: GrateWorker<T>) -> Self {
         Self {
             owner,
@@ -120,12 +310,20 @@ impl<'a, T> WorkerLease<'a, T> {
         }
     }
 
+    /// Get mutable access to the leased worker.
+    ///
+    /// This is used by the submission path to run a grate request inside the
+    /// borrowed worker before the worker is returned to the pool on drop.
     fn worker_mut(&mut self) -> &mut GrateWorker<T> {
         self.worker.as_mut().unwrap()
     }
 }
 
 impl<'a, T> Drop for WorkerLease<'a, T> {
+    /// Return the leased worker to its handler when the lease goes out of scope.
+    ///
+    /// This guarantees that worker-pool bookkeeping remains correct even when
+    /// execution unwinds due to an error or trap.
     fn drop(&mut self) {
         if let Some(worker) = self.worker.take() {
             self.owner.return_worker(worker);
@@ -133,29 +331,80 @@ impl<'a, T> Drop for WorkerLease<'a, T> {
     }
 }
 
-pub enum ConcurrencyMode {
-    Parallel,
-    Serialized,
-}
-
+/// Scheduler and worker-pool owner for one grate.
+///
+/// A `GrateHandler` manages the reusable worker pool for a grate and defines
+/// how incoming grate requests are admitted, scheduled, and shut down.
+/// It is the main runtime object responsible for grate-call concurrency.
 pub struct GrateHandler<T> {
+    /// Identifier of the grate or cage associated with this handler.
+    ///
+    /// This is mainly used for diagnostics and error reporting.
     grate_id: u64,
+
+    /// Id of the designated main worker.
+    ///
+    /// This field records the canonical first worker in the pool.
+    ///
+    /// todo:
+    /// It may be useful for debugging or future policy decisions, even
+    /// though the current submission path leases any available worker.
     main_worker: WorkerId,
+
+    /// Configured concurrency policy for this grate.
+    ///
+    /// Determines whether `submit()` dispatches through serialized or parallel
+    /// execution.
     concurrency_mode: ConcurrencyMode,
+
+    /// Serialization gate used only when the handler is in `Serialized` mode.
     serial_executor: SerialExecutor,
 
+    /// Mutex-protected internal worker-pool state.
+    ///
+    /// This protects the queue of available workers.
     inner: Mutex<GrateHandlerInner<T>>,
+
+    /// Condition variable used to block until a worker becomes available or
+    /// until shutdown-related state changes.
     cv: Condvar,
 
+    /// Flag indicating that shutdown has started.
+    ///
+    /// Once set, new submissions are rejected, while existing in-flight calls
+    /// are allowed to complete
+    ///
+    /// todo: not integrated with actual grate teardown yet
     shutting_down: AtomicBool,
+
+    /// Number of grate calls currently in flight.
+    ///
+    /// This is used to coordinate graceful shutdown and to detect when the
+    /// handler has become idle.
+    ///
+    /// todo: not integrated with actual grate teardown yet
     active_calls: AtomicUsize,
 }
 
+/// Mutex-protected internal state for a `GrateHandler`.
+///
+/// This structure exists to keep the lock scope narrow and separate the
+/// worker-pool state from the rest of the handler’s control fields.
 struct GrateHandlerInner<T> {
     workers: VecDeque<GrateWorker<T>>,
 }
 
 impl<T: Clone> GrateHandler<T> {
+    /// Pre-create the worker pool for a grate handler.
+    ///
+    /// Each worker is an independent `store + instance + call stack` execution
+    /// context for the same grate module. Pre-initializing the full pool allows
+    /// later grate calls to lease a ready-to-run worker without paying the cost
+    /// of instantiation on the fast path.
+    ///
+    /// This worker replication is what enables grate-call concurrency: parallel
+    /// calls execute in different Wasmtime stores rather than contending on a
+    /// single shared execution context.
     fn init_ten_workers(
         &mut self,
         template: &GrateTemplate<T>,
@@ -179,6 +428,11 @@ impl<T: Clone> GrateHandler<T> {
 }
 
 impl<T> GrateHandler<T> {
+    /// Lease one available worker from the pool, blocking until one is free.
+    ///
+    /// This function is the core worker-pool acquisition primitive. If all
+    /// workers are currently in use, the caller waits on the condition variable
+    /// until another call finishes and returns a worker to the pool.
     fn take_worker_blocking(&self) -> GrateWorker<T> {
         let mut inner = self.inner.lock().unwrap();
 
@@ -190,17 +444,36 @@ impl<T> GrateHandler<T> {
         }
     }
 
+    /// Return a worker to the pool and wake one waiting submitter.
+    ///
+    /// This makes the worker available for reuse by future grate calls.
+    /// Returning workers through the handler centralizes pool management and
+    /// ensures that blocked callers can resume when capacity becomes available.
     fn return_worker(&self, worker: GrateWorker<T>) {
         let mut inner = self.inner.lock().unwrap();
         inner.workers.push_back(worker);
         self.cv.notify_one();
     }
 
+    /// Mark this grate handler as shutting down.
+    ///
+    /// After shutdown begins, new submissions are rejected by `ActiveCallGuard`.
+    /// Existing in-flight calls are allowed to finish, and waiters are notified
+    /// so that shutdown coordination can make progress.
+    ///
+    /// todo: not integrated with actual grate teardown yet
     pub fn begin_shutdown(&self) {
         self.shutting_down.store(true, Ordering::Release);
         self.cv.notify_all();
     }
 
+    /// Block until all in-flight grate calls have completed.
+    ///
+    /// This is typically used during shutdown after `begin_shutdown()` has
+    /// prevented new calls from entering. The function waits until the active
+    /// call count drops to zero.
+    ///
+    /// todo: not integrated with actual grate teardown yet
     pub fn wait_for_idle(&self) {
         let mut guard = self.inner.lock().unwrap();
         while self.active_calls.load(Ordering::Acquire) != 0 {
@@ -208,6 +481,11 @@ impl<T> GrateHandler<T> {
         }
     }
 
+    /// Execute a grate request under serialized execution.
+    ///
+    /// This path acquires the serialization lock before leasing a worker,
+    /// ensuring that at most one call enters the grate at a time even though
+    /// the handler may still own multiple workers.
     fn submit_serialized(&self, req: GrateRequest) -> anyhow::Result<i32> {
         let _serial_guard = self.serial_executor.enter();
         let worker = self.take_worker_blocking();
@@ -215,12 +493,23 @@ impl<T> GrateHandler<T> {
         lease.worker_mut().run(req)
     }
 
+    /// Execute a grate request under parallel execution.
+    ///
+    /// In parallel mode, the handler simply leases an available worker and
+    /// runs the request immediately. Different callers may therefore execute
+    /// concurrently as long as different workers are available.
     fn submit_parallel(&self, req: GrateRequest) -> anyhow::Result<i32> {
         let worker = self.take_worker_blocking();
         let mut lease = WorkerLease::new(self, worker);
         lease.worker_mut().run(req)
     }
 
+    /// Submit a grate request to this handler.
+    ///
+    /// This is the main entry point for grate calls. It first registers the
+    /// request as an active in-flight call, rejecting it if shutdown has begun,
+    /// and then dispatches the request according to the handler’s configured
+    /// concurrency mode.
     pub fn submit(&self, req: GrateRequest) -> anyhow::Result<i32> {
         let _active_guard = ActiveCallGuard::new(self)?;
 
@@ -231,11 +520,22 @@ impl<T> GrateHandler<T> {
     }
 }
 
+/// RAII guard representing one active in-flight grate call.
+///
+/// An `ActiveCallGuard` increments the handler’s active-call counter when a
+/// submission begins and decrements it automatically when execution ends,
+/// ensuring correct shutdown coordination even in the presence of errors.
 struct ActiveCallGuard<'a, T> {
     owner: &'a GrateHandler<T>,
 }
 
 impl<'a, T> ActiveCallGuard<'a, T> {
+    /// Register one in-flight grate call against the handler.
+    ///
+    /// This guard prevents shutdown races by incrementing the active-call count
+    /// before execution begins and double-checking whether shutdown started in
+    /// the small window after the increment. If shutdown is already in progress,
+    /// the increment is rolled back and submission fails.
     fn new(owner: &'a GrateHandler<T>) -> anyhow::Result<Self> {
         if owner.shutting_down.load(Ordering::Acquire) {
             anyhow::bail!("grate handler {} is shutting down", owner.grate_id);
@@ -255,6 +555,10 @@ impl<'a, T> ActiveCallGuard<'a, T> {
 }
 
 impl<'a, T> Drop for ActiveCallGuard<'a, T> {
+    /// Deregister one in-flight grate call.
+    ///
+    /// Dropping this guard decrements the active-call count and notifies waiters,
+    /// allowing shutdown code to observe when the handler has become idle.
     fn drop(&mut self) {
         self.owner.active_calls.fetch_sub(1, Ordering::AcqRel);
         self.owner.cv.notify_all();
@@ -262,6 +566,12 @@ impl<'a, T> Drop for ActiveCallGuard<'a, T> {
 }
 
 impl<T> GrateWorker<T> {
+    /// Reset this worker’s stack pointer to the top of its private stack slot.
+    ///
+    /// Grate workers are reusable execution contexts. Before each new grate call,
+    /// the worker’s Wasm stack pointer is reset so that the next invocation starts
+    /// from a clean stack state rather than inheriting frames or stack position
+    /// from a previous call.
     fn reset_worker_stack(&mut self) {
         let sp = self.stack_top;
         let stack_global = self
@@ -274,6 +584,12 @@ impl<T> GrateWorker<T> {
             .expect("failed to set __stack_pointer");
     }
 
+    /// Run one grate request inside this worker.
+    ///
+    /// Execution happens inside this worker’s private `Store` and `Instance`,
+    /// which isolates its runtime state from other concurrently executing workers.
+    /// The worker resets its stack, resolves the exported grate entry function,
+    /// and invokes `pass_fptr_to_wt` with the marshalled request arguments.
     fn run(&mut self, req: GrateRequest) -> anyhow::Result<i32> {
         #[cfg(feature = "debug-grate-calls")]
         {
@@ -326,6 +642,25 @@ impl<T> GrateWorker<T> {
     }
 }
 
+/// Create a single grate worker.
+///
+/// A worker is an independently executable `Store + Instance + call stack`
+/// context for one grate module. Workers are the unit of grate-call execution:
+/// each submitted request runs inside one worker borrowed from the handler’s
+/// pool.
+///
+/// Although different workers own different Wasmtime `Store`s and `Instance`s,
+/// they are attached to the same underlying linear memory region. As a result,
+/// workers must not share the same stack range inside linear memory.
+///
+/// To preserve isolation between concurrent grate calls, lind-wasm partitions
+/// the grate stack arena into per-worker stack slots at instantiation time.
+/// Each worker is then assigned its own dedicated stack slot, and later resets
+/// its `__stack_pointer` to that slot before beginning execution.
+///
+/// The stack-slot partitioning is established by
+/// `instantiate_with_lind_thread()`. See that function’s comments for the
+/// detailed layout and attachment semantics.
 pub fn create_worker<T>(
     template: &GrateTemplate<T>,
     host: T,
@@ -379,6 +714,16 @@ where
     })
 }
 
+/// Create and initialize a grate handler for one cage.
+///
+/// A `GrateHandler` owns the reusable worker pool for the target grate and
+/// defines how incoming grate calls are scheduled. In `Parallel` mode, multiple
+/// calls may execute concurrently by leasing different workers. In `Serialized`
+/// mode, calls still use the same worker-pool abstraction, but entry is gated
+/// so that only one call runs at a time.
+///
+/// This function performs eager worker creation so that the handler is ready to
+/// serve grate calls immediately after registration.
 pub fn create_handler_for_cage<T: Clone>(
     template: &GrateTemplate<T>,
     host: T,
@@ -403,11 +748,6 @@ pub fn create_handler_for_cage<T: Clone>(
     Ok(handler)
 }
 
-use std::collections::VecDeque;
-use std::ffi::c_void;
-use std::ptr::NonNull;
-use std::sync::OnceLock;
-
 #[derive(Clone, Copy)]
 pub struct VmCtxWrapper {
     pub vmctx: NonNull<c_void>,
@@ -424,8 +764,17 @@ impl VmCtxWrapper {
     }
 }
 
+/// Per-cage, per-thread *active* `VMContext` table.
+///
+/// This table stores the *currently active* Wasmtime execution context for each thread and is
+/// used exclusively for **continuation-sensitive operations** that must resume execution in the
+/// same Wasmtime instance that originally issued the syscall.
 static VMCTX_THREADS: OnceLock<Vec<Mutex<HashMap<u64, VmCtxWrapper>>>> = OnceLock::new();
 
+/// Initialize the global `VMContext` pool.
+///
+/// This function must be called exactly once during lind-wasm startup, before any `VMContext` is
+/// pushed to or retrieved from the pool. It eagerly allocates one empty queue per possible `cage_id`.
 pub fn init_vmctx_pool() {
     VMCTX_THREADS.get_or_init(|| {
         (0..lind_platform_const::MAX_CAGEID)
@@ -434,6 +783,10 @@ pub fn init_vmctx_pool() {
     });
 }
 
+/// Register a VMContext according to `(cage_id, tid)` in the per-thread active table.
+///
+/// This is used exclusively for pthread-related syscalls and thread exit.
+/// Grate calls and normal execution never consult this table.
 pub fn set_vmctx_thread(cage_id: u64, tid: u64, vmctx: VmCtxWrapper) {
     let tables = VMCTX_THREADS.get().expect("VMCTX_THREADS not initialized");
     let t = tables.get(cage_id as usize).expect("invalid cage_id");

--- a/src/wasmtime/crates/lind-3i/src/lib.rs
+++ b/src/wasmtime/crates/lind-3i/src/lib.rs
@@ -111,8 +111,8 @@ pub enum ConcurrencyMode {
     /// workers are available in the pool.
     Parallel,
 
-    /// Allow multiple calls to execute concurrently as long as distinct
-    /// workers are available in the pool.
+    /// A single call request is addressed at a time even though requests
+    /// are made concurrently.
     Serialized,
 }
 
@@ -406,7 +406,7 @@ impl<T: Clone> GrateHandler<T> {
     /// This worker replication is what enables grate-call concurrency: parallel
     /// calls execute in different Wasmtime stores rather than contending on a
     /// single shared execution context.
-    fn init_ten_workers(
+    fn init_workers(
         &mut self,
         template: &GrateTemplate<T>,
         host: &T,
@@ -742,7 +742,7 @@ pub fn create_handler_for_cage<T: Clone>(
         active_calls: AtomicUsize::new(0),
     };
 
-    handler.init_ten_workers(template, &host, cageid)?;
+    handler.init_workers(template, &host, cageid)?;
 
     Ok(handler)
 }

--- a/src/wasmtime/crates/lind-3i/src/lib.rs
+++ b/src/wasmtime/crates/lind-3i/src/lib.rs
@@ -261,10 +261,11 @@ struct GrateWorker<T> {
 /// Each grate worker owns a dedicated stack slot inside the global stack arena.
 /// This function maps a logical `worker_id` to the first usable byte of that
 /// worker’s stack, skipping over the guard region placed before the slot.
-fn worker_stack_base(workerid: WorkerId) -> u32 {
-    let stack_arena_base = STACK_ARENA_BASE.get().copied().unwrap_or_else(|| {
-        panic!("STACK_ARENA_BASE is not initialized");
-    });
+fn worker_stack_base(cageid: u64, workerid: WorkerId) -> u32 {
+    let stack_arena_base = lind_platform_const::get_stack_arena_base(cageid as usize)
+        .unwrap_or_else(|| {
+            panic!("STACK_ARENA_BASE is not initialized for cageid {}", cageid);
+        });
     stack_arena_base
         + (workerid as u32 - 1) * (GRATE_STACK_GUARD_SIZE + GRATE_STACK_SLOT_SIZE)
         + GRATE_STACK_GUARD_SIZE
@@ -275,8 +276,8 @@ fn worker_stack_base(workerid: WorkerId) -> u32 {
 /// The returned address is used to reset the worker’s `__stack_pointer` before
 /// starting a new grate call, ensuring that each invocation begins with a clean
 /// stack state inside that worker’s private stack slot.
-fn worker_stack_top(workerid: WorkerId) -> u32 {
-    worker_stack_base(workerid) + GRATE_STACK_SLOT_SIZE
+fn worker_stack_top(cageid: u64, workerid: WorkerId) -> u32 {
+    worker_stack_base(cageid, workerid) + GRATE_STACK_SLOT_SIZE
 }
 
 /// Scoped ownership of a borrowed worker.
@@ -412,12 +413,13 @@ impl<T: Clone> GrateHandler<T> {
         cageid: u64,
     ) -> anyhow::Result<()> {
         for handler_id in 1_u64..=MAX_GRATE_WORKERS as u64 {
-            let worker = create_worker(template, host.clone(), handler_id).with_context(|| {
-                format!(
-                    "failed to create worker {} for cageid {}",
-                    handler_id, cageid
-                )
-            })?;
+            let worker =
+                create_worker(template, host.clone(), cageid, handler_id).with_context(|| {
+                    format!(
+                        "failed to create worker {} for cageid {}",
+                        handler_id, cageid
+                    )
+                })?;
 
             self.inner.lock().unwrap().workers.push_back(worker);
         }
@@ -664,6 +666,7 @@ impl<T> GrateWorker<T> {
 pub fn create_worker<T>(
     template: &GrateTemplate<T>,
     host: T,
+    cageid: u64,
     worker_id: WorkerId,
 ) -> anyhow::Result<GrateWorker<T>>
 where
@@ -697,8 +700,8 @@ where
         None => None,
     };
 
-    let stack_base = worker_stack_base(worker_id);
-    let stack_top = worker_stack_top(worker_id);
+    let stack_base = worker_stack_base(cageid, worker_id);
+    let stack_top = worker_stack_top(cageid, worker_id);
 
     Ok(GrateWorker {
         worker_id,

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -2,7 +2,7 @@
 
 use cfg_if::cfg_if;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::ffi::c_void;
 use std::ptr::NonNull;
 use sysdefs::constants::lind_platform_const::{UNUSED_ARG, UNUSED_ID, UNUSED_NAME};
@@ -11,10 +11,7 @@ use sysdefs::constants::{Errno, MAX_SHEBANG_DEPTH, MMAP_SYSCALL};
 use sysdefs::logging::lind_debug_panic;
 use sysdefs::{constants::sys_const, data::sys_struct};
 use threei::{threei::make_syscall, threei_const};
-use wasmtime_lind_3i::{
-    get_vmctx, get_vmctx_thread, rm_vmctx, rm_vmctx_thread, set_vmctx, set_vmctx_thread,
-    VmCtxWrapper,
-};
+use wasmtime_lind_3i::*;
 use wasmtime_lind_utils::{LindCageManager, LindGOT};
 
 use std::ffi::CStr;
@@ -505,7 +502,8 @@ impl<
                         store.set_is_thread(true);
                     }
 
-                    let (instance, grate_instanceid) = linker
+                    // don't use child's stack_arena_base since it is not initialized yet, use parent's stack_arena_base instead
+                    let (instance, _, grate_instanceid) = linker
                         .instantiate_with_lind(
                             &mut store,
                             &module,
@@ -635,12 +633,19 @@ impl<
 
                     // new cage created, increment the cage counter
                     lind_manager.increment();
-                    // The main challenge in enabling dynamic syscall interposition between grates and 3i lies in Rust’s
-                    // strict lifetime and ownership system, which makes retrieving the Wasmtime runtime context across
-                    // instance boundaries particularly difficult. To overcome this, the design employs low-level context
-                    // capture by extracting and storing vmctx pointers from Wasmtime’s internal `StoreOpaque` and `InstanceHandler`
-                    // structures. See more details in [lind-3i/src/lib.rs]
-                    // 1) Get StoreOpaque & InstanceHandler to extract vmctx pointer
+
+                    // 4) Notify threei of the cage runtime type
+                    threei::set_cage_runtime(child_cageid, threei_const::RUNTIME_TYPE_WASMTIME);
+
+                    barrier_clone.wait();
+
+                    // update the linker for the child instance, since new linker contains some child-specific defines
+                    let mut new_child_host = store.data_mut();
+                    let new_child_ctx = get_cx(&mut new_child_host);
+                    let cloned_linker = linker.clone();
+                    new_child_ctx.attach_linker(linker);
+                    new_child_ctx.attach_got_table(child_got);
+
                     let grate_storeopaque = store.inner_mut();
                     let grate_instancehandler = grate_storeopaque.instance(grate_instanceid);
                     let vmctx_ptr: *mut c_void = grate_instancehandler.vmctx().cast();
@@ -653,35 +658,23 @@ impl<
                     // 3) Store the vmctx wrapper in the global table for later retrieval during syscalls
                     let rc = set_vmctx_thread(child_cageid, THREAD_START_ID as u64, vmctx_wrapper);
 
-                    // 4) Notify threei of the cage runtime type
-                    threei::set_cage_runtime(child_cageid, threei_const::RUNTIME_TYPE_WASMTIME);
+                    let grate_template = GrateTemplate {
+                        engine: module.engine().clone(),
+                        module: module.clone(),
+                        linker: cloned_linker,
+                    };
 
-                    // 5) Create backup instances to populate the vmctx pool
-                    // See more comments in lind-3i/lib.rs
-                    for _ in 0..9 {
-                        let (_, backup_cage_instanceid) = linker
-                            .instantiate_with_lind_thread(&mut store, &module, false)
-                            .unwrap();
-                        let backup_cage_storeopaque = store.inner_mut();
-                        let backup_cage_instancehandler =
-                            backup_cage_storeopaque.instance(backup_cage_instanceid);
-                        let backup_vmctx_ptr: *mut c_void =
-                            backup_cage_instancehandler.vmctx().cast();
-
-                        let backup_vmctx_wrapper = VmCtxWrapper {
-                            vmctx: NonNull::new(backup_vmctx_ptr).unwrap(),
-                        };
-
-                        set_vmctx(child_cageid, backup_vmctx_wrapper);
-                    }
-
-                    barrier_clone.wait();
-
-                    // update the linker for the child instance, since new linker contains some child-specific defines
-                    let mut new_child_host = store.data_mut();
-                    let new_child_ctx = get_cx(&mut new_child_host);
-                    new_child_ctx.attach_linker(linker);
-                    new_child_ctx.attach_got_table(child_got);
+                    // register grate workers for this cage
+                    create_handler_for_cage(
+                        &grate_template,
+                        store.data().clone(),
+                        child_cageid,
+                        ConcurrencyMode::Parallel,
+                    )
+                    .with_context(|| {
+                        format!("failed to register grate workers for cage {}", child_cageid)
+                    })
+                    .expect("create_handler_for_cage failed");
 
                     // get the asyncify_rewind_start and module start function
                     let child_rewind_start;
@@ -745,7 +738,7 @@ impl<
                             threei::handler_table::_rm_grate_from_handler(child_cageid);
                             cage::signal::lind_thread_exit(child_cageid, THREAD_START_ID as u64);
                             cage::cage_finalize(child_cageid);
-                            if !rm_vmctx(child_cageid) {
+                            if !rm_vmctx_thread(child_cageid, 0) {
                                 eprintln!(
                                     "[wasmtime|fork-crash] Failed to remove VMContext for cage {}",
                                     child_cageid
@@ -976,17 +969,16 @@ impl<
                         None
                     };
 
-                    let (mut linker,
-                         memory_base_table,
-                         epoch_handler,
-                         _,
-                        ) = Linker::new_child_linker(&mut store,
-                                &engine,
-                                &mut child_got,
-                                &snapshot.0,
-                                &snapshot.1,
-                                &snapshot.2
-                        ).expect("failed to create child linker");
+                    let (mut linker, memory_base_table, epoch_handler, _) =
+                        Linker::new_child_linker(
+                            &mut store,
+                            &engine,
+                            &mut child_got,
+                            &snapshot.0,
+                            &snapshot.1,
+                            &snapshot.2,
+                        )
+                        .expect("failed to create child linker");
 
                     let child_table = if dylink_enabled {
                         let mut table_size = 0;
@@ -995,7 +987,9 @@ impl<
                                 table_size = table.minimum();
                             }
                         }
-                        let mut child_table = linker.attach_function_table(&mut store, table_size).unwrap();
+                        let mut child_table = linker
+                            .attach_function_table(&mut store, table_size)
+                            .unwrap();
 
                         linker.attach_asyncify(&mut store).unwrap();
 
@@ -1017,21 +1011,29 @@ impl<
                             // Grow the shared indirect function table by the amount requested by the
                             // library (as recorded in its dylink section). New slots are initialized
                             // to null funcref.
-                            child_table.grow(
-                                &mut store,
-                                dylink_info.table_size,
-                                wasmtime::Ref::Func(None),
-                            ).unwrap();
+                            child_table
+                                .grow(
+                                    &mut store,
+                                    dylink_info.table_size,
+                                    wasmtime::Ref::Func(None),
+                                )
+                                .unwrap();
 
-                            let module_name = module.name().unwrap_or_else(|| lind_debug_panic("module has no name"));
-                            let module_memory_base = *memory_base_table.get(module_name).expect("memory base not found for library");
+                            let module_name = module
+                                .name()
+                                .unwrap_or_else(|| lind_debug_panic("module has no name"));
+                            let module_memory_base = *memory_base_table
+                                .get(module_name)
+                                .expect("memory base not found for library");
 
                             linker.allow_shadowing(true);
                             // Link the library instance into the main linker namespace.
                             // The linker records the module under `name` and uses `table_start`
                             // to relocate/interpret the library's function references into the
                             // shared table. GOT entries are patched through the shared LindGOT.
-                            let module_name = module.name().unwrap_or_else(|| lind_debug_panic("module has no name"));
+                            let module_name = module
+                                .name()
+                                .unwrap_or_else(|| lind_debug_panic("module has no name"));
                             linker
                                 .module_with_child(
                                     &mut store,
@@ -1042,8 +1044,12 @@ impl<
                                     table_start,
                                     module_memory_base,
                                     ChildLibraryType::Thread(&mut stack_addr),
-                                    global_snapshots.get(module_name).map(Vec::as_slice).unwrap_or(&[]),
-                                ).unwrap();
+                                    global_snapshots
+                                        .get(module_name)
+                                        .map(Vec::as_slice)
+                                        .unwrap_or(&[]),
+                                )
+                                .unwrap();
                             linker.allow_shadowing(false);
                         }
 
@@ -1056,7 +1062,7 @@ impl<
                     store.set_is_thread(true);
 
                     // instantiate the module
-                    let (instance, grate_instanceid) = linker
+                    let (instance, _, grate_instanceid) = linker
                         .instantiate_with_lind_thread(&mut store, &module, false)
                         .unwrap();
 
@@ -1070,11 +1076,18 @@ impl<
                     //    Store/Instance, so globals must be explicitly synced from the parent's
                     //    snapshot. Snapshots are looked up by module name; backup instances are
                     //    never registered and are therefore naturally excluded.
-                    let main_module_name = module.name().unwrap_or_else(|| lind_debug_panic("module has no name"));
-                    store.as_context_mut().register_named_instance(main_module_name.to_string(), grate_instanceid);
+                    let main_module_name = module
+                        .name()
+                        .unwrap_or_else(|| lind_debug_panic("module has no name"));
+                    store
+                        .as_context_mut()
+                        .register_named_instance(main_module_name.to_string(), grate_instanceid);
                     instance.apply_global_snapshots(
                         &mut store,
-                        global_snapshots.get(main_module_name).map(Vec::as_slice).unwrap_or(&[]),
+                        global_snapshots
+                            .get(main_module_name)
+                            .map(Vec::as_slice)
+                            .unwrap_or(&[]),
                     );
 
                     if dylink_enabled {
@@ -1099,7 +1112,9 @@ impl<
                                 )
                                 .unwrap();
 
-                            let module_name = module.name().unwrap_or_else(|| lind_debug_panic("module has no name"));
+                            let module_name = module
+                                .name()
+                                .unwrap_or_else(|| lind_debug_panic("module has no name"));
                             let module_memory_base = *memory_base_table
                                 .get(module_name)
                                 .expect("memory base not found for library");
@@ -1115,25 +1130,31 @@ impl<
                                     table_start,
                                     module_memory_base,
                                     ChildLibraryType::Thread(&mut stack_addr),
-                                    global_snapshots.get(module_name).map(Vec::as_slice).unwrap_or(&[]),
+                                    global_snapshots
+                                        .get(module_name)
+                                        .map(Vec::as_slice)
+                                        .unwrap_or(&[]),
                                 )
                                 .unwrap();
                             linker.allow_shadowing(false);
                         }
                     }
 
-                    if let Ok(init_tls) = instance.get_typed_func::<i32, ()>(
-                        store.as_context_mut(),
-                        "__wasm_init_tls",
-                    ) {
-                        let get_tls_size = instance.get_typed_func::<(), i32>(
-                            store.as_context_mut(),
-                            "__get_aligned_tls_size",
-                        ).unwrap();
+                    if let Ok(init_tls) = instance
+                        .get_typed_func::<i32, ()>(store.as_context_mut(), "__wasm_init_tls")
+                    {
+                        let get_tls_size = instance
+                            .get_typed_func::<(), i32>(
+                                store.as_context_mut(),
+                                "__get_aligned_tls_size",
+                            )
+                            .unwrap();
 
                         let tls_size = get_tls_size.call(store.as_context_mut(), ()).unwrap();
                         stack_addr -= tls_size as u32;
-                        let _ = init_tls.call(store.as_context_mut(), stack_addr as i32).unwrap();
+                        let _ = init_tls
+                            .call(store.as_context_mut(), stack_addr as i32)
+                            .unwrap();
                     }
 
                     // we might also want to perserve the offset of current stack pointer to stack bottom
@@ -1250,12 +1271,8 @@ impl<
                         .expect("_start function does not have a return value");
                     match exit_code {
                         Val::I32(val) => {
-                            if !rm_vmctx_thread(child_cageid as u64, next_tid as u64) {
-                                panic!(
-                                    "[wasmtime|thread] Failed to remove existing VMContext for cage_id {}, tid {}",
-                                    child_cageid, next_tid
-                                );
-                            }
+                            // we don't check the status here, since might be removed by group exit
+                            rm_vmctx_thread(child_cageid as u64, next_tid as u64);
                         }
                         _ => {
                             eprintln!("unexpected _start function return type: {:?}", exit_code);
@@ -1392,7 +1409,7 @@ impl<
             // for exec, we do not need to do rewind after unwinding is done
             store.set_asyncify_state(AsyncifyState::Normal);
 
-            if !rm_vmctx(cloned_cageid as u64) {
+            if !rm_vmctx_thread(cloned_cageid as u64, 0) {
                 panic!(
                     "[wasmtime|run] Failed to remove existing VMContext for cage_id {}",
                     cloned_cageid
@@ -1481,8 +1498,8 @@ impl<
                 // records zombie/SIGCHLD, removes fdtable + cage.
                 cage::cage_finalize(deferred_cageid);
 
-                // Remove the VMContext pool (backup instances).
-                if !rm_vmctx(deferred_cageid) {
+                // Remove the VMContext pool
+                if !rm_vmctx_thread(deferred_cageid, 0) {
                     eprintln!(
                         "[wasmtime|exit] Failed to remove VMContext for cage_id {}",
                         deferred_cageid

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -634,7 +634,7 @@ impl<
                     // new cage created, increment the cage counter
                     lind_manager.increment();
 
-                    // 4) Notify threei of the cage runtime type
+                    // Notify threei of the cage runtime type
                     threei::set_cage_runtime(child_cageid, threei_const::RUNTIME_TYPE_WASMTIME);
 
                     barrier_clone.wait();

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -658,23 +658,27 @@ impl<
                     // 3) Store the vmctx wrapper in the global table for later retrieval during syscalls
                     let rc = set_vmctx_thread(child_cageid, THREAD_START_ID as u64, vmctx_wrapper);
 
-                    let grate_template = GrateTemplate {
-                        engine: module.engine().clone(),
-                        module: module.clone(),
-                        linker: cloned_linker,
-                    };
+                    // Grate calls only supports static linking for now, so we only register
+                    // grate workers when dylink is not enabled.
+                    if !dylink_enabled {
+                        let grate_template = GrateTemplate {
+                            engine: module.engine().clone(),
+                            module: module.clone(),
+                            linker: cloned_linker,
+                        };
 
-                    // register grate workers for this cage
-                    create_handler_for_cage(
-                        &grate_template,
-                        store.data().clone(),
-                        child_cageid,
-                        ConcurrencyMode::Parallel,
-                    )
-                    .with_context(|| {
-                        format!("failed to register grate workers for cage {}", child_cageid)
-                    })
-                    .expect("create_handler_for_cage failed");
+                        // register grate workers for this cage
+                        create_handler_for_cage(
+                            &grate_template,
+                            store.data().clone(),
+                            child_cageid,
+                            ConcurrencyMode::Parallel,
+                        )
+                        .with_context(|| {
+                            format!("failed to register grate workers for cage {}", child_cageid)
+                        })
+                        .expect("create_handler_for_cage failed");
+                    }
 
                     // get the asyncify_rewind_start and module start function
                     let child_rewind_start;

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -478,7 +478,13 @@ impl Instance {
                         * (lind_platform_const::GRATE_STACK_GUARD_SIZE as usize
                             + lind_platform_const::GRATE_STACK_SLOT_SIZE as usize);
 
-                    lind_platform_const::init_stack_arena_base(stack_arena_base);
+                    lind_platform_const::init_stack_arena_base(cageid as usize, stack_arena_base)
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "failed to initialize stack arena base for cageid {}: {}",
+                                cageid, e
+                            )
+                        });
 
                     (
                         0,
@@ -532,6 +538,18 @@ impl Instance {
                 let child_address = memory.data_ptr(&mut *store) as usize;
 
                 fork_vmmap(parent_cageid as u64, child_cageid);
+
+                // For child instances, the stack arena is inherited from the parent cage, and grate calls
+                // only works at static build, so we only need to fork the stack arena base if dylink is not enabled.
+                if !dylink_enabled {
+                    lind_platform_const::fork_stack_arena_base_for_child(parent_cageid as usize, child_cageid as usize)
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "failed to fork stack arena base from parent cageid {} to child cageid {}: {}",
+                                parent_cageid, child_cageid, e
+                            )
+                        });
+                }
             }
             InstantiateType::InstantiateLib {
                 cageid,

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -290,25 +290,58 @@ impl Instance {
         Ok((instance, 0, instanceid))
     }
 
-    /// This is a lind-wasm extension of Wasmtime’s internal instance creation path.
-    /// Unlike the upstream `new_started_impl`, this function performs lind-specific linear-memory
-    /// initialization so that new cages have the correct RawPOSIX / microvisor-managed memory
-    /// semantics. In lind-wasm, memory setup must happen inside the microvisor layer, so we
-    /// intentionally bypass/override Wasmtime’s default memory initialization behavior and
-    /// initialize the cage’s memory state ourselves.
+    /// This is a lind-wasm extension of Wasmtime’s internal instance-creation path.
     ///
-    /// This function returns `(Instance, InstanceId)` (instead of only `Instance`) because lind-wasm
-    /// needs the `InstanceId` later to recover the corresponding `VMContext` pointer and re-enter the
-    /// correct runtime state during cross-cage / cross-grate transitions. See more details in [lind-3i/src/lib.rs]
+    /// Unlike upstream `new_started_impl`, this function performs lind-specific
+    /// linear-memory initialization so that newly created cages obey RawPOSIX /
+    /// microvisor-managed memory semantics. In lind-wasm, linear memory must be
+    /// established inside the microvisor layer rather than through Wasmtime’s
+    /// default memory-initialization path, so the upstream behavior is
+    /// intentionally bypassed and replaced with lind-specific setup logic.
     ///
-    /// The concrete initialization steps depend on `InstantiateType`:
-    /// `InstantiateFirst(cageid)`: creates the first cage’s linear memory, records the memory base address,
-    /// initializes vmmap, and performs a RawPOSIX-backed mmap to establish the initial memory region.
-    /// `InstantiateChild { parent_cageid, child_cageid }`: corresponds to fork semantics. After initializing
-    /// the child’s vmmap using the child’s memory base address, we clone the parent’s memory mappings/state
-    /// into the child (`fork_vmmap`) so that the child starts with an identical address space. After
-    /// lind-specific memory setup is complete, this function runs the module’s start function (if present)
-    /// and returns both the created `instance` and its `InstanceId`.
+    /// This function returns `(Instance, stack_arena_base, InstanceId)` rather than
+    /// only `Instance`.
+    ///
+    /// - `InstanceId` is needed later to recover the corresponding `VMContext` and
+    ///   re-enter the correct runtime state during continuation-sensitive or
+    ///   cross-cage / cross-grate execution transfers. See `lind-3i/src/lib.rs`
+    ///   for more details.
+    /// - `stack_arena_base` records the base of the grate-worker stack arena
+    ///   reserved inside linear memory for this instance.
+    ///
+    /// The concrete initialization steps depend on `InstantiateType`.
+    ///
+    /// - `InstantiateFirst(cageid)` creates the first cage’s linear memory state.
+    ///   In this case, the function:
+    ///   1. discovers the instance’s linear-memory base address,
+    ///   2. computes and records the stack-arena base,
+    ///   3. reserves space for per-worker grate stacks inside linear memory, and
+    ///   4. initializes vmmap and establishes the initial memory region via the
+    ///      underlying RawPOSIX `mmap`.
+    ///
+    ///   The stack-arena setup is required because multiple Wasmtime stores may be
+    ///   attached to the same underlying linear memory. As a result, different
+    ///   grate workers cannot share one stack region. Instead, lind-wasm reserves
+    ///   a stack arena and later partitions it into per-worker stack slots, so
+    ///   each worker executes with its own independent Wasm stack range even
+    ///   though workers share the same linear-memory object.
+    ///
+    /// - `InstantiateChild { parent_cageid, child_cageid }` corresponds to fork
+    ///   semantics. After discovering the child instance’s memory base, lind-wasm
+    ///   clones the parent’s memory mappings / state into the child via
+    ///   `fork_vmmap`, so the child begins with the same address-space contents as
+    ///   the parent.
+    ///
+    /// - `InstantiateLib { cageid, memory_base }` initializes memory for a
+    ///   dynamically loaded library instance by allocating its linear-memory region
+    ///   through RawPOSIX and publishing the resolved base address through
+    ///   `memory_base`.
+    ///
+    /// After lind-specific memory setup is complete, the function creates the raw
+    /// instance, runs the module start function when required, performs dylink
+    /// relocation / constructor steps when applicable, and returns the created
+    /// `Instance`, the computed `stack_arena_base`, and the associated
+    /// `InstanceId`.
     pub(crate) unsafe fn new_started_impl_with_lind<T>(
         store: &mut StoreContextMut<'_, T>,
         module: &Module,
@@ -378,6 +411,67 @@ impl Instance {
 
                     let minimal_size = minimal_pages << PAGESHIFT;
 
+                    // For statically linked main modules, we reserve a dedicated "grate stack arena"
+                    // at the end of the module's initially required memory region.
+                    //
+                    // Layout in linear memory:
+                    //
+                    //   0
+                    //   |
+                    //   |<---------------- minimal_size ---------------->|
+                    //   |                                                |
+                    //   +------------------------------------------------+
+                    //   |   module memory required by the main module    |
+                    //   |   (static data / heap-visible initial region)  |
+                    //   +------------------------------------------------+  <- stack_arena_base
+                    //   | guard | worker 1 stack slot | guard | worker 2 stack slot | ...
+                    //   +-------------------------------------------------------------
+                    //   | ... repeated for all grate workers ...
+                    //   +-------------------------------------------------------------
+                    //   | guard | worker N stack slot |
+                    //   +-------------------------------------------------------------
+                    //
+                    // where
+                    //
+                    //   `N = MAX_GRATE_WORKERS`
+                    //
+                    // and each worker consumes exactly:
+                    //
+                    //   `GRATE_STACK_GUARD_SIZE + GRATE_STACK_SLOT_SIZE`
+                    //
+                    // bytes inside the arena.
+                    //
+                    // Therefore, the total reserved arena size is:
+                    //
+                    //   `stack_arena_size = MAX_GRATE_WORKERS *
+                    //       (GRATE_STACK_GUARD_SIZE + GRATE_STACK_SLOT_SIZE)`
+                    //
+                    // The arena begins at `stack_arena_base`, which is chosen by rounding the
+                    // module's minimal required memory size upward to a host page boundary.
+                    // This guarantees that the worker-stack region starts at a page-aligned
+                    // location after the module's initial memory footprint.
+                    //
+                    // Why can `stack_arena_size` be globally constant?
+                    //
+                    // Because grate workers are created from one fixed runtime configuration:
+                    // every grate instance uses the same
+                    //
+                    //   - MAX_GRATE_WORKERS
+                    //   - GRATE_STACK_GUARD_SIZE
+                    //   - GRATE_STACK_SLOT_SIZE
+                    //
+                    // constants.
+                    //
+                    // In other words, the worker-pool width and the per-worker stack layout are
+                    // not instance-specific; they are part of the global lind-wasm platform
+                    // configuration. As a result, every grate-enabled instance reserves the same
+                    // total amount of stack-arena space, and worker `i` always maps to the same
+                    // slot formula relative to `stack_arena_base`.
+                    //
+                    // This uniform layout is especially important because multiple Wasmtime stores
+                    // may attach to the same underlying linear memory. Since workers do not get
+                    // separate linear memories, they must instead be isolated by assigning each
+                    // one a disjoint stack slot inside this shared arena.
                     stack_arena_base = round_up_size(minimal_size as u32, PAGESIZE) as u32;
 
                     let stack_arena_size = lind_platform_const::MAX_GRATE_WORKERS as usize

--- a/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/instance.rs
@@ -278,7 +278,7 @@ impl Instance {
         module: &Module,
         imports: Imports<'_>,
         no_start: bool,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         let (instance, start, instanceid) = Instance::new_raw(store.0, module, imports)?;
 
         if !no_start {
@@ -287,7 +287,7 @@ impl Instance {
             }
         }
 
-        Ok((instance, instanceid))
+        Ok((instance, 0, instanceid))
     }
 
     /// This is a lind-wasm extension of Wasmtime’s internal instance creation path.
@@ -314,8 +314,9 @@ impl Instance {
         module: &Module,
         imports: Imports<'_>,
         instantiate_type: InstantiateType,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         let dylink_enabled = module.dylink_meminfo().is_some();
+        let mut stack_arena_base = 0;
 
         // initialize the memory
         // the memory initialization should happen inside microvisor, so we should discard the original
@@ -377,9 +378,17 @@ impl Instance {
 
                     let minimal_size = minimal_pages << PAGESHIFT;
 
+                    stack_arena_base = round_up_size(minimal_size as u32, PAGESIZE) as u32;
+
+                    let stack_arena_size = lind_platform_const::MAX_GRATE_WORKERS as usize
+                        * (lind_platform_const::GRATE_STACK_GUARD_SIZE as usize
+                            + lind_platform_const::GRATE_STACK_SLOT_SIZE as usize);
+
+                    lind_platform_const::init_stack_arena_base(stack_arena_base);
+
                     (
                         0,
-                        minimal_size
+                        (stack_arena_base as usize + stack_arena_size)
                             .try_into()
                             .expect("allocated memory is larger than 4GB"),
                     )
@@ -526,7 +535,7 @@ impl Instance {
             }
         }
 
-        Ok((instance, instanceid))
+        Ok((instance, stack_arena_base, instanceid))
     }
 
     /// Internal function to create an instance and run the start function.
@@ -1411,7 +1420,7 @@ impl<T> InstancePre<T> {
         &self,
         mut store: impl AsContextMut<Data = T>,
         no_start: bool,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         let mut store = store.as_context_mut();
         let imports = pre_instantiate_raw(
             &mut store.0,
@@ -1438,7 +1447,7 @@ impl<T> InstancePre<T> {
         &self,
         mut store: impl AsContextMut<Data = T>,
         instantiate_type: InstantiateType,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         let mut store = store.as_context_mut();
         let imports = pre_instantiate_raw(
             &mut store.0,

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -1233,7 +1233,7 @@ impl<T> Linker<T> {
 
                 // Instantiate the library module. `InstantiateLib(handler)` tells the Lind instantiation
                 // path where to patch the `__memory_base` placeholder once the shared-memory base is known.
-                let (instance, instance_id) = module_linker.instantiate_with_lind(
+                let (instance, _, instance_id) = module_linker.instantiate_with_lind(
                     &mut store,
                     &module,
                     InstantiateType::InstantiateLib {
@@ -1333,7 +1333,7 @@ impl<T> Linker<T> {
                 module_linker.define_unknown_imports_as_traps(module);
                 // Instantiate the library module. Do not need to do any initialization for the module
                 // since all the state are already copied from parent
-                let (instance, instance_id) =
+                let (instance, _stack_arena_size, instance_id) =
                     module_linker.instantiate_with_lind_thread(&mut store, &module, true)?;
 
                 if let Some(wasm_name) = module.name() {
@@ -1441,14 +1441,15 @@ impl<T> Linker<T> {
 
                 // Instantiate the library module. `InstantiateLib(handler)` tells the Lind instantiation
                 // path where to patch the `__memory_base` placeholder once the shared-memory base is known.
-                let (instance, instance_id) = module_linker.instantiate_with_lind(
-                    &mut store,
-                    &module,
-                    InstantiateType::InstantiateLib {
-                        cageid,
-                        memory_base: handler,
-                    },
-                )?;
+                let (instance, _stack_arena_size, instance_id) = module_linker
+                    .instantiate_with_lind(
+                        &mut store,
+                        &module,
+                        InstantiateType::InstantiateLib {
+                            cageid,
+                            memory_base: handler,
+                        },
+                    )?;
 
                 if let Some(wasm_name) = module.name() {
                     store
@@ -1856,7 +1857,7 @@ impl<T> Linker<T> {
         mut store: impl AsContextMut<Data = T>,
         module: &Module,
         no_start: bool,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         self._instantiate_pre(module, Some(store.as_context_mut().0))?
             .instantiate_with_lind_thread(store, no_start)
     }
@@ -1882,7 +1883,7 @@ impl<T> Linker<T> {
         mut store: impl AsContextMut<Data = T>,
         module: &Module,
         instantiate_type: InstantiateType,
-    ) -> Result<(Instance, InstanceId)> {
+    ) -> Result<(Instance, u32, InstanceId)> {
         self._instantiate_pre(module, Some(store.as_context_mut().0))?
             .instantiate_with_lind(store, instantiate_type)
     }


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
## Summary

Resolves #961 

This PR implements the grate-call execution model based on reusable workers.

A grate call is no longer treated as entering one shared grate instance. Instead,
each call is executed by leasing an independent worker from a per-grate handler
pool, where each worker owns its own:

- Wasmtime `Store`
- instantiated grate `Instance`
- dedicated Wasm stack slot

This PR also introduces the global grate-handler registry used to resolve the
target handler for a grate id at runtime, and documents how the stack arena is
reserved and partitioned when multiple stores attach to the same underlying
linear memory.

Grate calls are not continuation-sensitive in the same way as `fork` / `exit`.
They do not need to resume inside the exact same Wasmtime continuation context.
Instead, they only need a compatible grate execution context.

This PR makes that model explicit by representing grate execution as a pool of
independent workers. That enables concurrency while still keeping stack state
isolated even when multiple stores attach to the same linear memory.

## Main changes

### 1. Add `GrateHandler` / `GrateWorker` execution model
- introduce worker-based grate execution
- support `Parallel` and `Serialized` concurrency modes
- add worker leasing / return logic
- track in-flight calls and shutdown state

### 2. Add global grate-handler registry in `lind-boot`
- initialize a process-wide table of `GrateHandler<HostCtx>`
- register / look up / submit / unregister / clean up grate handlers by cage/grate id
- keep this registry in `lind-boot` because the handler type is tied to the concrete `HostCtx`

### 3. Reserve and document grate stack arena layout
- reserve stack arena space in linear memory during lind-specific instance initialization
- define per-worker stack-slot layout using:
  - `MAX_GRATE_WORKERS`
  - `GRATE_STACK_SLOT_SIZE`
  - `GRATE_STACK_GUARD_SIZE`
- record `STACK_ARENA_BASE` globally for later worker stack-slot computation
- place `STACK_ARENA_BASE` in `sysdefs` to avoid circular dependencies between
  Wasmtime, `lind-3i`, and `lind-multi-process`

## Notes

- worker stacks are isolated by disjoint stack slots inside a shared stack arena
- the global handler registry is intentionally outside `lind-3i` because the
  stored handler type depends on `HostCtx`

## Tests

**Passed simple grate call tests.** 

**Passed grates testing:**

1. IPC grates 
2. fdtables grates 
3. strace grates
4. mtls grates
5. net-namespacing