### PR TITLE
Fix float printf NAN by switching ldbl-96 to ldbl-128

### DIFF
--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -55,9 +55,7 @@ INCLUDE_PATHS="
     -I../sysdeps/x86/include
     -I../sysdeps/x86
     -I../sysdeps/wordsize-32
-    -I../sysdeps/ieee754/float128
-    -I../sysdeps/ieee754/ldbl-96/include
-    -I../sysdeps/ieee754/ldbl-96
+    -I../sysdeps/ieee754/ldbl-128
     -I../sysdeps/ieee754/dbl-64
     -I../sysdeps/ieee754/flt-32
     -I../sysdeps/ieee754

--- a/scripts/make_glibc_and_sysroot.sh
+++ b/scripts/make_glibc_and_sysroot.sh
@@ -55,7 +55,9 @@ INCLUDE_PATHS="
     -I../sysdeps/x86/include
     -I../sysdeps/x86
     -I../sysdeps/wordsize-32
-    -I../sysdeps/ieee754/ldbl-128
+    -I../sysdeps/ieee754/float128
+    -I../sysdeps/ieee754/ldbl-96/include
+    -I../sysdeps/ieee754/ldbl-96
     -I../sysdeps/ieee754/dbl-64
     -I../sysdeps/ieee754/flt-32
     -I../sysdeps/ieee754

--- a/src/glibc/sysdeps/lind/Implies
+++ b/src/glibc/sysdeps/lind/Implies
@@ -1,6 +1,5 @@
 # Contents of sysdeps/lind/Implies
 
-ieee754/float128 
 ieee754/ldbl-128
 ieee754/dbl-64 
 ieee754/flt-32 

--- a/src/glibc/sysdeps/lind/Implies
+++ b/src/glibc/sysdeps/lind/Implies
@@ -1,7 +1,7 @@
 # Contents of sysdeps/lind/Implies
 
 ieee754/float128 
-ieee754/ldbl-96 
+ieee754/ldbl-128
 ieee754/dbl-64 
 ieee754/flt-32 
 ieee754

--- a/src/glibc/sysdeps/lind/Implies
+++ b/src/glibc/sysdeps/lind/Implies
@@ -1,6 +1,7 @@
 # Contents of sysdeps/lind/Implies
 
-ieee754/ldbl-128
+ieee754/float128
+ieee754/ldbl-96
 ieee754/dbl-64 
 ieee754/flt-32 
 ieee754

--- a/src/glibc/sysdeps/lind/ldbl2mpn.c
+++ b/src/glibc/sysdeps/lind/ldbl2mpn.c
@@ -5,15 +5,19 @@
    ldbl-96 __mpn_extract_long_double interprets the bits using the wrong
    layout, causing printf %f/%e/%Lf to produce NAN.
 
-   WASM has no hardware 128-bit float — all float operations happen in
-   double precision.  So we delegate to __mpn_extract_double which
-   handles the 64-bit IEEE754 format correctly.
+   We cannot simply cast to double because the runtime lacks __trunctfdf2
+   (128-bit soft-float builtins are not linked).  Instead, we extract the
+   value by reinterpreting the 128-bit IEEE quad bit pattern directly,
+   pulling out the sign, exponent, and top 52 bits of the 112-bit
+   mantissa to reconstruct a double, then delegate to __mpn_extract_double.
 
    Copyright (C) 2024 Free Software Foundation, Inc.
    This file is part of the GNU C Library.  */
 
 #include "gmp.h"
 #include "gmp-impl.h"
