### PR TITLE
Refactor cage_map to allow concurrent access

### DIFF
--- a/benchmarks/cage_stress.c
+++ b/benchmarks/cage_stress.c
@@ -1,0 +1,317 @@
+/*
+ * Microbenchmark for process/cage metadata lookup and fork lifecycle overhead.
+ *
+ * This benchmark measures the cost of several lightweight process-related
+ * syscalls that are expected to exercise the runtime's hot-path cage lookup
+ * logic, including getpid(), getppid(), getuid(), and geteuid().
+ *
+ * It also measures fork() + waitpid() performance, which exercises the heavier
+ * cage lifecycle path: cage ID allocation, child cage creation, parent/child
+ * bookkeeping, child exit, zombie recording, SIGCHLD delivery, waitpid()
+ * wakeup, fd-table cleanup, and final cage removal.
+ *
+ * The benchmark reports total operations, elapsed time, nanoseconds per
+ * operation, and operations per second for each workload. A short warmup phase
+ * is run before the measured section to reduce one-time initialization noise.
+ *
+ * Usage:
+ *   ./benchmark [iters] [forks] [threads]
+ *
+ * Defaults:
+ *   iters   = 1000000
+ *   forks   = 2000
+ *   threads = 4
+ */
+#define _GNU_SOURCE
+#include <errno.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef DEFAULT_ITERS
+#define DEFAULT_ITERS 1000000
+#endif
+
+#ifndef DEFAULT_FORKS
+#define DEFAULT_FORKS 2000
+#endif
+
+#ifndef DEFAULT_THREADS
+#define DEFAULT_THREADS 4
+#endif
+
+static uint64_t now_ns(void) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        perror("clock_gettime");
+        exit(1);
+    }
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+static void print_result(const char *name, uint64_t ops, uint64_t ns) {
+    double sec = (double)ns / 1e9;
+    double ns_per_op = ops ? (double)ns / (double)ops : 0.0;
+    double ops_per_sec = sec > 0.0 ? (double)ops / sec : 0.0;
+
+    printf("%-28s ops=%" PRIu64 " time=%.6f sec ns/op=%.2f ops/sec=%.2f\n",
+           name, ops, sec, ns_per_op, ops_per_sec);
+}
+
+static void bench_getpid_loop(uint64_t iters) {
+    volatile pid_t sink = 0;
+
+    uint64_t start = now_ns();
+
+    for (uint64_t i = 0; i < iters; i++) {
+        sink ^= getpid();
+    }
+
+    uint64_t end = now_ns();
+
+    if (sink == (pid_t)-1) {
+        fprintf(stderr, "impossible sink value\n");
+    }
+
+    print_result("getpid loop", iters, end - start);
+}
+
+static void bench_getppid_loop(uint64_t iters) {
+    volatile pid_t sink = 0;
+
+    uint64_t start = now_ns();
+
+    for (uint64_t i = 0; i < iters; i++) {
+        sink ^= getppid();
+    }
+
+    uint64_t end = now_ns();
+
+    if (sink == (pid_t)-1) {
+        fprintf(stderr, "impossible sink value\n");
+    }
+
+    print_result("getppid loop", iters, end - start);
+}
+
+static void bench_mixed_lookup_loop(uint64_t iters) {
+    volatile long sink = 0;
+
+    uint64_t start = now_ns();
+
+    for (uint64_t i = 0; i < iters; i++) {
+        switch (i & 3) {
+            case 0:
+                sink ^= getpid();
+                break;
+            case 1:
+                sink ^= getppid();
+                break;
+            case 2:
+                sink ^= getuid();
+                break;
+            case 3:
+                sink ^= geteuid();
+                break;
+        }
+    }
+
+    uint64_t end = now_ns();
+
+    if (sink == -1) {
+        fprintf(stderr, "impossible sink value\n");
+    }
+
+    print_result("mixed lookup syscalls", iters, end - start);
+}
+
+static void bench_fork_wait(uint64_t forks) {
+    uint64_t start = now_ns();
+
+    for (uint64_t i = 0; i < forks; i++) {
+        pid_t pid = fork();
+
+        if (pid < 0) {
+            perror("fork");
+            fprintf(stderr, "failed at fork iteration %" PRIu64 "\n", i);
+            exit(1);
+        }
+
+        if (pid == 0) {
+            _exit((int)(i & 0xff));
+        }
+
+        int status = 0;
+        pid_t waited = waitpid(pid, &status, 0);
+        if (waited < 0) {
+            perror("waitpid");
+            exit(1);
+        }
+
+        if (!WIFEXITED(status)) {
+            fprintf(stderr, "child did not exit normally at iteration %" PRIu64 "\n", i);
+            exit(1);
+        }
+
+        if (WEXITSTATUS(status) != (int)(i & 0xff)) {
+            fprintf(stderr,
+                    "bad exit status at iteration %" PRIu64 ": got %d expected %d\n",
+                    i,
+                    WEXITSTATUS(status),
+                    (int)(i & 0xff));
+            exit(1);
+        }
+    }
+
+    uint64_t end = now_ns();
+
+    print_result("fork + waitpid", forks, end - start);
+}
+
+struct thread_arg {
+    uint64_t iters;
+    int tid;
+};
+
+static void *thread_lookup_worker(void *argp) {
+    struct thread_arg *arg = (struct thread_arg *)argp;
+    volatile long sink = arg->tid;
+
+    for (uint64_t i = 0; i < arg->iters; i++) {
+        switch ((i + (uint64_t)arg->tid) & 3) {
+            case 0:
+                sink ^= getpid();
+                break;
+            case 1:
+                sink ^= getppid();
+                break;
+            case 2:
+                sink ^= getuid();
+                break;
+            case 3:
+                sink ^= geteuid();
+                break;
+        }
+    }
+
+    return (void *)(uintptr_t)(sink & 0xff);
+}
+
+static void bench_threaded_lookup(int threads, uint64_t iters_per_thread) {
+    pthread_t *ths = calloc((size_t)threads, sizeof(pthread_t));
+    struct thread_arg *args = calloc((size_t)threads, sizeof(struct thread_arg));
+
+    if (!ths || !args) {
+        perror("calloc");
+        exit(1);
+    }
+
+    uint64_t start = now_ns();
+
+    for (int i = 0; i < threads; i++) {
+        args[i].iters = iters_per_thread;
+        args[i].tid = i;
+
+        int rc = pthread_create(&ths[i], NULL, thread_lookup_worker, &args[i]);
+        if (rc != 0) {
+            errno = rc;
+            perror("pthread_create");
+            exit(1);
+        }
+    }
+
+    for (int i = 0; i < threads; i++) {
+        void *ret = NULL;
+        int rc = pthread_join(ths[i], &ret);
+        if (rc != 0) {
+            errno = rc;
+            perror("pthread_join");
+            exit(1);
+        }
+    }
+
+    uint64_t end = now_ns();
+
+    uint64_t total_ops = (uint64_t)threads * iters_per_thread;
+    print_result("pthread mixed lookup", total_ops, end - start);
+
+    free(ths);
+    free(args);
+}
+
+static void usage(const char *prog) {
+    fprintf(stderr,
+            "usage: %s [iters] [forks] [threads]\n"
+            "\n"
+            "defaults:\n"
+            "  iters   = %d\n"
+            "  forks   = %d\n"
+            "  threads = %d\n"
+            "\n"
+            "examples:\n"
+            "  %s\n"
+            "  %s 10000000 5000 8\n",
+            prog,
+            DEFAULT_ITERS,
+            DEFAULT_FORKS,
+            DEFAULT_THREADS,
+            prog,
+            prog);
+}
+
+int main(int argc, char **argv) {
+    uint64_t iters = DEFAULT_ITERS;
+    uint64_t forks = DEFAULT_FORKS;
+    int threads = DEFAULT_THREADS;
+
+    if (argc > 4) {
+        usage(argv[0]);
+        return 2;
+    }
+
+    if (argc >= 2) {
+        iters = strtoull(argv[1], NULL, 10);
+    }
+
+    if (argc >= 3) {
+        forks = strtoull(argv[2], NULL, 10);
+    }
+
+    if (argc >= 4) {
+        threads = atoi(argv[3]);
+        if (threads <= 0) {
+            fprintf(stderr, "threads must be positive\n");
+            return 2;
+        }
+    }
+
+    printf("pid=%ld iters=%" PRIu64 " forks=%" PRIu64 " threads=%d\n",
+           (long)getpid(), iters, forks, threads);
+
+    /*
+     * Warmup. This reduces one-time initialization noise from the benchmark.
+     */
+    bench_getpid_loop(10000);
+    bench_getppid_loop(10000);
+    bench_mixed_lookup_loop(10000);
+
+    printf("\n--- measured ---\n");
+
+    bench_getpid_loop(iters);
+    bench_getppid_loop(iters);
+    bench_mixed_lookup_loop(iters);
+    bench_threaded_lookup(threads, iters / (uint64_t)threads);
+    bench_fork_wait(forks);
+
+    return 0;
+}

