### PR TITLE
Add wasm-opt wrapper script

### DIFF
--- a/scripts/lind-wasm-opt
+++ b/scripts/lind-wasm-opt
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# lind-wasm-opt — wasm-opt wrapper that applies lind's standard instrumentation
+# flags for a given compilation target.
+#
+# Usage:
+#   lind-wasm-opt (--target=<target> | --static) [OPTIONS] input.wasm -o output.wasm
+#
+# Exactly one of --target or --static must be given:
+#   --target=main      Dynamic main-module binary.
+#   --target=library   Dynamic shared-library binary.
+#   --static           Static (non-dynamic) binary.
+#
+# Options:
+#   --fpcast-emu          Enable function-pointer-cast emulation.
+#   --without-asyncify    Omit asyncify instrumentation.
+#   --without-epoch       Omit epoch/signal instrumentation.
+#   -v, --verbose         Print the exact wasm-opt command before executing it.
+#   -h, --help            Show this help and exit.
+#
+# Examples:
+#   lind-wasm-opt --target=main    input.wasm -o output.wasm
+#   lind-wasm-opt --target=library input.wasm -o output.wasm
+#   lind-wasm-opt --static         input.wasm -o output.wasm
+#   lind-wasm-opt --target=main --fpcast-emu input.wasm -o output.wasm
+#   lind-wasm-opt --static --fpcast-emu      input.wasm -o output.wasm
+#   lind-wasm-opt --target=main --without-asyncify --without-epoch input.wasm -o output.wasm
+
+usage() {
+  sed -n '/^# Usage:/,/^[^#]/{ /^[^#]/d; s/^# \{0,3\}//; p }' "$0" >&2
+}
+
+TARGET=""
+STATIC="false"
+WITH_FPCAST="false"
+WITHOUT_ASYNCIFY="false"
+WITHOUT_EPOCH="false"
+PRINT_CMD="false"
+
+# --- option parsing ---
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --target=main|--target=library)
+      TARGET="${1#--target=}"
+      ;;
+    --target=*)
+      echo "error: unknown target '${1#--target=}' (expected: main, library)" >&2
+      usage
+      exit 2
+      ;;
+    --static)
+      STATIC="true"
+      ;;
+    --fpcast-emu)
+      WITH_FPCAST="true"
+      ;;
+    --without-asyncify)
+      WITHOUT_ASYNCIFY="true"
+      ;;
+    --without-epoch)
+      WITHOUT_EPOCH="true"
+      ;;
+    -v|--verbose)
+      PRINT_CMD="true"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+  shift
+done
+
+if [[ "${STATIC}" == "true" && -n "${TARGET}" ]]; then
+  echo "error: --static and --target are mutually exclusive" >&2
+  usage
+  exit 2
+fi
+
+if [[ "${STATIC}" == "false" && -z "${TARGET}" ]]; then
+  echo "error: one of --target=main, --target=library, or --static is required" >&2
+  usage
+  exit 2
+fi
+
+# Expect exactly: input.wasm -o output.wasm
+if [[ "$#" -ne 3 || "$2" != "-o" ]]; then
+  echo "error: expected exactly: input.wasm -o output.wasm" >&2
+  usage
+  exit 2
+fi
+
+INPUT_WASM="$1"
+OUTPUT_WASM="$3"
+
+if [[ ! -f "${INPUT_WASM}" ]]; then
+  echo "error: input file not found: ${INPUT_WASM}" >&2
+  exit 2
+fi
+
+# --- locate wasm-opt (repo-relative, matching lind_compile's path) ---
+if [[ -n "${LIND_WASM_ROOT:-}" && -d "${LIND_WASM_ROOT}" ]]; then
+  REPO_ROOT="${LIND_WASM_ROOT}"
+else
+  SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -f "${SCRIPT_DIR}/../Makefile" ]]; then
+    REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+  elif command -v git >/dev/null 2>&1; then
+    REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  else
+    REPO_ROOT=""
+  fi
+fi
+
+if [[ -z "${REPO_ROOT}" || ! -d "${REPO_ROOT}" ]]; then
+  echo "error: cannot locate lind-wasm repo root; export LIND_WASM_ROOT=/path/to/lind-wasm" >&2
+  exit 2
+fi
+
+WASM_OPT_BIN="${REPO_ROOT}/tools/binaryen/bin/wasm-opt"
+if [[ ! -x "${WASM_OPT_BIN}" ]]; then
+  echo "error: wasm-opt not found at ${WASM_OPT_BIN}" >&2
+  exit 127
+fi
+
+# --- build flag list, matching lind_compile's do_optimize() exactly ---
+LIND_FLAGS=()
+
+if [[ "${STATIC}" == "true" ]]; then
+  [[ "${WITHOUT_EPOCH}" == "false" ]] && LIND_FLAGS+=(--epoch-injection)
+  [[ "${WITHOUT_ASYNCIFY}" == "false" ]] && LIND_FLAGS+=(--asyncify)
+  if [[ "${WITH_FPCAST}" == "true" ]]; then
+    LIND_FLAGS+=(--fpcast-emu)
+  fi
+elif [[ "${TARGET}" == "main" ]]; then
+  LIND_FLAGS+=(--enable-bulk-memory --enable-threads)
+  if [[ "${WITHOUT_EPOCH}" == "false" ]]; then
+    LIND_FLAGS+=(--epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module)
+  fi
+  if [[ "${WITHOUT_ASYNCIFY}" == "false" ]]; then
+    LIND_FLAGS+=(--asyncify --pass-arg=asyncify-import-globals)
+  fi
+  if [[ "${WITH_FPCAST}" == "true" ]]; then
+    LIND_FLAGS+=(--fpcast-emu --pass-arg=relocatable-fpcast)
+  fi
+else  # library
+  LIND_FLAGS+=(--enable-bulk-memory --enable-threads)
+  if [[ "${WITHOUT_EPOCH}" == "false" ]]; then
+    LIND_FLAGS+=(--epoch-injection --pass-arg=epoch-import)
+  fi
+  if [[ "${WITHOUT_ASYNCIFY}" == "false" ]]; then
+    LIND_FLAGS+=(--asyncify --pass-arg=asyncify-import-globals)
+  fi
+  if [[ "${WITH_FPCAST}" == "true" ]]; then
+    LIND_FLAGS+=(--fpcast-emu --pass-arg=relocatable-fpcast)
+  fi
+fi
+
+LIND_FLAGS+=(-O2 --debuginfo)
+
+# --- run wasm-opt ---
+if [[ "${PRINT_CMD}" == "true" ]]; then
+  printf '+ %q' "${WASM_OPT_BIN}" >&2
+  printf ' %q' "${LIND_FLAGS[@]}" "${INPUT_WASM}" -o "${OUTPUT_WASM}" >&2
+  printf '\n' >&2
+fi
+
+exec "${WASM_OPT_BIN}" "${LIND_FLAGS[@]}" "${INPUT_WASM}" -o "${OUTPUT_WASM}"