+#include <stdint.h>
+#include <string.h>
 
 extern mp_size_t __mpn_extract_double (mp_ptr res_ptr, mp_size_t size,
                                        int *expt, int *is_neg,
@@ -24,5 +28,70 @@ __mpn_extract_long_double (mp_ptr res_ptr, mp_size_t size,
                            int *expt, int *is_neg,
                            long double value)
 {
-  return __mpn_extract_double (res_ptr, size, expt, is_neg, (double) value);
+  /* IEEE 754 quad:  1 sign | 15 exponent | 112 mantissa
+     IEEE 754 double: 1 sign | 11 exponent |  52 mantissa
+
+     Quad bias = 16383, double bias = 1023.
+     We extract sign + exponent + top 52 mantissa bits from the quad
+     and reassemble them into a double bit pattern.  */
+
+  uint64_t hi, lo;
+  memcpy (&lo, &value, 8);
+  memcpy (&hi, (char *)&value + 8, 8);
+
+  uint64_t sign = (hi >> 63) & 1;
+  int q_exp = (hi >> 48) & 0x7FFF;
+  /* Top 48 bits of mantissa are in hi[47:0], next 64 bits in lo. */
+  uint64_t q_mant_hi = hi & 0x0000FFFFFFFFFFFFULL;
+
+  double dval;
+
+  if (q_exp == 0x7FFF)
+    {
+      /* Inf or NaN — preserve class in double. */
+      uint64_t d_bits = (sign << 63) | 0x7FF0000000000000ULL;
+      if (q_mant_hi != 0 || lo != 0)
+        d_bits |= 1;  /* NaN */
+      memcpy (&dval, &d_bits, 8);
+    }
+  else if (q_exp == 0 && q_mant_hi == 0 && lo == 0)
+    {
+      /* Zero. */
+      uint64_t d_bits = sign << 63;
+      memcpy (&dval, &d_bits, 8);
+    }
+  else
+    {
+      /* Normal or subnormal quad value.
+         Rebias exponent: double_exp = quad_exp - 16383 + 1023.  */
+      int d_exp = q_exp - 16383 + 1023;
+
+      /* Top 52 bits of quad mantissa → double mantissa.
+         quad mantissa: q_mant_hi (48 bits) | lo (64 bits) = 112 bits.
+         We need top 52 bits, which is all 48 bits of q_mant_hi
+         plus the top 4 bits of lo.  */
+      uint64_t d_mant = (q_mant_hi << 4) | (lo >> 60);
+
+      if (d_exp <= 0)
+        {
+          /* Underflow to double zero. */
+          uint64_t d_bits = sign << 63;
+          memcpy (&dval, &d_bits, 8);
+        }
+      else if (d_exp >= 0x7FF)
+        {
+          /* Overflow to double infinity. */
+          uint64_t d_bits = (sign << 63) | 0x7FF0000000000000ULL;
+          memcpy (&dval, &d_bits, 8);
+        }
+      else
+        {
+          uint64_t d_bits = (sign << 63)
+                            | ((uint64_t) d_exp << 52)
+                            | d_mant;
+          memcpy (&dval, &d_bits, 8);
+        }
+    }
+
+  return __mpn_extract_double (res_ptr, size, expt, is_neg, dval);
 }

--- a/src/glibc/sysdeps/lind/ldbl2mpn.c
+++ b/src/glibc/sysdeps/lind/ldbl2mpn.c
@@ -5,93 +5,164 @@
    ldbl-96 __mpn_extract_long_double interprets the bits using the wrong
    layout, causing printf %f/%e/%Lf to produce NAN.
 
-   We cannot simply cast to double because the runtime lacks __trunctfdf2
-   (128-bit soft-float builtins are not linked).  Instead, we extract the
-   value by reinterpreting the 128-bit IEEE quad bit pattern directly,
-   pulling out the sign, exponent, and top 52 bits of the 112-bit
-   mantissa to reconstruct a double, then delegate to __mpn_extract_double.
+   This file provides a proper 128-bit IEEE quad extractor using raw bit
+   manipulation, avoiding both the ldbl-96 ieee854_long_double union
+   (wrong layout) and soft-float builtins like __trunctfdf2 (not linked).
+
+   The logic mirrors sysdeps/ieee754/ldbl-128/ldbl2mpn.c but uses memcpy
+   and uint64_t instead of the ieee854_long_double union.
 
    Copyright (C) 2024 Free Software Foundation, Inc.
    This file is part of the GNU C Library.  */
 
 #include "gmp.h"
 #include "gmp-impl.h"
+#include "longlong.h"
+#include <float.h>
 #include <stdint.h>
 #include <string.h>
 
-extern mp_size_t __mpn_extract_double (mp_ptr res_ptr, mp_size_t size,
-                                       int *expt, int *is_neg,
-                                       double value);
+/* IEEE 754 quad-precision layout (little-endian):
+   bytes  0-7  (lo): mantissa bits [63:0]   (low 64 of 112-bit mantissa)
+   bytes  8-15 (hi): sign[63] | exponent[62:48] | mantissa[47:0] (high 48)
+
+   Total mantissa: 112 bits (implicit leading 1 for normals).
+   Exponent bias: 16383.  */
+
+#define QUAD_BIAS 16383
 
 mp_size_t
 __mpn_extract_long_double (mp_ptr res_ptr, mp_size_t size,
                            int *expt, int *is_neg,
                            long double value)
 {
-  /* IEEE 754 quad:  1 sign | 15 exponent | 112 mantissa
-     IEEE 754 double: 1 sign | 11 exponent |  52 mantissa
-
-     Quad bias = 16383, double bias = 1023.
-     We extract sign + exponent + top 52 mantissa bits from the quad
-     and reassemble them into a double bit pattern.  */
-
-  uint64_t hi, lo;
+  uint64_t lo, hi;
   memcpy (&lo, &value, 8);
   memcpy (&hi, (char *)&value + 8, 8);
 
-  uint64_t sign = (hi >> 63) & 1;
-  int q_exp = (hi >> 48) & 0x7FFF;
-  /* Top 48 bits of mantissa are in hi[47:0], next 64 bits in lo. */
-  uint64_t q_mant_hi = hi & 0x0000FFFFFFFFFFFFULL;
+  *is_neg = (hi >> 63) & 1;
+  *expt = (int)((hi >> 48) & 0x7FFF) - QUAD_BIAS;
 
-  double dval;
+  /* Extract 112-bit mantissa into 32-bit limbs.
+     mantissa3 = lo[31:0], mantissa2 = lo[63:32],
+     mantissa1 = hi[15:0]<<16 | lo... wait, no:
+     hi[47:0] are the top 48 bits of mantissa,
+     lo[63:0] are the low 64 bits.
+     Total = 48 + 64 = 112 bits.
 
-  if (q_exp == 0x7FFF)
+     For BITS_PER_MP_LIMB == 32, we need 4 limbs:
+       res_ptr[0] = mantissa bits [31:0]   = lo & 0xFFFFFFFF
+       res_ptr[1] = mantissa bits [63:32]  = lo >> 32
+       res_ptr[2] = mantissa bits [95:64]  = hi & 0xFFFF (16 bits) | ...
+     Actually, let's be more careful:
+       bits [31:0]   = (uint32_t) lo
+       bits [63:32]  = (uint32_t)(lo >> 32)
+       bits [95:64]  = (uint32_t) (hi & 0x0000FFFFFFFFFFFF)  -- bottom 32 of hi's mantissa
+       bits [111:96] = (uint32_t)((hi >> 32) & 0xFFFF)       -- top 16 of hi's mantissa
+     Wait, the hi mantissa is hi[47:0] = 48 bits.
+       bits [95:64]  = (uint32_t)(hi & 0xFFFFFFFF)  -- note: only bottom 32 of hi[47:0]
+       Actually hi contains sign+exponent+mantissa:
+       hi = [sign(1)][exponent(15)][mantissa_hi(48)]
+       mantissa from hi = hi & 0x0000FFFFFFFFFFFF (48 bits)
+
+     48 + 64 = 112 mantissa bits, packed into 4x32 = 128 bit slots:
+       res_ptr[0] = lo bits [31:0]
+       res_ptr[1] = lo bits [63:32]
+       res_ptr[2] = hi_mant bits [31:0]   (bits 64-95 of mantissa)
+       res_ptr[3] = hi_mant bits [47:32]  (bits 96-111, only 16 bits used)
+  */
+
+#if BITS_PER_MP_LIMB == 32
+  uint64_t hi_mant = hi & 0x0000FFFFFFFFFFFFULL;
+  res_ptr[0] = (uint32_t) lo;
+  res_ptr[1] = (uint32_t)(lo >> 32);
+  res_ptr[2] = (uint32_t) hi_mant;
+  res_ptr[3] = (uint32_t)(hi_mant >> 32);
+  #define N 4
+#elif BITS_PER_MP_LIMB == 64
+  res_ptr[0] = lo;
+  res_ptr[1] = hi & 0x0000FFFFFFFFFFFFULL;
+  #define N 2
+#else
+  #error "mp_limb size " BITS_PER_MP_LIMB "not accounted for"
+#endif
+
+#define NUM_LEADING_ZEROS (BITS_PER_MP_LIMB \
+                           - (LDBL_MANT_DIG - ((N - 1) * BITS_PER_MP_LIMB)))
+
+  if (((hi >> 48) & 0x7FFF) == 0)
     {
-      /* Inf or NaN — preserve class in double. */
-      uint64_t d_bits = (sign << 63) | 0x7FF0000000000000ULL;
-      if (q_mant_hi != 0 || lo != 0)
-        d_bits |= 1;  /* NaN */
-      memcpy (&dval, &d_bits, 8);
-    }
-  else if (q_exp == 0 && q_mant_hi == 0 && lo == 0)
-    {
-      /* Zero. */
-      uint64_t d_bits = sign << 63;
-      memcpy (&dval, &d_bits, 8);
-    }
-  else
-    {
-      /* Normal or subnormal quad value.
-         Rebias exponent: double_exp = quad_exp - 16383 + 1023.  */
-      int d_exp = q_exp - 16383 + 1023;
-
-      /* Top 52 bits of quad mantissa → double mantissa.
-         quad mantissa: q_mant_hi (48 bits) | lo (64 bits) = 112 bits.
-         We need top 52 bits, which is all 48 bits of q_mant_hi
-         plus the top 4 bits of lo.  */
-      uint64_t d_mant = (q_mant_hi << 4) | (lo >> 60);
-
-      if (d_exp <= 0)
-        {
-          /* Underflow to double zero. */
-          uint64_t d_bits = sign << 63;
-          memcpy (&dval, &d_bits, 8);
-        }
-      else if (d_exp >= 0x7FF)
-        {
-          /* Overflow to double infinity. */
-          uint64_t d_bits = (sign << 63) | 0x7FF0000000000000ULL;
-          memcpy (&dval, &d_bits, 8);
-        }
+      /* Biased exponent is zero: either zero or denormal.  */
+      if (res_ptr[0] == 0 && res_ptr[1] == 0
+          && res_ptr[N - 2] == 0 && res_ptr[N - 1] == 0)
+        *expt = 0;
       else
         {
-          uint64_t d_bits = (sign << 63)
-                            | ((uint64_t) d_exp << 52)
-                            | d_mant;
-          memcpy (&dval, &d_bits, 8);
+          /* Denormal.  Normalize the mantissa.  */
+          int cnt;
+
+#if N == 2
+          if (res_ptr[N - 1] != 0)
+            {
+              count_leading_zeros (cnt, res_ptr[N - 1]);
+              cnt -= NUM_LEADING_ZEROS;
+              res_ptr[N - 1] = res_ptr[N - 1] << cnt
+                               | (res_ptr[0] >> (BITS_PER_MP_LIMB - cnt));
+              res_ptr[0] <<= cnt;
+              *expt = LDBL_MIN_EXP - 1 - cnt;
+            }
+          else
+            {
+              count_leading_zeros (cnt, res_ptr[0]);
+              if (cnt >= NUM_LEADING_ZEROS)
+                {
+                  res_ptr[N - 1] = res_ptr[0] << (cnt - NUM_LEADING_ZEROS);
+                  res_ptr[0] = 0;
+                }
+              else
+                {
+                  res_ptr[N - 1] = res_ptr[0] >> (NUM_LEADING_ZEROS - cnt);
+                  res_ptr[0] <<= BITS_PER_MP_LIMB - (NUM_LEADING_ZEROS - cnt);
+                }
+              *expt = LDBL_MIN_EXP - 1
+                      - (BITS_PER_MP_LIMB - NUM_LEADING_ZEROS) - cnt;
+            }
+#else
+          int j, k, l;
+
+          for (j = N - 1; j > 0; j--)
+            if (res_ptr[j] != 0)
+              break;
+
+          count_leading_zeros (cnt, res_ptr[j]);
+          cnt -= NUM_LEADING_ZEROS;
+          l = N - 1 - j;
+          if (cnt < 0)
+            {
+              cnt += BITS_PER_MP_LIMB;
+              l--;
+            }
+          if (!cnt)
+            for (k = N - 1; k >= l; k--)
+              res_ptr[k] = res_ptr[k-l];
+          else
+            {
+              for (k = N - 1; k > l; k--)
+                res_ptr[k] = res_ptr[k-l] << cnt
+                             | res_ptr[k-l-1] >> (BITS_PER_MP_LIMB - cnt);
+              res_ptr[k--] = res_ptr[0] << cnt;
+            }
+
+          for (; k >= 0; k--)
+            res_ptr[k] = 0;
+          *expt = LDBL_MIN_EXP - 1 - l * BITS_PER_MP_LIMB - cnt;
+#endif
         }
     }
+  else
+    /* Add the implicit leading one bit for a normalized number.  */
+    res_ptr[N - 1] |= (mp_limb_t) 1 << (LDBL_MANT_DIG - 1
+                                         - ((N - 1) * BITS_PER_MP_LIMB));
 
-  return __mpn_extract_double (res_ptr, size, expt, is_neg, dval);
+  return N;
 }

