### PR TITLE
Expose fdtables backend selector via FDTABLES_IMPL

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,11 +40,15 @@ jobs:
 
       - name: Clippy
         run: |
-          # Run clippy over lind-boot and its dependencies
+          # Run clippy over lind-boot and its dependencies.
+          # Note: --all-features can't be used because it would enable every
+          # fdtables-* impl simultaneously, tripping the fdtables impl-mutex
+          # compile_error guard. Enumerate the non-fdtables features explicitly
+          # and pin to the default fdtables impl.
           # See `cargo clippy` and `cargo check` for available options
           cargo clippy \
               --manifest-path src/lind-boot/Cargo.toml \
-              --all-features \
+              --features "disable_signals secure lind_debug debug-dylink debug-grate-calls fdtables-dashmaparray" \
               --keep-going \
               -- \
               -A warnings \

--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,13 @@ lint:
 	    src/fdtables/src/dashmapvecglobal.rs \
 	    src/fdtables/src/muthashmaxglobal.rs \
 	    src/fdtables/src/vanillaglobal.rs
+	# Note: --all-features can't be used here because it enables every
+	# fdtables-* impl simultaneously, which trips the fdtables impl-mutex
+	# compile_error guard. Enumerate the non-fdtables features explicitly
+	# and pin to the default fdtables impl.
 	cargo clippy \
 	    --manifest-path src/lind-boot/Cargo.toml \
-	    --all-features \
+	    --features "disable_signals secure lind_debug debug-dylink debug-grate-calls fdtables-dashmaparray" \
 	    --keep-going \
 	    -- \
 	    -A warnings \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ sysroot: build-dir
 # fdtables backend selector. One of: dashmaparray (default), dashmapvec,
 # muthashmax, vanilla. Threaded through lind-boot -> rawposix -> fdtables
 # via Cargo features.
+#
+# Examples:
+#   make                                  # default (dashmaparray)
+#   make build FDTABLES_IMPL=muthashmax   # full build with muthashmax
+#   make lind-boot FDTABLES_IMPL=vanilla  # rebuild only lind-boot with vanilla
+#   make fpcast FDTABLES_IMPL=dashmapvec  # fpcast variant with dashmapvec
+#   make lind-debug FDTABLES_IMPL=muthashmax   # debug build with muthashmax
+#   FDTABLES_IMPL=muthashmax make         # also works via env var
 FDTABLES_IMPL ?= dashmaparray
 
 .PHONY: lind-boot

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,16 @@ sysroot: build-dir
 	./scripts/make_glibc_and_sysroot.sh $(if $(WITH_FPCAST),--with-fpcast)
 	$(MAKE) sync-sysroot
 
+# fdtables backend selector. One of: dashmaparray (default), dashmapvec,
+# muthashmax, vanilla. Threaded through lind-boot -> rawposix -> fdtables
+# via Cargo features.
+FDTABLES_IMPL ?= dashmaparray
+
 .PHONY: lind-boot
 lind-boot: build-dir
 	# Build lind-boot with `--release` flag for faster runtime (e.g. for tests)
-	cargo build --manifest-path src/lind-boot/Cargo.toml --release
+	cargo build --manifest-path src/lind-boot/Cargo.toml --release \
+	    --no-default-features --features fdtables-$(FDTABLES_IMPL)
 	cp src/lind-boot/target/release/lind-boot $(LINDBOOT_BIN)
 
 .PHONY: lindfs
@@ -70,7 +76,8 @@ clean-lindfs:
 .PHONY: lind-debug
 lind-debug: lindfs build-dir
 	# Build lind-boot with the lind_debug feature enabled
-	cargo build --manifest-path src/lind-boot/Cargo.toml --features lind_debug
+	cargo build --manifest-path src/lind-boot/Cargo.toml \
+	    --no-default-features --features "lind_debug fdtables-$(FDTABLES_IMPL)"
 	cp src/lind-boot/target/debug/lind-boot $(LINDBOOT_BIN)
 
 	# Build glibc with LIND_DEBUG enabled (by setting the LIND_DEBUG variable)

--- a/src/cage/Cargo.toml
+++ b/src/cage/Cargo.toml
@@ -8,7 +8,7 @@ sysdefs = { path = "../sysdefs" }
 libc = "0.2"
 nodit = "0.9.2" # Used for VMMAP
 quick_cache = "0.6.9"
