### PR TITLE
fix: change release.schedule from monthly to weekly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Test and release on Docker Hub
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 8 1 * *"
+  - cron: "0 8 * * 1" # Run at 08:00, every Monday
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
Change the release workflow schedule from monthly to weekly.

## Changes
- Updated cron expression in `.github/workflows/release.yml`

## Related Issue
Closes #1111