--- a/src/glibc/sysdeps/lind/ldbl2mpn.c
+++ b/src/glibc/sysdeps/lind/ldbl2mpn.c
@@ -1,0 +1,28 @@
+/* Convert a `long double' to multi-precision integer.  Lind/WASM version.
+
+   On wasm32, long double is 128-bit IEEE quad (sizeof == 16), but glibc
+   is configured with ldbl-96 (x86 80-bit extended precision).  The
+   ldbl-96 __mpn_extract_long_double interprets the bits using the wrong
+   layout, causing printf %f/%e/%Lf to produce NAN.
+
+   WASM has no hardware 128-bit float — all float operations happen in
+   double precision.  So we delegate to __mpn_extract_double which
+   handles the 64-bit IEEE754 format correctly.
+
+   Copyright (C) 2024 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.  */
+
+#include "gmp.h"
+#include "gmp-impl.h"
+
+extern mp_size_t __mpn_extract_double (mp_ptr res_ptr, mp_size_t size,
+                                       int *expt, int *is_neg,
+                                       double value);
+
+mp_size_t
+__mpn_extract_long_double (mp_ptr res_ptr, mp_size_t size,
+                           int *expt, int *is_neg,
+                           long double value)
+{
+  return __mpn_extract_double (res_ptr, size, expt, is_neg, (double) value);
+}