--- a/src/cage/src/cage.rs
+++ b/src/cage/src/cage.rs
@@ -3,14 +3,14 @@
 //! finialization required by wasmtime
 use crate::memory::vmmap::*;
 use crate::timer::*;
+use arc_swap::ArcSwapOption;
 use dashmap::DashMap;
-pub use once_cell::sync::Lazy;
 /// Uses spinlocks first (for short waits) and parks threads when blocking to reduce kernel
 /// interaction and increases efficiency.
 pub use parking_lot::{Mutex, RwLock};
 pub use std::path::{Path, PathBuf};
 pub use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64, Ordering};
-pub use std::sync::Arc;
+pub use std::sync::{Arc, LazyLock};
 use sysdefs::constants::lind_platform_const::MAX_CAGEID;
 use sysdefs::constants::sys_const::EXIT_SUCCESS;
 use sysdefs::constants::SIGCHLD;
@@ -258,25 +258,18 @@ pub struct Cage {
     pub grate_inflight: AtomicU64,
 }
 
-/// We achieve an O(1) complexity for our cage map implementation through the following three approaches:
+/// Global cage table indexed by cage ID.
 ///
-/// Direct Indexing with `cageid`:
-///     `cageid` directly as the index to access the `Vec`, allowing O(1) complexity for lookup, insertion,
-///     and deletion.
-/// `Vec<Option<Arc<Cage>>>` for Efficient Deletion:
-///     When deleting an entry, we replace it with `None` instead of restructuring the `Vec`. If we were to
-///     use `Vec<Arc<Cage>>`, there would be no empty slots after deletion, forcing us to use `retain()` to
-///     reallocate the `Vec`, which results in O(n) complexity. Using `Vec<Option<Arc<Cage>>>` allows us to
-///     maintain O(1) deletion complexity.
-/// `RwLock` for Concurrent Access Control:
-///     `RwLock` ensures thread-safe access to `CAGE_MAP`, providing control over concurrent reads and writes.
-///     Since writes occur only during initialization (`lindrustinit`) and `fork()` / `exec()`, and deletions
-///     happen only via `exit()`, the additional overhead introduced by `RwLock` should be minimal in terms
-///     of overall performance impact.
+/// Each slot stores an optional `Arc<Cage>` using `ArcSwapOption`, allowing
+/// readers to load cage references concurrently without taking a lock.
 ///
