### PR TITLE
fix typo in --preload env in lind_run

### DIFF
--- a/scripts/lind_run
+++ b/scripts/lind_run
@@ -43,4 +43,4 @@ if [[ $EUID -ne 0 ]]; then
   exec sudo -E "$0" "$@"
 fi
 
-exec "${LINDBOOT_BIN}" --preload env=/lib/libc.cwasm --preload env=lib/libm.cwasm "$@"
+exec "${LINDBOOT_BIN}" --preload env=/lib/libc.cwasm --preload env=/lib/libm.cwasm "$@"


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Purpose
**Correct**
`--preload env=/lib/libc.cwasm`
**Incorrect**
`--preload env=lib/libm.cwasm `                                                                                                                                                                                
 
Impact: libm.cwasm fails to load with relative path inside chroot.