--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -268,7 +268,7 @@ esac
 
 # --- tool paths & quick checks (anchored to repo) ---
 CLANG_BIN="clang"  # must be on PATH
-WASM_OPT_BIN="${REPO_ROOT}/tools/binaryen/bin/wasm-opt"
+LIND_WASM_OPT_BIN="${REPO_ROOT}/scripts/lind-wasm-opt"
 LINDBOOT_BIN="${REPO_ROOT}/build/lind-boot"
 LINDFS_ROOT="${REPO_ROOT}/lindfs/"
 if [[ -n "${TARGET_DIR}" ]]; then
@@ -290,7 +290,7 @@ if [[ "${MODE}" == "full" || "${MODE}" == "compile-only" ]]; then
 fi
 
 if [[ "${MODE}" == "full" || "${MODE}" == "opt-only" ]]; then
-  [[ -x "${WASM_OPT_BIN}" ]] || { echo "error: wasm-opt not found at ${WASM_OPT_BIN}" >&2; exit 2; }
+  [[ -x "${LIND_WASM_OPT_BIN}" ]] || { echo "error: lind-wasm-opt not found at ${LIND_WASM_OPT_BIN}" >&2; exit 2; }
 fi
 
 if [[ "${MODE}" == "full" || "${MODE}" == "precompile-only" ]]; then