-/// Pre-allocate MAX_CAGEID elements, all initialized to None.
-
-pub static mut CAGE_MAP: Vec<Option<Arc<Cage>>> = Vec::new();
+/// Empty slots represent unused or finalized cage IDs. A cage is inserted
+/// with `add_cage()` and removed with `remove_cage()` during final teardown.
+///
+/// The table is lazily initialized on first use and contains one slot for
+/// every valid cage ID in `0..MAX_CAGEID`.
+pub static CAGE_MAP: LazyLock<Vec<ArcSwapOption<Cage>>> =
+    LazyLock::new(|| (0..MAX_CAGEID).map(|_| ArcSwapOption::empty()).collect());
 
 pub fn check_cageid(cageid: u64) {
     if cageid >= MAX_CAGEID as u64 {
@@ -284,37 +277,28 @@ pub fn check_cageid(cageid: u64) {
     }
 }
 
-#[allow(static_mut_refs)]
-// SAFETY: This code is single-threaded during initialization, and no other
-// mutable or immutable references to `CAGE_MAP` exist while this call executes.
 pub fn cagetable_init() {
-    unsafe {
-        for _cage in 0..MAX_CAGEID {
-            CAGE_MAP.push(None);
-        }
-    }
+    LazyLock::force(&CAGE_MAP);
 }
 
 pub fn add_cage(cageid: u64, cage: Cage) {
     check_cageid(cageid);
-    let _insertret = unsafe { CAGE_MAP[cageid as usize].insert(Arc::new(cage)) };
+
+    CAGE_MAP[cageid as usize].store(Some(Arc::new(cage)));
 }
 
 pub fn remove_cage(cageid: u64) {
     check_cageid(cageid);
-    unsafe { CAGE_MAP[cageid as usize].take() };
+
+    CAGE_MAP[cageid as usize].store(None);
 }
 
 pub fn get_cage(cageid: u64) -> Option<Arc<Cage>> {
     if cageid >= MAX_CAGEID as u64 {
         return None;
     }
-    unsafe {
-        match CAGE_MAP[cageid as usize].as_ref() {
-            Some(cage) => Some(cage.clone()),
-            None => None,
-        }
-    }
+
+    CAGE_MAP[cageid as usize].load_full()
 }
 
 /// Borrows the `cageid` cage and applies a function `f` to it, return `Some(R)` or `None`
@@ -333,21 +317,20 @@ where
         return None;
     }
 
