### PR TITLE
Make error_handling_net use dynamic port for ECONNREFUSED test

### DIFF
--- a/tests/unit-tests/networking_tests/deterministic/error_handling_net.c
+++ b/tests/unit-tests/networking_tests/deterministic/error_handling_net.c
@@ -63,14 +63,25 @@ int main(void) {
     printf("2. recv on unconnected socket → ENOTCONN\n");
     close(s);
 
-    /* --- 3) ECONNREFUSED: connect to port with nobody listening --- */
-    s = socket(AF_INET, SOCK_STREAM, 0);
-    assert(s >= 0);
+    /* --- 3) ECONNREFUSED: connect to a dynamically selected closed port --- */
+    int probe = socket(AF_INET, SOCK_STREAM, 0);
+    assert(probe >= 0);
 
     struct sockaddr_in refuse = {0};
     refuse.sin_family = AF_INET;
     refuse.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-    refuse.sin_port = htons(PORT_BASE); /* nobody listening here */
+    refuse.sin_port = 0; /* let the OS choose an available port */
+
+    assert(bind(probe, (struct sockaddr *)&refuse, sizeof(refuse)) == 0);
+
+    socklen_t refuse_len = sizeof(refuse);
+    assert(getsockname(probe, (struct sockaddr *)&refuse, &refuse_len) == 0);
+
+    /* Close the probe socket so the selected port has no listener. */
+    close(probe);
+
+    s = socket(AF_INET, SOCK_STREAM, 0);
+    assert(s >= 0);
 
     errno = 0;
     int ret = connect(s, (struct sockaddr *)&refuse, sizeof(refuse));


### PR DESCRIPTION
## Purpose

This PR makes `networking_tests/deterministic/error_handling_net.c` avoid depending on a fixed loopback port for the `ECONNREFUSED` test case.

The test previously assumed that port `49230` was always closed:

```c
#define PORT_BASE 49230
...
refuse.sin_port = htons(PORT_BASE);
```

This passed locally, but failed repeatedly in GitHub CI at:

```c
error_handling_net.c:77: int main(void): Assertion `ret == -1' failed.
```

The failure happened in the connect() ECONNREFUSED check, suggesting that the fixed port assumption may not be stable in the CI environment.

## Changes

This PR updates the test to:

1. Create a temporary probe socket.
2. Bind it to loopback port 0 so the OS selects an available port.
3. Retrieve the selected port using getsockname().
4. Close the probe socket.
5. Attempt to connect() to that selected closed port and verify ECONNREFUSED.

This preserves the intent of the test while avoiding reliance on a hard-coded port.

## Related Issue

Fixes ##1148

## Testing

Verified locally with Lind:

```c
cd ~/lind-wasm

rm -f tests/unit-tests/networking_tests/deterministic/error_handling_net.cwasm

lind-clang tests/unit-tests/networking_tests/deterministic/error_handling_net.c

cd tests/unit-tests/networking_tests/deterministic
lind-wasm error_handling_net.cwasm
```

Output:

```c
1. EBADF on all operations with fd=-1
2. recv on unconnected socket → ENOTCONN
3. connect to closed port → ECONNREFUSED
4. send after peer close → EPIPE
5. bind same port twice → EADDRINUSE
6. shutdown with invalid 'how' → EINVAL
7. recv after peer SHUT_WR → 0 (EOF)
8. send after own SHUT_WR → EPIPE
All network error handling tests passed
```

Also verified with native gcc:

```c
gcc error_handling_net.c -o /tmp/error_handling_net_native
/tmp/error_handling_net_native
```

Output:

```c
All network error handling tests passed
```