### PR TITLE
Propagate interposed clone return value across Asyncify rewind

### DIFF
--- a/src/lind-boot/src/lind_wasmtime/host.rs
+++ b/src/lind-boot/src/lind_wasmtime/host.rs
@@ -37,6 +37,10 @@ impl LindHost<HostCtx, CliOptions> for HostCtx {
     fn get_ctx(&self) -> LindCtx<HostCtx, CliOptions> {
         self.lind_fork_ctx.clone().unwrap()
     }
+
+    fn get_ctx_mut(&mut self) -> &mut LindCtx<HostCtx, CliOptions> {
+        self.lind_fork_ctx.as_mut().unwrap()
+    }
 }
 
 pub struct DylinkMetadata {

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -129,6 +129,20 @@ fn add_syscall_to_linker<
             // check here to early-return when we are on a rewind replay path.
             if call_number as i32 == CLONE_SYSCALL {
                 if let Some(rewind_res) = wasmtime_lind_multi_process::catch_rewind(&mut caller) {
+                    if rewind_res > 0 {
+                        // On Asyncify rewind replay, `clone` must not be executed again.
+                        // The positive rewind result is the real child cage id returned to the
+                        // parent guest by default. If a grate supplied a pending visible return
+                        // value during the first normal execution, consume it here and return it
+                        // instead. The child-side rewind result is 0 and must not be overridden.
+                        if let Some(retval) = wasmtime_lind_multi_process::take_pending_clone_visible_retval(&mut caller) {
+                            // Only override the return value with the pending visible retval if it is actually set.
+                            // If it's not set, that means the clone syscall being replayed on rewind is the one in the child process, and we should return the actual syscall return value (0) instead of the pending visible retval from the parent process.
+                            if retval > 0 {
+                                return retval;
+                            }
+                        }
+                    }
                     return rewind_res;
                 }
             }
@@ -189,6 +203,17 @@ fn add_syscall_to_linker<
                 arg6,
                 arg6cageid,
             );
+
+            if call_number as i32 == CLONE_SYSCALL {
+                // Save the grate-defined return value produced by the normal clone execution. 
+                // The guest-visible parent return is produced later during Asyncify rewind 
+                // replay, so this value must be carried across that boundary.
+                wasmtime_lind_multi_process::set_pending_clone_visible_retval(&mut caller, retval).unwrap_or_else(|e| {
+                    panic!("{}", format!(
+                        "failed to set pending_clone_visible_retval for retval={retval} with error: {e}"
+                    ));
+                });
+            }
 
             // If the syscall was interrupted by a signal (EINTR), invoke the signal handler.
             // If fork is called within the signal handler, asyncify will unwind the stack;

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -54,6 +54,7 @@ const UNWIND_METADATA_SIZE: u64 = 16;
 // Define the trait with the required method
 pub trait LindHost<T, U> {
     fn get_ctx(&self) -> LindCtx<T, U>;
+    fn get_ctx_mut(&mut self) -> &mut LindCtx<T, U>;
 }
 
 // Closures are abused in this file, mainly because the architecture of wasmtime itself does not support
