### PR TITLE
remove maybe_exit_on_error to prevent bypassing lind cage cleanup

### DIFF
--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -765,8 +765,7 @@ impl<
                         // as the signal-handler error path so the parent
                         // sees a proper zombie and resources are freed.
                         if let Err(err) = invoke_res {
-                            let e = wasi_common::maybe_exit_on_error(err);
-                            eprintln!("Child Error: {:?}", e);
+                            eprintln!("Child Error: {:?}", err);
                             cage::cage_record_exit_status(
                                 child_cageid,
                                 cage::ExitStatus::Exited(1),
@@ -1302,8 +1301,7 @@ impl<
 
                     // print errors if any when running the thread
                     if let Err(err) = invoke_res {
-                        let e = wasi_common::maybe_exit_on_error(err);
-                        eprintln!("Error: {:?}", e);
+                        eprintln!("Error: {:?}", err);
                         return 0;
                     }
 

--- a/src/wasmtime/crates/lind-multi-process/src/signal.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/signal.rs
@@ -138,8 +138,7 @@ pub fn signal_handler<
                 signal_func.call(caller.as_context_mut(), (signal_handler as i32, signo));
             // print errors if any when running the signal handler
             if let Err(err) = invoke_res {
-                let e = wasi_common::maybe_exit_on_error(err);
-                eprintln!("Error: {:?}", e);
+                eprintln!("Error: {:?}", err);
                 // if we encountered any error when executing the signal handler, we should terminate the cage
                 cage::cage_record_exit_status(cageid, cage::ExitStatus::Exited(1));
                 if let Some(c) = cage::get_cage(cageid) {


### PR DESCRIPTION
wasi_common::maybe_exit_on_error calls process::exit() when the error is an I32Exit (guest called exit()) or a Wasm trap, killing the entire host process immediately. In lind-wasm, this sits in front of cage cleanup code — recording exit status, finalizing the cage, decrementing the cage counter, removing VMContexts — which would all be skipped.

This PR removes maybe_exit_on_error from the three call sites in lind-multi-process (fork child crash, thread crash, signal handler crash) so lind's cleanup always runs regardless of error type.