@@ -470,39 +470,15 @@ do_compile() {
 }
 
 do_optimize() {
-  FPCAST_ARG=""
-  if [[ "${WITH_FPCAST}" == "true" ]]; then
-    if [[ "${SHARED_BUILD}" == "true" || "${COMPILE_LIBRARY}" == "true" ]]; then
-      FPCAST_ARG="--fpcast-emu --pass-arg=relocatable-fpcast"
-    else
-      FPCAST_ARG="--fpcast-emu"
-    fi
-  fi
+  local fpcast_flag=()
+  [[ "${WITH_FPCAST}" == "true" ]] && fpcast_flag=(--fpcast-emu)
 
   if [[ "${SHARED_BUILD}" == "true" ]]; then
-    # --enable-bulk-memory --enable-threads: required wasm feature enabled for lind
-    # --epoch-injection --pass-arg=epoch-import: enable signal support, with dynamic build feature (epoch-import), with hint for applying epoch on main module (epoch-main-module)
-    # --asyncify --pass-arg=asyncify-import-globals --pass-arg=epoch-main-module: enable asyncify for multiprocess, with dynamic build feature (import-globals)
-    # --debuginfo: retain debug information for better debugging experience 
-    run_cmd "${WASM_OPT_BIN}" \
-      --enable-bulk-memory --enable-threads \
-      --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
-      --asyncify --pass-arg=asyncify-import-globals \
-      $FPCAST_ARG \
-      -O2 --debuginfo \
-      "${OUT_WASM}" -o "${OUT_WASM}"
-  else 
-    if [[ "${COMPILE_LIBRARY}" == "true" ]]; then
-        run_cmd "${WASM_OPT_BIN}" \
-        --enable-bulk-memory --enable-threads \
-        --epoch-injection --pass-arg=epoch-import \
-        --asyncify --pass-arg=asyncify-import-globals \
-        $FPCAST_ARG \
-        -O2 --debuginfo \
-        "${OUT_WASM}" -o "${OUT_WASM}"
-    else
-      run_cmd "${WASM_OPT_BIN}" --epoch-injection --asyncify $FPCAST_ARG -O2 --debuginfo "${OUT_WASM}" -o "${OUT_WASM}"
-    fi
+    run_cmd "${LIND_WASM_OPT_BIN}" --target=main "${fpcast_flag[@]}" "${OUT_WASM}" -o "${OUT_WASM}"
+  elif [[ "${COMPILE_LIBRARY}" == "true" ]]; then
+    run_cmd "${LIND_WASM_OPT_BIN}" --target=library "${fpcast_flag[@]}" "${OUT_WASM}" -o "${OUT_WASM}"
+  else
+    run_cmd "${LIND_WASM_OPT_BIN}" --static "${fpcast_flag[@]}" "${OUT_WASM}" -o "${OUT_WASM}"
   fi
 }
 

