### PR TITLE
fdtables: select impl via Cargo features instead of include!()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,9 +170,10 @@ md_generation:
 lint:
 	cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
 	cargo fmt --check --all --manifest-path src/lind-boot/Cargo.toml
-	rustfmt --check src/fdtables/src/muthashmaxglobal.rs \
-	    src/fdtables/src/vanillaglobal.rs \
-	    src/fdtables/src/dashmapvecglobal.rs
+	rustfmt --check src/fdtables/src/dashmaparrayglobal.rs \
+	    src/fdtables/src/dashmapvecglobal.rs \
+	    src/fdtables/src/muthashmaxglobal.rs \
+	    src/fdtables/src/vanillaglobal.rs
 	cargo clippy \
 	    --manifest-path src/lind-boot/Cargo.toml \
 	    --all-features \
@@ -186,9 +187,10 @@ lint:
 format:
 	cargo fmt --all --manifest-path src/wasmtime/Cargo.toml
 	cargo fmt --all --manifest-path src/lind-boot/Cargo.toml
-	rustfmt src/fdtables/src/muthashmaxglobal.rs \
-	    src/fdtables/src/vanillaglobal.rs \
-	    src/fdtables/src/dashmapvecglobal.rs
+	rustfmt src/fdtables/src/dashmaparrayglobal.rs \
+	    src/fdtables/src/dashmapvecglobal.rs \
+	    src/fdtables/src/muthashmaxglobal.rs \
+	    src/fdtables/src/vanillaglobal.rs
  
 
 .PHONY: docs-serve

--- a/src/fdtables/Cargo.toml
+++ b/src/fdtables/Cargo.toml
@@ -9,6 +9,15 @@ license = "Apache-2.0"
 keywords = ["lind"]
 categories = ["os", "filesystem"]
 
+[features]
+# Pick exactly one. `dashmaparray` matches the historical default that was
+# previously hard-coded via src/current_impl.
+default = ["dashmaparray"]
+dashmaparray = []
+dashmapvec = []
+muthashmax = []
+vanilla = []
+
 [dependencies]
 libc = "0.2"
 dashmap = { version = "5.1", features=["serde"] }

--- a/src/fdtables/src/current_impl
+++ b/src/fdtables/src/current_impl
@@ -1,2 +1,0 @@
-pub mod dashmaparrayglobal;
-pub use crate::dashmaparrayglobal::*;

--- a/src/fdtables/src/lib.rs
+++ b/src/fdtables/src/lib.rs
@@ -112,8 +112,55 @@
 //       ENFILE The system-wide limit on the total number of open files
 //              has been reached. (mostly unimplemented)
 
-// This includes the specific implementation of the algorithm chosen.
-include!("current_impl");
+// The specific implementation of the algorithm is selected via a Cargo feature
+// (see Cargo.toml `[features]`). Exactly one impl feature must be enabled; the
+// default is `dashmaparray`. To switch, build with e.g.
+//   cargo build --no-default-features --features muthashmax
+
+#[cfg(not(any(
+    feature = "dashmaparray",
+    feature = "dashmapvec",
+    feature = "muthashmax",
+    feature = "vanilla",
+)))]
+compile_error!(
+    "fdtables: no impl feature enabled; pick exactly one of \
+     `dashmaparray`, `dashmapvec`, `muthashmax`, or `vanilla`"
+);
+
+#[cfg(any(
+    all(feature = "dashmaparray", feature = "dashmapvec"),
+    all(feature = "dashmaparray", feature = "muthashmax"),
+    all(feature = "dashmaparray", feature = "vanilla"),
+    all(feature = "dashmapvec", feature = "muthashmax"),
+    all(feature = "dashmapvec", feature = "vanilla"),
+    all(feature = "muthashmax", feature = "vanilla"),
+))]
+compile_error!(
+    "fdtables: more than one impl feature enabled; pick exactly one of \
+     `dashmaparray`, `dashmapvec`, `muthashmax`, or `vanilla` \
+     (use --no-default-features when overriding the default)"
+);
+
+#[cfg(feature = "dashmaparray")]
+mod dashmaparrayglobal;
+#[cfg(feature = "dashmaparray")]
+pub use dashmaparrayglobal::*;
+
+#[cfg(feature = "dashmapvec")]
+mod dashmapvecglobal;
+#[cfg(feature = "dashmapvec")]
+pub use dashmapvecglobal::*;
+
+#[cfg(feature = "muthashmax")]
+mod muthashmaxglobal;
+#[cfg(feature = "muthashmax")]
+pub use muthashmaxglobal::*;
+
+#[cfg(feature = "vanilla")]
+mod vanillaglobal;
+#[cfg(feature = "vanilla")]
+pub use vanillaglobal::*;
 
 // This includes general constants and definitions for things that are
 // needed everywhere, like FDTableEntry.  I use the * import here to flatten


### PR DESCRIPTION
Replaces the hand-edited extensionless `src/current_impl` file with a `[features]` block in Cargo.toml plus `#[cfg(feature = ...)]` gates in lib.rs. Compile-time guards emit a clear error when zero or more than one impl feature is enabled.

Switch impl with e.g.:
  cargo build --no-default-features --features muthashmax

Also fixes the Makefile lint/format targets, which previously formatted three impls but skipped `dashmaparrayglobal.rs` — the one actually in use under the old default.

