### PR TITLE
handle error in epoll_wait_syscall()

### DIFF
--- a/src/rawposix/src/net_calls.rs
+++ b/src/rawposix/src/net_calls.rs
@@ -948,10 +948,23 @@ pub extern "C" fn epoll_wait_syscall(
 
     // Get the underfd of type FDKIND_KERNEL to the vitual fd
     // Details see documentation on fdtables/epoll_get_underfd_hashmap.md
-    let epfd = *fdtables::epoll_get_underfd_hashmap(cageid, epfd_arg)
-        .unwrap()
-        .get(&FDKIND_KERNEL)
-        .unwrap();
+    let fd_map = match fdtables::epoll_get_underfd_hashmap(cageid, epfd_arg) {
+        Ok(map) => map,
+        Err(_) => {
+            return syscall_error(Errno::EBADF, "epoll_wait_syscall", "invalid epoll fd");
+        }
+    };
+
+    let epfd = match fd_map.get(&FDKIND_KERNEL) {
+        Some(fd) => *fd,
+        None => {
+            return syscall_error(
+                Errno::EBADF,
+                "epoll_wait_syscall",
+                "missing kernel epoll fd",
+            );
+        }
+    };
 
     // Convert arguments
     let maxevents = sc_convert_sysarg_to_i32(maxevents_arg, maxevents_cageid, cageid);
@@ -1030,13 +1043,24 @@ pub extern "C" fn epoll_wait_syscall(
         // Loop over virtual epollfd to find corresponding mapping relationship between kernel fd and virtual fd
         for i in 0..ret as usize {
             let ret_kernelfd = kernel_events[i].u64;
-            let epollmapping = REAL_EPOLL_MAP.lock();
-            let ret_virtualfd = epollmapping
-                .get(&(epfd))
-                .and_then(|kernel_map| kernel_map.get(&(ret_kernelfd as i32)).copied());
 
-            // Write back to user's buffer: store virtual fd in the u64 data field
-            events[i].u64 = ret_virtualfd.unwrap() as u64;
+            let epollmapping = REAL_EPOLL_MAP.lock();
+
+            let ret_virtualfd = match epollmapping
+                .get(&epfd)
+                .and_then(|kernel_map| kernel_map.get(&(ret_kernelfd as i32)).copied())
+            {
+                Some(vfd) => vfd,
+                None => {
+                    return syscall_error(
+                        Errno::EBADF,
+                        "epoll",
+                        "could not translate kernel fd to virtual fd",
+                    );
+                }
+            };
+
+            events[i].u64 = ret_virtualfd as u64;
             events[i].events = kernel_events[i].events;
         }
         return ret;

--- a/tests/unit-tests/networking_tests/deterministic/epoll_badfd.c
+++ b/tests/unit-tests/networking_tests/deterministic/epoll_badfd.c
@@ -1,0 +1,22 @@
+#include <sys/epoll.h>
+#include <unistd.h>
+#include <errno.h>
+#include <assert.h>
+
+int main(void) {
+    struct epoll_event events[4];
+
+    /* create epoll instance */
+    int epfd = epoll_create1(0);
+    assert(epfd != -1);
+
+    /* close it so fd becomes invalid */
+    assert(close(epfd) == 0);
+
+    /* epoll_wait on closed fd must fail with EBADF */
+    int ret = epoll_wait(epfd, events, 4, 1000);
+    assert(ret == -1);
+    assert(errno == EBADF);
+
+    return 0;
+}


### PR DESCRIPTION
- replaces unsafe `unwrap()` with error handeling based on Result<>
- returns appropriate error code

This PR resolves the issue causing failure of `test_epoll` test in `cpython` app.

<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
