### PR TITLE
create /dev/urandom and /dev/random and add ./resource/Versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ lindfs:
 		mkdir -p $(LINDFS_ROOT)/$$d; \
 	done
 	touch $(LINDFS_ROOT)/dev/null
+	@if [ -c /dev/urandom ]; then \
+		cp -a /dev/urandom $(LINDFS_ROOT)/dev/; \
+		cp -a /dev/random $(LINDFS_ROOT)/dev/; \
+	fi
 	cp -rT scripts/lindfs-conf/etc $(LINDFS_ROOT)/etc
 	cp -rT scripts/lindfs-conf/usr/lib/locale $(LINDFS_ROOT)/usr/lib/locale
 	cp -rT scripts/lindfs-conf/usr/share/zoneinfo $(LINDFS_ROOT)/usr/share/zoneinfo

--- a/scripts/version-path-minimal.txt
+++ b/scripts/version-path-minimal.txt
@@ -27,3 +27,4 @@
 ./intl/Versions
 ./iconv/Versions
 ./wctype/Versions
+./resource/Versions


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Purpose
During building PostgreSQL, we found that `/dev/random` was missing from lindfs to generate secret authorization token
and env::getrusage has not been defined.

To fix that:

1. Makefile: Copies /dev/urandom and /dev/random during make lindfs                                                                                 
2. version-path-minimal.txt: Adds ./resource/Versions for getrusage export