### PR TITLE
Restore lind debug import helper for debug builds

### DIFF
--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -405,7 +405,7 @@ do_dynamic_compile() {
   fi
 
   run_cmd "${CLANG_BIN}" "${default_clang_flags[@]}" "${mandatory_clang_flags[@]}"\
-    "${EXTRA_CLANG_ARGS[@]}" "${SRC}" "$SYSROOT/lib/wasm32-wasi/crt1_shared.o" "$SYSROOT/lib/wasm32-wasi/lind_utils.o" -o "${OUT_WASM}"
+    "${EXTRA_CLANG_ARGS[@]}" "${SRC}" "$SYSROOT/lib/wasm32-wasi/crt1_shared.o" "$SYSROOT/lib/wasm32-wasi/lind_utils.o" "$SYSROOT/lib/wasm32-wasi/lind_debug.o" -o "${OUT_WASM}"
   
   run_cmd $REPO_ROOT/tools/add-export-tool/add-export-tool "${OUT_WASM}" "${OUT_WASM}" __wasm_apply_tls_relocs func __wasm_apply_tls_relocs optional
   run_cmd $REPO_ROOT/tools/add-export-tool/add-export-tool "${OUT_WASM}" "${OUT_WASM}" __wasm_apply_global_relocs func __wasm_apply_global_relocs optional

--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -181,6 +181,7 @@ rm -rf "$SYSROOT"
 # Create the sysroot directory structure
 mkdir -p "$SYSROOT/include/wasm32-wasi" "$SYSROOT/lib/wasm32-wasi"
 cp "$BUILD/lind_utils.o" "$SYSROOT/lib/wasm32-wasi/"
+cp "$BUILD/lind_debug.o" "$SYSROOT/lib/wasm32-wasi/"
 
 "$SCRIPT_DIR/make_archive.sh"
 cd $SCRIPT_DIR

--- a/src/glibc/lind_syscall/crt1/crt1.c
+++ b/src/glibc/lind_syscall/crt1/crt1.c
@@ -206,7 +206,7 @@ int _start() {
     __lind_initialize_environ();
     __ctype_init(); //lind-wasm: init ctypes for isalpha etc.
     #ifdef LIND_DEBUG
-    	lind_debug_printf("Lind running in debug mode\n");
+    	__lind_debug_import();
     #endif
 // Lind-Wasm: conditional compilation to ensure exit() is called before program termination,
 // and return __main_void() if NO_ASYNCIFY is defined. exit() depends on asyncify,

--- a/src/glibc/lind_syscall/lind_debug.c
+++ b/src/glibc/lind_syscall/lind_debug.c
@@ -20,11 +20,28 @@ void lind_debug_panic (const char* msg)
 
 #ifdef LIND_DEBUG
 
-// Imported debug function to log a string directly to host-visible debug output.
+// These functions return the input value to ensure the operand
+// remains on the WASM stack for potential debugging.
+
+// Imported debug function to log or trace unsigned integer.
+extern unsigned int __lind_debug_num(unsigned int num) __attribute__((
+    __import_module__("debug"),
+    __import_name__("lind_debug_num")
+));
+
+// Imported debug function to log or trace string.
 extern const char* __lind_debug_str(const char *str) __attribute__((
     __import_module__("debug"),
     __import_name__("lind_debug_str")
 ));
+
+// Force calls to import debug functions. Execution is not required;
+// their presence here prevents the linker from stripping the imports.
+void __lind_debug_import(void)
+{
+    __lind_debug_num(0);
+    __lind_debug_str("LIND DEBUG INIT");
+}
 
 void lind_debug_printf(const char *fmt, ...)
 {

--- a/src/glibc/lind_syscall/lind_debug.h
+++ b/src/glibc/lind_syscall/lind_debug.h
@@ -5,6 +5,14 @@
 void lind_debug_panic (const char* msg);
 
 #ifdef LIND_DEBUG
+// lind_debug raw WASM imports
+unsigned int __lind_debug_num(unsigned int num);
+const char* __lind_debug_str(const char *str);
+
+// lind_debug force import
+void __lind_debug_import(void);
+
+// formatted debug print helper
 void lind_debug_printf(const char *fmt, ...);
 #endif // LIND_DEBUG
 


### PR DESCRIPTION
## Purpose

This PR addresses the requested change on #1119 regarding the Lind debug build regression.

A previous cleanup accidentally removed the debug import-preserving helper logic from `lind_debug.c`, including `__lind_debug_num` and `__lind_debug_import`. A later change also replaced the debug-mode startup call in `crt1.c` from `__lind_debug_import()` to `lind_debug_printf(...)`, which was not the expected behavior.

This PR restores the original import-preserving path while keeping `lind_debug_printf()` available as a formatted debug-print helper.

## Related PR / Review Comment

Addresses the requested change on #1119.

Related commits discussed in the review:
- `0f386b3`: removed the debug import helper path from `lind_debug.c`
- `4265012`: replaced the `crt1.c` debug startup call with `lind_debug_printf(...)`

## Changes

- Restored the raw debug imports under `LIND_DEBUG`:
  - `__lind_debug_num`
  - `__lind_debug_str`
- Restored `__lind_debug_import()` in `lind_debug.c` to force the debug imports to be kept.
- Added the corresponding declarations back to `lind_debug.h`.
- Changed the `crt1.c` debug-mode startup call back to `__lind_debug_import()`.
- Kept `lind_debug_printf()` available for formatted debug output.

## Testing

I ran the relevant local build/check command and confirmed that it completed without errors.

## Notes for Reviewers

This PR is intended to minimally restore the missing debug import-preserving behavior requested in #1119, without removing the newer `lind_debug_printf()` helper.