-    unsafe { CAGE_MAP[cageid as usize].as_deref().map(f) }
+    let guard = CAGE_MAP[cageid as usize].load();
+
+    guard.as_deref().map(f)
 }
 
-#[allow(static_mut_refs)]
 // SAFETY: This code is single-threaded during teardown, and no other
 // mutable or immutable references to `CAGE_MAP` exist while this call executes.
 pub fn cagetable_clear() -> Vec<usize> {
     let mut exitvec = Vec::new();
 
-    unsafe {
-        for (cageid, cage) in CAGE_MAP.iter_mut().enumerate() {
-            let cageopt = cage.take();
-            if !cageopt.is_none() {
-                exitvec.push(cageid)
-            }
+    for (cageid, slot) in CAGE_MAP.iter().enumerate() {
+        let old = slot.swap(None);
+        if old.is_some() {
+            exitvec.push(cageid);
         }
     }
 


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Resolves #1050 

This PR replaces the unsynchronized mutable slot with `ArcSwapOption<Cage>`, so each cage table entry can be atomically loaded, replaced, or cleared. This removes the data race between concurrent lookup and removal while preserving O(1) indexed lookup by cage ID.

## Performance Impact

Raw implementation:

```sh
lind@de860ae5950e:~/lind-wasm$ ./scripts/lind_run cage_stress.cwasm 1000000 2000 4
pid=1 iters=1000000 forks=2000 threads=4
getpid loop                  ops=10000 time=0.001481 sec ns/op=148.13 ops/sec=6750640.13
getppid loop                 ops=10000 time=0.001490 sec ns/op=148.98 ops/sec=6712522.14
mixed lookup syscalls        ops=10000 time=0.002143 sec ns/op=214.30 ops/sec=4666312.03

--- measured ---
getpid loop                  ops=1000000 time=0.228167 sec ns/op=228.17 ops/sec=4382761.08
getppid loop                 ops=1000000 time=0.145727 sec ns/op=145.73 ops/sec=6862161.60
mixed lookup syscalls        ops=1000000 time=0.203926 sec ns/op=203.93 ops/sec=4903746.16
pthread mixed lookup         ops=1000000 time=0.180652 sec ns/op=180.65 ops/sec=5535506.87
fork + waitpid               ops=2000 time=18.764816 sec ns/op=9382408.15 ops/sec=106.58
```

ArcSwap implementation:

```sh
lind@de860ae5950e:~/lind-wasm$ ./scripts/lind_run cage_stress.cwasm 1000000 2000 4
pid=1 iters=1000000 forks=2000 threads=4
getpid loop                  ops=10000 time=0.008866 sec ns/op=886.60 ops/sec=1127902.57
getppid loop                 ops=10000 time=0.001904 sec ns/op=190.36 ops/sec=5253301.04
mixed lookup syscalls        ops=10000 time=0.009859 sec ns/op=985.93 ops/sec=1014268.32

--- measured ---
getpid loop                  ops=1000000 time=0.280564 sec ns/op=280.56 ops/sec=3564254.95
getppid loop                 ops=1000000 time=0.189801 sec ns/op=189.80 ops/sec=5268670.14
mixed lookup syscalls        ops=1000000 time=0.270599 sec ns/op=270.60 ops/sec=3695504.31
pthread mixed lookup         ops=1000000 time=0.193474 sec ns/op=193.47 ops/sec=5168659.70
fork + waitpid               ops=2000 time=18.503752 sec ns/op=9251875.85 ops/sec=108.09
```

This change does introduce measurable overhead on lightweight metadata syscall paths where cage lookup dominates the operation cost. The overhead is most visible in very lightweight syscalls such as getpid(), getppid(), getuid(), and geteuid(), because these calls do little work besides runtime metadata lookup.

The fork + waitpid lifecycle benchmark does not show a measurable regression.

## Future Optimization

There is still room to optimize cage lookup after the remaining exit-handling issues #1072 are resolved. In particular, once we can guarantee cage lifetime through 3i. For example, by ensuring that a cage cannot be removed while a grate dispatch or syscall path is still using it, we may be able to optimize hot-path lookup further.