@@ -86,6 +87,30 @@ pub struct LindCtx<T, U> {
 
     // from lind-boot, used for exec call
     lindboot_cli: U,
+
+    // Optional parent-visible return value for a pending `clone`/`fork`.
+    //
+    // `fork` is special in the Lind/Wasmtime runtime because the guest-visible
+    // return value is not necessarily the immediate return value of the first
+    // hostcall. The logical fork operation is split by Asyncify:
+    //
+    // 1. the first normal `clone` hostcall performs the real fork setup and may
+    //    return through an interposed grate;
+    // 2. Wasmtime unwinds and later rewinds the guest stack;
+    // 3. the guest's actual `fork()` call site receives the value returned during
+    //    the rewind replay.
+    //
+    // This field is used to carry a grate-defined "visible" fork return value
+    // from the normal hostcall path to the later parent-side rewind replay path.
+    // The real child cage id is still used internally for RawPOSIX/Wasmtime
+    // bookkeeping; this value only affects what the parent guest observes as the
+    // return value of `fork()`.
+    //
+    // This must be shared state rather than a plain `Option<i32>` because the
+    // host/Lind context can be cloned during fork/rewind setup. Using an
+    // `Arc<Mutex<_>>` ensures that the normal path and the rewind replay path
+    // observe the same pending slot.
+    pending_clone_visible_retval: Arc<Mutex<Option<i32>>>,
 
     // host thread stack size for spawned cage/thread processes
     pub thread_stack_size: usize,
@@ -172,6 +197,7 @@ impl<
             next_threadid,
             lind_manager: lind_manager.clone(),
             lindboot_cli,
+            pending_clone_visible_retval: Arc::new(Mutex::new(None)),
             thread_stack_size,
             get_cx,
             fork_host,
@@ -1763,6 +1789,7 @@ impl<
             next_threadid: Arc::new(AtomicU32::new(1)), // thread id starts from 1
             lind_manager: self.lind_manager.clone(),
             lindboot_cli: self.lindboot_cli.clone(),
+            pending_clone_visible_retval: self.pending_clone_visible_retval.clone(),
             thread_stack_size: self.thread_stack_size,
             get_cx: self.get_cx.clone(),
             fork_host: self.fork_host.clone(),
@@ -1784,6 +1811,7 @@ impl<
             next_threadid: self.next_threadid.clone(),
             lind_manager: self.lind_manager.clone(),
             lindboot_cli: self.lindboot_cli.clone(),
+            pending_clone_visible_retval: self.pending_clone_visible_retval.clone(),
             thread_stack_size: self.thread_stack_size,
             get_cx: self.get_cx.clone(),
             fork_host: self.fork_host.clone(),
@@ -2342,4 +2370,63 @@ fn has_correct_signature(module: &Module) -> bool {
     }
 
     true
+}
+
+/// Stores a pending parent-visible return value for the current logical
+/// `clone`/`fork`.
+///
+/// This should be called on the first, non-rewind execution path after the
+/// syscall/interposition layer has produced the value that should be exposed
+/// to the parent guest. For example, a grate may perform the real fork but
+/// return a spoofed value that should later be returned from the guest's
+/// `fork()` call site.
+///
+/// The value is not returned to the guest immediately here. Instead, it is
+/// saved until the parent-side Asyncify rewind replay reaches the same
+/// `make-syscall` import again. At that point, `take_pending_clone_visible_retval`
+/// consumes this value and uses it to override the positive real child cage id.
+///
+/// The slot is protected by a mutex and stored behind an `Arc` so that it
+/// survives `HostCtx`/`LindCtx` cloning across fork setup.
+pub fn set_pending_clone_visible_retval<
+    T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync,
+    U: Clone + Send + 'static + std::marker::Sync,
+>(
+    caller: &mut Caller<'_, T>,
+    retval: i32,
+) -> Result<()> {
+    let ctx = caller.data_mut().get_ctx_mut();
+
+    let mut slot = ctx.pending_clone_visible_retval.lock().unwrap();
+
+    *slot = Some(retval);
+
+    Ok(())
+}
+
+/// Consumes the pending parent-visible `clone`/`fork` return value, if any.
+///
+/// This is intended to be called from the `CLONE_SYSCALL` rewind replay path,
+/// after `catch_rewind` returns a positive `rewind_res`. A positive rewind
+/// result means we are replaying the parent side of `fork`, where the default
+/// return value would be the real child cage id.
+///
+/// If a pending visible value exists, this function returns it and clears the
+/// slot, so the override applies to exactly one logical fork. If no pending
+/// value exists, the caller should fall back to the original `rewind_res`.
+///
+/// Child-side fork replay should not use this override: the child must still
+/// observe `fork()` returning 0.
+pub fn take_pending_clone_visible_retval<
+    T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync,
+    U: Clone + Send + 'static + std::marker::Sync,
+>(
+    caller: &mut Caller<'_, T>,
+) -> Option<i32> {
+    let ctx = caller.data_mut().get_ctx_mut();
+
+    let mut slot = ctx.pending_clone_visible_retval.lock().unwrap();
+    let ret = slot.take();
+
+    ret
 }

--- a/tests/grate-tests/interposing-calls/fork-with-newret.c
+++ b/tests/grate-tests/interposing-calls/fork-with-newret.c
@@ -1,0 +1,24 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main()
+{
+    pid_t cpid;
+    cpid = fork();
+    assert(cpid >= 0);
+    
+    
+    if (cpid == 0) {
+        exit(0);           /* terminate child */
+    } else {
+        printf("[Cage] Forked process with PID: %d\n", cpid);
+        assert(cpid == 10); // The fork_grate handler in the grate should return 10, which is determined by the grate ret
+        wait(NULL);           /* wait for child */
+    }
+
+    return 0;
+}
+