--- a/scripts/lind_compile
+++ b/scripts/lind_compile
@@ -489,7 +489,7 @@ do_optimize() {
       --epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module \
       --asyncify --pass-arg=asyncify-import-globals \
       $FPCAST_ARG \
-      --debuginfo \
+      -O2 --debuginfo \
       "${OUT_WASM}" -o "${OUT_WASM}"
   else 
     if [[ "${COMPILE_LIBRARY}" == "true" ]]; then
@@ -498,7 +498,7 @@ do_optimize() {
         --epoch-injection --pass-arg=epoch-import \
         --asyncify --pass-arg=asyncify-import-globals \
         $FPCAST_ARG \
-        --debuginfo \
+        -O2 --debuginfo \
         "${OUT_WASM}" -o "${OUT_WASM}"
     else
       run_cmd "${WASM_OPT_BIN}" --epoch-injection --asyncify $FPCAST_ARG -O2 --debuginfo "${OUT_WASM}" -o "${OUT_WASM}"

--- a/scripts/make_shared_glibc.sh
+++ b/scripts/make_shared_glibc.sh
@@ -17,9 +17,9 @@ BUILD="$GLIBC/build"
 SYSROOT="$GLIBC/sysroot"
 SYSROOT_ARCHIVE="$SYSROOT/lib/wasm32-wasi/libc.a"
 
-WITH_FPCAST=""
+FPCAST_FLAG=""
 if [[ "$1" == "--with-fpcast" ]]; then
-    WITH_FPCAST="--fpcast-emu --pass-arg=relocatable-fpcast"
+    FPCAST_FLAG="--fpcast-emu"
 fi
 
 symbols=$($SCRIPTS_DIR/extract_glibc_symbols.sh $GLIBC $SCRIPTS_DIR/extract_versions.py --flags --paths-file $SCRIPTS_DIR/version-path-minimal.txt)
@@ -59,7 +59,7 @@ $REPO_ROOT/tools/add-export-tool/add-export-tool $REPO_ROOT/lindfs/lib/libc.so $
 $REPO_ROOT/tools/add-export-tool/add-export-tool $REPO_ROOT/lindfs/lib/libc.so $REPO_ROOT/lindfs/lib/libc.so __stack_pointer global __stack_pointer
 
 # apply wasm-opt
-$REPO_ROOT/tools/binaryen/bin/wasm-opt --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals $WITH_FPCAST -O2 --debuginfo $REPO_ROOT/lindfs/lib/libc.so -o $REPO_ROOT/lindfs/lib/libc.so
+$REPO_ROOT/scripts/lind-wasm-opt --target=library $FPCAST_FLAG $REPO_ROOT/lindfs/lib/libc.so -o $REPO_ROOT/lindfs/lib/libc.so
 
 # do precompile (call lind-boot directly to avoid lind_compile copying to lindfs root)
 rm -f $REPO_ROOT/lindfs/lib/libc.cwasm

--- a/scripts/make_shared_libm.sh
+++ b/scripts/make_shared_libm.sh
@@ -17,9 +17,9 @@ BUILD="$GLIBC/build"
 SYSROOT="$GLIBC/sysroot"
 SYSROOT_ARCHIVE="$SYSROOT/lib/wasm32-wasi/libc.a"
 
-WITH_FPCAST=""
+FPCAST_FLAG=""
 if [[ "$1" == "--with-fpcast" ]]; then
-    WITH_FPCAST="--fpcast-emu --pass-arg=relocatable-fpcast"
+    FPCAST_FLAG="--fpcast-emu"
 fi
 
 symbols=$($SCRIPTS_DIR/extract_glibc_symbols.sh $GLIBC $SCRIPTS_DIR/extract_versions.py --flags --paths-file $SCRIPTS_DIR/math-path.txt)
@@ -48,7 +48,7 @@ $REPO_ROOT/tools/add-export-tool/add-export-tool "$SYSROOT/lib/wasm32-wasi/libm.
 mkdir -p $REPO_ROOT/lindfs/lib
 
 # apply wasm-opt
-$REPO_ROOT/tools/binaryen/bin/wasm-opt --enable-bulk-memory --enable-threads --epoch-injection --pass-arg=epoch-import --asyncify --pass-arg=asyncify-import-globals $WITH_FPCAST -O2 --debuginfo $SYSROOT/lib/wasm32-wasi/libm.so -o $REPO_ROOT/lindfs/lib/libm.so
+$REPO_ROOT/scripts/lind-wasm-opt --target=library $FPCAST_FLAG $SYSROOT/lib/wasm32-wasi/libm.so -o $REPO_ROOT/lindfs/lib/libm.so
 
 # do precompile (call lind-boot directly to avoid lind_compile copying to lindfs root)
 rm -f $REPO_ROOT/lindfs/lib/libm.cwasm


### PR DESCRIPTION
## Summary

Introduces `scripts/lind-wasm-opt`, a wrapper around `wasm-opt` that encapsulates lind's standard instrumentation flags, and migrates all direct `wasm-opt` invocations in the build scripts to use it.

**`lind-wasm-opt`** selects the correct flag set based on a required build target:
- `--target=main` — dynamic main-module binary (epoch-import + epoch-main-module + asyncify-import-globals)
- `--target=library` — dynamic shared library (epoch-import + asyncify-import-globals, no epoch-main-module)
- `--static` — static binary (bare epoch + asyncify, with -O2)

Optional flags: `--fpcast-emu` (adds `--pass-arg=relocatable-fpcast` automatically for dynamic targets), `--without-asyncify`, `--without-epoch`, `--verbose`.

The wrapper enforces the correct wasm-opt argument ordering (in particular, `-O2` after `--asyncify`) and rejects unknown options, making it harder to accidentally produce a mis-instrumented binary.

Also includes a rebuilt `libbinaryen.so` with two fixes to `FuncCastEmulation`:
- **Crash fix**: `makeThunk` now returns `nullptr` for functions exceeding `max-func-params` (default 18) instead of emitting out-of-bounds `local.get` indices, which caused heap corruption in `SimplifyLocals` on large modules like postgres
- **Whitelist support**: new `--pass-arg=fpcast-whitelist@name1,glob*` argument limits thunk generation to a named subset of functions

Related changes with `wasm-opt` are at https://github.com/Lind-Project/lind-wasm-binaryen/commit/f13fa3298ce3f26acd707299fe07e5f4f4f53a79 and https://github.com/Lind-Project/lind-wasm-binaryen/commit/f85da490f35412c5974eb6b38171a124d6d02b51