### PR TITLE
fix lind fd limit

### DIFF
--- a/src/rawposix/src/init.rs
+++ b/src/rawposix/src/init.rs
@@ -220,6 +220,25 @@ pub fn rawposix_start(verbosity: isize) {
         libc::sigaction(libc::SIGUSR2, &sa, std::ptr::null_mut());
     }
 
+    // Raise the host process soft fd limit to the hard maximum. Lind supports up to 1024 cages
+    // each with up to 1024 fds, so the default soft limit (typically 1024) is too low.
+    unsafe {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
+            panic!("getrlimit failed: {}", std::io::Error::last_os_error());
+        }
+
+        lim.rlim_cur = lim.rlim_max; // raise soft to hard
+
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &lim) != 0 {
+            panic!("setrlimit failed: {}", std::io::Error::last_os_error());
+        }
+    }
+
     // init cage table
     cagetable_init();
 

--- a/src/rawposix/src/init.rs
+++ b/src/rawposix/src/init.rs
@@ -180,6 +180,27 @@ pub fn register_threei_syscall(self_cageid: u64) -> i32 {
     0
 }
 
+/// Raise the host process soft fd limit to the hard maximum. Lind supports up to 1024 cages
+/// each with up to 1024 fds, so the default soft limit (typically 1024) is too low.
+fn init_fd_limit() {
+    unsafe {
+        let mut lim = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+
+        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
+            panic!("getrlimit failed: {}", std::io::Error::last_os_error());
+        }
+
+        lim.rlim_cur = lim.rlim_max; // raise soft to hard
+
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &lim) != 0 {
+            panic!("setrlimit failed: {}", std::io::Error::last_os_error());
+        }
+    }
+}
+
 /// No-op signal handler for SIGUSR2. Its sole purpose is to interrupt
 /// blocking host syscalls (causing EINTR) so threads can re-enter wasm
 /// and notice they've been killed via epoch_kill_all.
@@ -220,24 +241,7 @@ pub fn rawposix_start(verbosity: isize) {
         libc::sigaction(libc::SIGUSR2, &sa, std::ptr::null_mut());
     }
 
-    // Raise the host process soft fd limit to the hard maximum. Lind supports up to 1024 cages
-    // each with up to 1024 fds, so the default soft limit (typically 1024) is too low.
-    unsafe {
-        let mut lim = libc::rlimit {
-            rlim_cur: 0,
-            rlim_max: 0,
-        };
-
-        if libc::getrlimit(libc::RLIMIT_NOFILE, &mut lim) != 0 {
-            panic!("getrlimit failed: {}", std::io::Error::last_os_error());
-        }
-
-        lim.rlim_cur = lim.rlim_max; // raise soft to hard
-
-        if libc::setrlimit(libc::RLIMIT_NOFILE, &lim) != 0 {
-            panic!("setrlimit failed: {}", std::io::Error::last_os_error());
-        }
-    }
+    init_fd_limit();
 
     // init cage table
     cagetable_init();


### PR DESCRIPTION
lind host process fd limit is by default 1024 (note this is lind host process system fd limit, not per-cage fd limit). This causes all the running cage can only have a sum of 1024 file descriptors together.