--- a/tests/grate-tests/interposing-calls/fork-with-newret_grate.c
+++ b/tests/grate-tests/interposing-calls/fork-with-newret_grate.c
@@ -1,0 +1,116 @@
+#include <errno.h>
+#include <lind_syscall.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <assert.h>
+
+// Dispatcher function
+int pass_fptr_to_wt(uint64_t fn_ptr_uint, uint64_t cageid, uint64_t arg1,
+                    uint64_t arg1cage, uint64_t arg2, uint64_t arg2cage,
+                    uint64_t arg3, uint64_t arg3cage, uint64_t arg4,
+                    uint64_t arg4cage, uint64_t arg5, uint64_t arg5cage,
+                    uint64_t arg6, uint64_t arg6cage) {
+  if (fn_ptr_uint == 0) {
+    fprintf(stderr, "[Grate|interpose-fork] Invalid function ptr\n");
+    assert(0);
+  }
+
+  printf("[Grate|interpose-fork] Handling function ptr: %llu from cage: %llu\n",
+         fn_ptr_uint, cageid);
+
+  int (*fn)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+              uint64_t, uint64_t, uint64_t) =
+        (int (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                 uint64_t, uint64_t, uint64_t))(uintptr_t)fn_ptr_uint;
+
+    return fn(cageid, arg1, arg1cage, arg2, arg2cage,
+              arg3, arg3cage, arg4, arg4cage,
+              arg5, arg5cage, arg6, arg6cage);
+}
+
+int fork_grate(uint64_t cageid, 
+    uint64_t arg1, uint64_t arg1cage, 
+    uint64_t arg2, uint64_t arg2cage,
+    uint64_t arg3, uint64_t arg3cage, 
+    uint64_t arg4, uint64_t arg4cage, 
+    uint64_t arg5, uint64_t arg5cage,
+    uint64_t arg6, uint64_t arg6cage) {
+  printf("[Grate|interpose-fork] In fork_grate %d handler for cage: %llu\n",
+         getpid(), cageid);
+  int self_grate_id = getpid();
+  int new_cageid = make_threei_call(
+    56, // syscallnum for clone
+    0,    // callname is not used in the trampoline, set to 0
+    self_grate_id,    // self_grate_id is not used in the trampoline, set to 0
+    arg1cage,    // target_cageid is not used in the trampoline, set to 0
+    arg1, arg1cage, 
+    arg2, arg2cage,
+    arg3, arg3cage, 
+    arg4, arg4cage, 
+    arg5, arg5cage,
+    arg6, arg6cage,
+    0 // we will handle the errno in this grate instead of translating it to -1 in the trampoline
+  );
+
+  // Ensure the return value is a valid process ID.
+  assert(new_cageid > 0);
+
+  return 10;
+}
+
+// Main function will always be same in all grates
+int main(int argc, char *argv[]) {
+    // Should be at least one input (at least one grate file and one cage file)
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <cage_file> <grate_file>\n",
+                argv[0]);
+        assert(0);
+    }
+
+    int grateid = getpid();
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork failed");
+        assert(0);
+    } else if (pid == 0) {
+        int cageid = getpid();
+        // Set the clone (syscallnum=56) of this cage to call this grate
+        // function fork_grate 
+        // Syntax of register_handler:
+        // <targetcage, targetcallnum, this_grate_id, fn_ptr_u64)>
+        uint64_t fn_ptr_addr = (uint64_t)(uintptr_t)&fork_grate;
+        printf("[Grate|interpose-fork] Registering fork handler for cage %d in "
+                "grate %d with fn ptr addr: %llu\n",
+                cageid, grateid, fn_ptr_addr);
+        int ret = register_handler(cageid, 56, grateid, fn_ptr_addr);
+        if (ret != 0) {
+            fprintf(stderr, "[Grate|interpose-fork] Failed to register handler for cage %d in "
+                    "grate %d with fn ptr addr: %llu, ret: %d\n",
+                    cageid, grateid, fn_ptr_addr, ret);
+            assert(0);
+        }
+
+        if (execv(argv[1], &argv[1]) == -1) {
+        perror("execv failed");
+        assert(0);
+        }
+    }
+
+    int status;
+    int failed = 0;
+    while (wait(&status) > 0) {
+        if (status != 0) {
+        fprintf(stderr, "[Grate|interpose-fork] FAIL: child exited with status %d\n", status);
+        assert(0);
+        }
+    }
+
+    printf("[Grate|interpose-fork] PASS\n");
+    return 0;
+}


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Resolves #1132 

This PR preserves a grate-defined return value for interposed `clone`/`fork` calls across the Asyncify unwind/rewind boundary.

Previously, when a grate interposed on `clone` and returned a custom value, the parent cage still observed the real child cage id. This happened because the guest-visible `fork()` return value is produced during the later Asyncify rewind replay, where `catch_rewind()` returns the saved rewind value directly and bypasses the normal syscall/interposition return path.

This PR adds a pending visible clone return slot to the Lind context and consumes it during the parent-side clone rewind