### PR TITLE
add --output-dir option to lind_compile and cargo lind_compile

### DIFF
--- a/scripts/cargo-lind_compile
+++ b/scripts/cargo-lind_compile
@@ -3,16 +3,27 @@ set -e
 
 shift
 
-# Determine profile from arguments
+# Determine profile and output dir from arguments
 PROFILE="debug"
 CARGO_ARGS=("--target" "wasm32-wasip1")
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-target}"
+LIND_TARGET_DIR=""
 
-for arg in "$@"; do
-    if [ "$arg" = "--release" ] || [ "$arg" = "-r" ]; then
-        PROFILE="release"
-    fi
-    CARGO_ARGS+=("$arg")
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --release|-r)
+            PROFILE="release"
+            CARGO_ARGS+=("$1")
+            ;;
+        --output-dir)
+            shift
+            LIND_TARGET_DIR="$1"
+            ;;
+        *)
+            CARGO_ARGS+=("$1")
+            ;;
+    esac
+    shift
 done
 
 # Set linker (allow override via environment variable)
@@ -40,9 +51,14 @@ echo "Building with profile: $PROFILE"
 cargo +nightly-2026-02-11 build -Z build-std=std,panic_abort "${CARGO_ARGS[@]}"
 
 echo "-------------------------------"
+LIND_TARGET_ARGS=()
+if [ -n "$LIND_TARGET_DIR" ]; then
+    LIND_TARGET_ARGS=("--output-dir" "$LIND_TARGET_DIR")
+fi
+
 for f in $(find "$CARGO_TARGET_DIR/wasm32-wasip1/$PROFILE" -name "*.wasm" ! -path "*deps*" 2>/dev/null | sort -r); do
         # Find the wasm files in the appropriate profile directory
         lind_compile -s --opt-only "$f" &> /dev/null || true
         # Precompile the optimized wasm file to cache it to LindFS
-        lind_compile --precompile-only "$f" &> /dev/null || true
+        lind_compile "${LIND_TARGET_ARGS[@]}" --precompile-only "$f" &> /dev/null || true
 done

--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -66,6 +66,7 @@ usage: $(basename "$0") [OPTIONS] <source> [-- <clang args>]
     $(basename "$0") --fpcast-emu hello.c
     $(basename "$0") --opt-only build/hello.wasm
     $(basename "$0") --precompile-only build/hello.wasm
+    $(basename "$0") --output-dir tmp hello.c                # copy output to lindfs/tmp/
     $(basename "$0") --print-cmd hello.c
     $(basename "$0") --no-default-clang-flags hello.c -- -target=wasm32-unknown-wasi
     $(basename "$0") hello.c -- -lm
@@ -81,6 +82,7 @@ PRINT_ARGS="false"
 NO_DEFAULT_CLANG_FLAGS="false"
 COMPILE_GRATE="false"
 COMPILE_LIBRARY="false"
+TARGET_DIR=""
 ORIGINAL_ARGS=("$@")
 
 set_mode() {
@@ -135,6 +137,10 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     --compile-grate)
       COMPILE_GRATE="true"
+      ;;
+    --output-dir)
+      shift
+      TARGET_DIR="$1"
       ;;
     -h|--help)
       usage
@@ -258,6 +264,9 @@ CLANG_BIN="clang"  # must be on PATH
 WASM_OPT_BIN="${REPO_ROOT}/tools/binaryen/bin/wasm-opt"
 LINDBOOT_BIN="${REPO_ROOT}/build/lind-boot"
 LINDFS_ROOT="${REPO_ROOT}/lindfs/"
+if [[ -n "${TARGET_DIR}" ]]; then
+  LINDFS_ROOT="${REPO_ROOT}/lindfs/${TARGET_DIR}/"
+fi
 if [[ ! -x "${LINDBOOT_BIN}" ]]; then
   echo "ERROR: lind-boot missing: ${LINDBOOT_BIN}" >&2
   exit 127 # Note: This is the traditional "command not found" exit code, can be changed as needed


### PR DESCRIPTION
Allows specifying a subdirectory within lindfs to copy the compiled output to. For example, --output-dir tmp copies to lindfs/tmp/. Default behavior (copying to lindfs root) is unchanged.

