### PR TITLE
getsockopt: translate guest pointers in glibc, drop redundant rawposix translation

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/getsockopt.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/getsockopt.c
@@ -22,12 +22,16 @@
 #include <socket-constants-time64.h>
 #include <syscall-template.h>
 #include <lind_syscall_num.h>
+#include <addr_translation.h>
 
 static int
 getsockopt_syscall (int fd, int level, int optname, void *optval,
 		    socklen_t *len)
 {
-  return MAKE_LEGACY_SYSCALL(GETSOCKOPT_SYSCALL, "syscall|getsockopt", (uint64_t)fd, (uint64_t)level, (uint64_t)optname, (uint64_t)optval, (uint64_t)len, NOTUSED, TRANSLATE_ERRNO_ON);
+  uint64_t host_optval = TRANSLATE_GUEST_POINTER_TO_HOST (optval);
+  uint64_t host_len = TRANSLATE_GUEST_POINTER_TO_HOST (len);
+
+  return MAKE_LEGACY_SYSCALL(GETSOCKOPT_SYSCALL, "syscall|getsockopt", (uint64_t)fd, (uint64_t)level, (uint64_t)optname, host_optval, host_len, NOTUSED, TRANSLATE_ERRNO_ON);
 }
 
 #ifndef __ASSUME_TIME64_SYSCALLS

--- a/src/rawposix/src/net_calls.rs
+++ b/src/rawposix/src/net_calls.rs
@@ -1969,17 +1969,21 @@ pub extern "C" fn getsockopt_syscall(
     optname_arg: u64,
     optname_cageid: u64,
     optval_arg: u64,
-    optval_cageid: u64,
+    _optval_cageid: u64,
     optlen_arg: u64,
-    optlen_cageid: u64,
+    _optlen_cageid: u64,
     arg6: u64,
     arg6_cageid: u64,
 ) -> i32 {
     let fd = convert_fd_to_host(fd_arg, fd_cageid, cageid);
     let level = sc_convert_sysarg_to_i32(level_arg, level_cageid, cageid);
     let optname = sc_convert_sysarg_to_i32(optname_arg, optname_cageid, cageid);
-    let optval = sc_convert_uaddr_to_host(optval_arg, optval_cageid, cageid) as *mut c_void;
-    let optlen = sc_convert_uaddr_to_host(optlen_arg, optlen_cageid, cageid) as *mut socklen_t;
+    // optval/optlen arrive as already-translated host pointers from glibc's
+    // getsockopt.c (matches setsockopt/sendto/recvfrom).  Re-translating here
+    // would break the grate forwarding path, where the grate has no way to
+    // translate cage offsets and relies on glibc having done so.
+    let optval = optval_arg as *mut c_void;
+    let optlen = optlen_arg as *mut socklen_t;
 
     // would check when `secure` flag has been set during compilation,
     // no-op by default


### PR DESCRIPTION

Glibc's getsockopt.c was passing raw wasm32 offsets for optval/optlen to MAKE_LEGACY_SYSCALL.  RawPOSIX's getsockopt_syscall worked around this host-side via sc_convert_uaddr_to_host, but that path isn't reachable when a grate intercepts and forwards the call: the grate has no access to the calling cage's __lind_base, so any forwarded args reach rawposix as untranslated cage offsets.

This brings getsockopt in line with setsockopt/sendto/recvfrom: glibc calls TRANSLATE_GUEST_POINTER_TO_HOST on optval and optlen before the syscall, and rawposix accepts already-host pointers.  The grate path now works because the host pointer is opaque to the grate but valid for the eventual libc::getsockopt call.