-fdtables = { path = "../fdtables" }
+fdtables = { path = "../fdtables", default-features = false }
 once_cell = "1.18" 
 parking_lot = "0.12"
 dashmap = { version = "5.1", features=["serde"] }

--- a/src/lind-boot/Cargo.toml
+++ b/src/lind-boot/Cargo.toml
@@ -4,11 +4,17 @@ version = "0.1.0"
 edition = "2024"
 
 [features]
+default = ["fdtables-dashmaparray"]
 disable_signals = ["cage/disable_signals", "wasmtime-lind-multi-process/disable_signals"]
 secure = ["typemap/secure"]
 lind_debug = ["wasmtime-lind-common/lind_debug", "cage/lind_debug" ]
 debug-dylink = ["wasmtime-lind-dylink/debug-dylink", "wasmtime-lind-multi-process/debug-dylink", "wasmtime-lind-utils/debug-dylink", "wasmtime/debug-dylink"]
 debug-grate-calls = ["wasmtime-lind-3i/debug-grate-calls"]
+# Pass-through selectors for the fdtables backend. Pick exactly one.
+fdtables-dashmaparray = ["rawposix/fdtables-dashmaparray"]
+fdtables-dashmapvec = ["rawposix/fdtables-dashmapvec"]
+fdtables-muthashmax = ["rawposix/fdtables-muthashmax"]
+fdtables-vanilla = ["rawposix/fdtables-vanilla"]
 
 [dependencies]
 wasmtime-lind-common = { path = "../wasmtime/crates/lind-common" }

--- a/src/rawposix/Cargo.toml
+++ b/src/rawposix/Cargo.toml
@@ -11,7 +11,7 @@ libc = "0.2"
 parking_lot = "0.12"
 tracing = "0.1" 
 tracing-subscriber = "0.3"
-fdtables = { path = "../fdtables" }
+fdtables = { path = "../fdtables", default-features = false }
 sysdefs = { path = "../sysdefs" }
 typemap = { path = "../typemap" }
 cage = { path = "../cage" }
@@ -21,5 +21,12 @@ threei = { path = "../threei" }
 default = ["fast"]
 fast = []
 secure = []
+# Pass-through selectors for the fdtables backend. Exactly one must be
+# enabled by a downstream crate (lind-boot) — rawposix on its own won't
+# compile without one of these because fdtables itself has no default.
+fdtables-dashmaparray = ["fdtables/dashmaparray"]
+fdtables-dashmapvec = ["fdtables/dashmapvec"]
+fdtables-muthashmax = ["fdtables/muthashmax"]
+fdtables-vanilla = ["fdtables/vanilla"]
 
 [dev-dependencies]

--- a/src/typemap/Cargo.toml
+++ b/src/typemap/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 libc = "0.2"
-fdtables = { path = "../fdtables" }
+fdtables = { path = "../fdtables", default-features = false }
 cage = { path = "../cage" }
 sysdefs = { path = "../sysdefs" }
 

--- a/src/wasmtime/Cargo.toml
+++ b/src/wasmtime/Cargo.toml
@@ -234,7 +234,7 @@ test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 threei = { path = "crates/threei" }
 rawposix = { path = "crates/rawposix" }
 typemap = { path = "crates/typemap", default-features = false }
-fdtables = { path = "crates/fdtables" }
+fdtables = { path = "crates/fdtables", default-features = false }
 sysdefs = { path = "crates/sysdefs" }
 cage = { path = "crates/cage" }
 


### PR DESCRIPTION
Adds passthrough Cargo features in rawposix and lind-boot so the fdtables impl picked by the fdtables crate's `default = ["dashmaparray"]` can be overridden from a single Makefile knob:

    make build                              # uses dashmaparray (default)
    make build FDTABLES_IMPL=muthashmax     # switches to muthashmax
    make lind-debug FDTABLES_IMPL=vanilla   # also propagates

Mechanically: every workspace crate that depends on fdtables now does so with `default-features = false`, otherwise Cargo's feature unification re-enables `dashmaparray` alongside whatever override the user picked, tripping the fdtables compile_error guard. lind-boot's own `default` feature picks `dashmaparray` so plain `cargo build` still works.

Verified all four impls compile via the override path.
