### PR TITLE
fdtables: bump highestneverusedfd in get_specific_virtual_fd

### DIFF
--- a/src/fdtables/src/lib.rs
+++ b/src/fdtables/src/lib.rs
@@ -741,6 +741,51 @@ mod tests {
     }
 
     #[test]
+    // Regression: after reserving fds via get_specific_virtual_fd, a
+    // subsequent get_unused_virtual_fd must not hand back one of the
+    // reserved fds.
+    //
+    // In the muthashmax backend, get_specific_virtual_fd previously
+    // didn't bump `highestneverusedfd`, so the get_unused_virtual_fd
+    // fast path would re-issue fd 0, 1, 2... and silently clobber the
+    // reservations. This surfaced in the IPC grate's preexec reserving
+    // stdio: the user binary's first pipe() call would overwrite stdin
+    // and stdout, sending printf into the pipe. The other backends scan
+    // for a vacant slot so this regression is impossible there, but the
+    // test exercises the contract for all of them.
+    fn get_specific_then_get_unused_does_not_reuse_fd() {
+        let mut _thelock = TESTMUTEX.lock().unwrap_or_else(|e| {
+            refresh();
+            TESTMUTEX.clear_poison();
+            e.into_inner()
+        });
+        refresh();
+
+        let cage_id = threei::TESTING_CAGEID;
+
+        // Reserve fds 0, 1, 2 (e.g. stdio) via get_specific_virtual_fd.
+        get_specific_virtual_fd(cage_id, 0, 0, 100, false, 0).unwrap();
+        get_specific_virtual_fd(cage_id, 1, 0, 101, false, 0).unwrap();
+        get_specific_virtual_fd(cage_id, 2, 0, 102, false, 0).unwrap();
+
+        // The next three get_unused_virtual_fd calls must skip the
+        // reserved slots.
+        for _ in 0..3 {
+            let fd = get_unused_virtual_fd(cage_id, 0, 200, false, 0).unwrap();
+            assert!(
+                fd >= 3,
+                "get_unused_virtual_fd returned reserved fd {} after get_specific_virtual_fd",
+                fd
+            );
+        }
+
+        // Reservations survive untouched.
+        assert_eq!(translate_virtual_fd(cage_id, 0).unwrap().underfd, 100);
+        assert_eq!(translate_virtual_fd(cage_id, 1).unwrap().underfd, 101);
+        assert_eq!(translate_virtual_fd(cage_id, 2).unwrap().underfd, 102);
+    }
+
+    #[test]
     // check some common poll cases...
     fn check_poll_helpers() {
         let mut _thelock: MutexGuard<bool>;

--- a/src/fdtables/src/muthashmaxglobal.rs
+++ b/src/fdtables/src/muthashmaxglobal.rs
@@ -273,11 +273,14 @@ pub fn get_specific_virtual_fd(
     _increment_fdcount(myentry);
 
     // always add the new entry.  insert returns the old entry.
-    let myoptionentry = fdtable
-        .get_mut(&cageid)
-        .unwrap()
-        .thisfdtable
-        .insert(requested_virtualfd, myentry);
+    let myfdentry = fdtable.get_mut(&cageid).unwrap();
+    let myoptionentry = myfdentry.thisfdtable.insert(requested_virtualfd, myentry);
+    // Bump highestneverusedfd past requested_virtualfd so the
+    // get_unused_virtual_fd fast path doesn't later hand out an fd
+    // that we just reserved here (e.g. stdio fds 0/1/2).
+    if requested_virtualfd >= myfdentry.highestneverusedfd {
+        myfdentry.highestneverusedfd = requested_virtualfd + 1;
+    }
     drop(fdtable);
 
     // Update the fdcount / close the old entry, if existed


### PR DESCRIPTION
`get_unused_virtual_fd` (muthashmax fast path) hands out the next fd at `highestneverusedfd` and increments it. `get_specific_virtual_fd` inserted at the requested fd but never updated the counter, so a caller that reserves stdio (e.g. fds 0/1/2) followed by an `get_unused_virtual_fd` would silently overwrite those reserved slots with the new entry — observed in the IPC grate's preexec where stdio got hijacked by the first user pipe().

Other backends (`vanillaglobal`, `dashmaparrayglobal`, `dashmapvecglobal`) linear-scan for a vacant slot and don't have this issue.