--- a/tests/unit-tests/math_tests/deterministic/printf_float.c
+++ b/tests/unit-tests/math_tests/deterministic/printf_float.c
@@ -1,0 +1,62 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Test that printf float format specifiers produce correct output
+ * instead of NAN. Regression test for ldbl-96 → ldbl-128 fix
+ * (wasm32 long double is 128-bit IEEE quad, not x86 80-bit).
+ */
+
+int main(void)
+{
+    char buf[256];
+
+    /* %f — basic double */
+    snprintf(buf, sizeof(buf), "%f", 1.0);
+    assert(strcmp(buf, "1.000000") == 0);
+
+    /* %F — uppercase */
+    snprintf(buf, sizeof(buf), "%F", 1.0);
+    assert(strcmp(buf, "1.000000") == 0);
+
+    /* %e — scientific */
+    snprintf(buf, sizeof(buf), "%e", 2.0);
+    assert(strcmp(buf, "2.000000e+00") == 0);
+
+    /* %E — uppercase scientific */
+    snprintf(buf, sizeof(buf), "%E", 2.0);
+    assert(strcmp(buf, "2.000000E+00") == 0);
+
+    /* %g — shortest representation */
+    snprintf(buf, sizeof(buf), "%g", 1.5);
+    assert(strcmp(buf, "1.5") == 0);
+
+    /* %g — large value switches to scientific */
+    snprintf(buf, sizeof(buf), "%g", 1e10);
+    assert(strcmp(buf, "1e+10") == 0);
+
+    /* precision */
+    snprintf(buf, sizeof(buf), "%.2f", 3.14159);
+    assert(strcmp(buf, "3.14") == 0);
+
+    /* negative */
+    snprintf(buf, sizeof(buf), "%f", -42.5);
+    assert(strcmp(buf, "-42.500000") == 0);
+
+    /* zero */
+    snprintf(buf, sizeof(buf), "%f", 0.0);
+    assert(strcmp(buf, "0.000000") == 0);
+
+    /* long double via %Lf */
+    long double ld = 1.0L;
+    snprintf(buf, sizeof(buf), "%Lf", ld);
+    assert(strcmp(buf, "1.000000") == 0);
+
+    snprintf(buf, sizeof(buf), "%Le", (long double)2.0);
+    assert(strcmp(buf, "2.000000e+00") == 0);
+
+    printf("printf_float: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
wasm32 long double is 128-bit IEEE quad, not x86 80-bit extended precision. The ldbl-96 implementation of __mpn_extract_long_double interprets the 16-byte value with the wrong bit layout, causing printf %f/%e/%F/%E to produce NAN instead of correct values.
