### PR TITLE
fix getcwd with NULL buffer

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/getcwd.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/getcwd.c
@@ -48,17 +48,30 @@
 char *
 __getcwd (char *buf, size_t size)
 {
-  // buf CAN be NULL - this means kernel should allocate the buffer
-  // Do NOT add null check here - NULL is valid
+  char *allocated = NULL;
+
+  if (buf == NULL)
+    {
+      /* POSIX: if buf is NULL, getcwd allocates the buffer.
+         If size is 0, use a reasonable default. */
+      if (size == 0)
+        size = PATH_MAX;
+      allocated = (char *) malloc (size);
+      if (allocated == NULL)
+        return NULL;
+      buf = allocated;
+    }
+
   uint64_t host_buf = TRANSLATE_GUEST_POINTER_TO_HOST (buf);
-  
+
   int ret = MAKE_LEGACY_SYSCALL (GETCWD_SYSCALL, "syscall|getcwd",
-		       host_buf, (uint64_t) size, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
-  
-  // kernel getcwd syscall returns the number of bytes copied
-  // while glibc wrapper should return the address of the string if success
+               host_buf, (uint64_t) size, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
+
   if (ret < 0)
+    {
+      free (allocated);
       return NULL;
+    }
 
   return buf;
 }

--- a/tests/unit-tests/file_tests/deterministic/getcwd_null.c
+++ b/tests/unit-tests/file_tests/deterministic/getcwd_null.c
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+
+int main(void) {
+    /* Test 1: getcwd with provided buffer */
+    char buf[1024];
+    char *ret = getcwd(buf, sizeof(buf));
+    assert(ret == buf);
+    assert(strlen(buf) > 0);
+    assert(buf[0] == '/');
+
+    /* Test 2: getcwd(NULL, 0) — glibc should allocate */
+    char *allocated = getcwd(NULL, 0);
+    assert(allocated != NULL);
+    assert(strlen(allocated) > 0);
+    assert(allocated[0] == '/');
+    assert(strcmp(allocated, buf) == 0);
+    free(allocated);
+
+    /* Test 3: getcwd(NULL, size) — glibc should allocate with given size */
+    char *allocated2 = getcwd(NULL, 1024);
+    assert(allocated2 != NULL);
+    assert(strcmp(allocated2, buf) == 0);
+    free(allocated2);
+
+    printf("getcwd_null: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
getcwd(NULL, 0) is valid POSIX — glibc should allocate the buffer. Our wrapper passed NULL through TRANSLATE_GUEST_POINTER_TO_HOST which produced a bad pointer, causing the syscall to fail. bash calls getcwd(0, 0) during shell init, triggering "error retrieving current directory" on startup.

Allocate a buffer when buf is NULL before calling the syscall.
