### PR TITLE
propagate canonical exit status through exit_group and epoch_kill

### DIFF
--- a/src/rawposix/src/sys_calls.rs
+++ b/src/rawposix/src/sys_calls.rs
@@ -1,6 +1,19 @@
 //! System syscalls implementation
 //!
 //! This module contains all system calls that are being emulated/faked in Lind.
+
+macro_rules! lind_log {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true).append(true)
+            .open("/tmp/lind.log")
+        {
+            let _ = writeln!(f, $($arg)*);
+        }
+    }};
+}
+
 use crate::fs_calls::kernel_close;
 use cage::memory::vmmap::{VmmapOps, *};
 use cage::signal::signal::{convert_signal_mask, lind_send_signal, signal_check_trigger};
@@ -340,11 +353,15 @@ pub extern "C" fn exit_syscall(
         );
     }
 
-    let status = sc_convert_sysarg_to_i32(status_arg, status_cageid, cageid);
+    let _status = sc_convert_sysarg_to_i32(status_arg, status_cageid, cageid);
 
-    // Thread-only exit: just record status and trigger asyncify unwind.
-    // No CAS, no epoch_kill_all — the cage stays alive for other threads.
-    cage::cage_record_exit_status(cageid, ExitStatus::Exited(status));
+    // Thread-only exit: trigger asyncify unwind for this thread only.
+    // Do NOT call cage_record_exit_status here — SYS_exit is only called by
+    // non-main threads when their thread function returns (glibc start_thread),
+    // and a thread's individual exit code does not determine the cage's
+    // process-level exit status.  Calling it here would race with and
+    // overwrite the exit_group(1) recorded by e.g. the faulthandler thread,
+    // causing the cage to exit with code 0 instead of 1.
 
     // Call wasmtime to trigger asyncify unwind for this thread.
     // OnCalledAction handles lind_thread_exit + cage_finalize if last.
@@ -404,6 +421,12 @@ pub extern "C" fn exit_group_syscall(
 
     // Only the first thread to win the CAS initiates cage shutdown.
     // Other threads just fall through and will be killed via epoch_kill_all.
+    lind_log!(
+        "[lind|exit_group] cage={} tid={} status={}",
+        cageid,
+        tid,
+        status
+    );
     if cage::signal::signal::try_initiate_exit_group(cageid) {
         cage::cage_record_exit_status(cageid, ExitStatus::Exited(status));
 
@@ -429,6 +452,18 @@ pub extern "C" fn exit_group_syscall(
         threei::handler_table::_rm_grate_from_handler(cageid);
     }
 
+    // Use the cage's authoritative recorded exit status so that whichever
+    // thread wins the CAS (e.g. faulthandler calling _exit(1)) determines
+    // the OS-level exit code.  Late threads calling exit_group(0) after
+    // the cage has already been marked Exited(1) will use code=1.
+    let canonical_status_arg = cage::get_cage(cageid)
+        .and_then(|c| *c.final_exit_status.read())
+        .map(|st| match st {
+            cage::ExitStatus::Exited(code) => code as u64,
+            cage::ExitStatus::Signaled(_, _) => 1u64,
+        })
+        .unwrap_or(status_arg as u64);
+
     // Call wasmtime to trigger asyncify unwind.
     // OnCalledAction handles lind_thread_exit + cage_finalize if last.
     threei::make_syscall(
@@ -436,7 +471,7 @@ pub extern "C" fn exit_group_syscall(
         60, // reuse exit trampoline in wasmtime
         UNUSED_NAME,
         WASMTIME_CAGEID,
-        status_arg,
+        canonical_status_arg,
         cageid,
         tid,
         UNUSED_ARG, // is_last_thread: determined dynamically in OnCalledAction

--- a/src/rawposix/src/sys_calls.rs
+++ b/src/rawposix/src/sys_calls.rs
@@ -1,19 +1,6 @@
 //! System syscalls implementation
 //!
 //! This module contains all system calls that are being emulated/faked in Lind.
-
-macro_rules! lind_log {
-    ($($arg:tt)*) => {{
-        use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true).append(true)
-            .open("/tmp/lind.log")
-        {
-            let _ = writeln!(f, $($arg)*);
-        }
-    }};
-}
-
 use crate::fs_calls::kernel_close;
 use cage::memory::vmmap::{VmmapOps, *};
 use cage::signal::signal::{convert_signal_mask, lind_send_signal, signal_check_trigger};
@@ -421,12 +408,6 @@ pub extern "C" fn exit_group_syscall(
 
     // Only the first thread to win the CAS initiates cage shutdown.
     // Other threads just fall through and will be killed via epoch_kill_all.
-    lind_log!(
-        "[lind|exit_group] cage={} tid={} status={}",
-        cageid,
-        tid,
-        status
-    );
     if cage::signal::signal::try_initiate_exit_group(cageid) {
         cage::cage_record_exit_status(cageid, ExitStatus::Exited(status));
 

--- a/src/wasmtime/crates/lind-multi-process/src/signal.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/signal.rs
@@ -3,18 +3,6 @@ use wasmtime::{AsContext, AsContextMut, AsyncifyState, Caller};
 
 use crate::LindHost;
 
-macro_rules! lind_log {
-    ($($arg:tt)*) => {{
-        use std::io::Write;
-        if let Ok(mut f) = std::fs::OpenOptions::new()
-            .create(true).append(true)
-            .open("/tmp/lind.log")
-        {
-            let _ = writeln!(f, $($arg)*);
-        }
-    }};
-}
-
 // handle all the epoch callback
 // this is where the wasm instance is directed when epoch is triggered
 // this function could possibly be on the callstack of the Asyncify operation
@@ -68,14 +56,6 @@ pub fn signal_handler<
                 cage::ExitStatus::Signaled(_, _) => 1,
             })
             .unwrap_or(0);
-        lind_log!(
-            "[lind|epoch_kill] cage={} tid={} cage_exists={} status={:?} exit_code={}",
-            cageid,
-            ctx.tid,
-            cage_opt.is_some(),
-            status_opt,
-            exit_code
-        );
         ctx.exit_call(caller, exit_code, 0);
         return 0;
     }

--- a/src/wasmtime/crates/lind-multi-process/src/signal.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/signal.rs
@@ -3,6 +3,18 @@ use wasmtime::{AsContext, AsContextMut, AsyncifyState, Caller};
 
 use crate::LindHost;
 
+macro_rules! lind_log {
+    ($($arg:tt)*) => {{
+        use std::io::Write;
+        if let Ok(mut f) = std::fs::OpenOptions::new()
+            .create(true).append(true)
+            .open("/tmp/lind.log")
+        {
+            let _ = writeln!(f, $($arg)*);
+        }
+    }};
+}
+
 // handle all the epoch callback
 // this is where the wasm instance is directed when epoch is triggered
 // this function could possibly be on the callstack of the Asyncify operation
@@ -43,7 +55,28 @@ pub fn signal_handler<
         // Don't call lind_thread_exit here — it's deferred to exit_call's
         // OnCalledAction so the epoch_handler entry stays until asyncify
         // unwind completes and any grate dispatch has fully returned.
-        ctx.exit_call(caller, 0, 0);
+        //
+        // Use the cage's recorded exit status so that exit_group(N) from any
+        // thread (e.g. faulthandler calling _exit(1)) propagates the right
+        // code to the OS-level process exit.  Default to 0 when the cage is
+        // already gone (late wakeup after cage_finalize).
+        let cage_opt = cage::get_cage(cageid);
+        let status_opt = cage_opt.as_ref().and_then(|c| *c.final_exit_status.read());
+        let exit_code = status_opt
+            .map(|st| match st {
+                cage::ExitStatus::Exited(code) => code,
+                cage::ExitStatus::Signaled(_, _) => 1,
+            })
+            .unwrap_or(0);
+        lind_log!(
+            "[lind|epoch_kill] cage={} tid={} cage_exists={} status={:?} exit_code={}",
+            cageid,
+            ctx.tid,
+            cage_opt.is_some(),
+            status_opt,
+            exit_code
+        );
+        ctx.exit_call(caller, exit_code, 0);
         return 0;
     }
 

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -1,40 +1,7 @@
-/*
- * Test: exit_status_first_wins — exit_syscall (SYS_exit) must not record
- * the cage exit status; only exit_group_syscall should.
- *
- * Bug:
- *   exit_syscall() called cage_record_exit_status(0) even though SYS_exit
- *   is a thread-only exit (triggered by glibc start_thread when a non-main
- *   pthread returns).  cage_record_exit_status uses first-write-wins
- *   semantics, so if SYS_exit(0) fires before exit_group_syscall(1), the
- *   cage's final_exit_status is locked at 0 and exit_group(1) cannot
- *   overwrite it.  cage_finalize then reports exit code 0 to the parent.
- *
- * Scenario that reliably triggers the bug:
- *   1. Child forks.
- *   2. Child creates thread A that immediately returns NULL.  glibc
- *      start_thread does, in order:
- *        atomic_store_release(&pd->tid, 0)  -- marks thread done
- *        FUTEX_WAKE(&pd->tid, 1)            -- unblocks pthread_join
- *        EXIT_SYSCALL(0)                    -- very next instruction
- *      On the unfixed branch, exit_syscall calls cage_record_exit_status(0)
- *      at the start of exit_syscall, before asyncify unwind.
- *   3. pthread_join(ta) in the child main thread returns right after
- *      FUTEX_WAKE, so thread A is still about to call EXIT_SYSCALL(0).
- *      Main's path from pthread_join back to exit(1) requires asyncify
- *      rewind and several library frames; thread A's
- *      cage_record_exit_status(0) runs first and locks final_exit_status=0.
- *   4. Child main calls exit(1).  exit_group_syscall tries to record 1
- *      but final_exit_status is already Some(0) — no overwrite.
- *
- * Before fix: cage_finalize reads Some(0) → parent waitpid sees 0 (WRONG).
- * After fix:  exit_syscall does not record status → exit_group(1) is the
- *             first write → cage_finalize reads Some(1) → parent sees 1.
- */
+/* Test: exit_syscall must not record the cage exit status. */
 
 #include <assert.h>
 #include <pthread.h>
-#include <stdlib.h>
 #include <stdio.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -42,11 +9,6 @@
 static void *thread_a(void *arg)
 {
     (void)arg;
-    /*
-     * Return immediately.  glibc start_thread will call FUTEX_WAKE then
-     * EXIT_SYSCALL(0).  On the unfixed branch, exit_syscall records
-     * final_exit_status = Some(0) before main can call exit(1).
-     */
     return NULL;
 }
 
@@ -59,21 +21,8 @@ int main(void)
         pthread_t ta;
         int rc = pthread_create(&ta, NULL, thread_a, NULL);
         assert(rc == 0 && "pthread_create should succeed");
-
-        /*
-         * pthread_join returns after FUTEX_WAKE but before EXIT_SYSCALL.
-         * Thread A will call EXIT_SYSCALL on its next instruction.
-         * Main's return path from pthread_join to exit(1) goes through
-         * asyncify rewind + multiple library frames, so on the unfixed
-         * branch thread A's cage_record_exit_status(0) reliably fires
-         * first, locking final_exit_status = Some(0).
-         *
-         * On the fixed branch exit_syscall does not call
-         * cage_record_exit_status, so exit_group(1) below records Some(1).
-         */
         pthread_join(ta, NULL);
         exit(1);
-
         _exit(99); /* unreachable */
     }
 

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -1,0 +1,67 @@
+/*
+ * Test: exit_status_first_wins — the first exit() call's code is what
+ * the parent sees, even if a competing thread later calls exit(0).
+ *
+ * Scenario:
+ *   1. Parent forks a child.
+ *   2. Child spawns a worker thread that calls exit(1).
+ *   3. The main thread spins briefly then calls exit(0).
+ *   4. Because exit_group_syscall uses a CAS to record the first caller's
+ *      status, exit(1) wins and subsequent exit(0) uses the already-
+ *      recorded code.
+ *   5. Parent's waitpid() should observe exit status 1.
+ *
+ * Before the fix:
+ *   - exit_syscall (thread-only exit) also recorded cage exit status, so
+ *     whichever thread ran last would overwrite the earlier code.
+ *   - exit_group_syscall did not consult the CAS-recorded status, so
+ *     exit(0) could clobber exit(1).
+ */
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void *worker(void *arg)
+{
+    (void)arg;
+    /* Call exit(1) — this should record exit code 1 via CAS and win. */
+    exit(1);
+    return NULL; /* unreachable */
+}
+
+int main(void)
+{
+    pid_t pid = fork();
+    assert(pid != -1 && "fork should succeed");
+
+    if (pid == 0) {
+        pthread_t t;
+        int rc = pthread_create(&t, NULL, worker, NULL);
+        assert(rc == 0 && "pthread_create should succeed");
+
+        /*
+         * Spin long enough for the worker to call exit(1) and have it
+         * recorded before we call exit(0).  The epoch-kill from exit(1)
+         * will terminate this thread regardless; exit(0) here should
+         * either never run or read the already-recorded status (1).
+         */
+        for (volatile int i = 0; i < 2000000; i++)
+            ;
+        exit(0);
+        /* unreachable */
+        _exit(99);
+    }
+
+    int status;
+    pid_t waited = waitpid(pid, &status, 0);
+    assert(waited == pid && "waitpid should return child pid");
+    assert(WIFEXITED(status) && "child should exit normally");
+    assert(WEXITSTATUS(status) == 1 && "first exit(1) should win over later exit(0)");
+
+    printf("exit_status_first_wins: PASS\n");
+    return 0;
+}

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -49,8 +49,7 @@ int main(void)
          * will terminate this thread regardless; exit(0) here should
          * either never run or read the already-recorded status (1).
          */
-        for (volatile int i = 0; i < 2000000; i++)
-            ;
+        sleep(1);
         exit(0);
         /* unreachable */
         _exit(99);

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -1,36 +1,52 @@
 /*
- * Test: exit_status_first_wins — the first exit() call's code is what
- * the parent sees, even if a competing thread later calls exit(0).
+ * Test: exit_status_first_wins — exit_syscall (SYS_exit) must not record
+ * the cage exit status; only exit_group_syscall should.
  *
- * Scenario:
- *   1. Parent forks a child.
- *   2. Child spawns a worker thread that calls exit(1).
- *   3. The main thread spins briefly then calls exit(0).
- *   4. Because exit_group_syscall uses a CAS to record the first caller's
- *      status, exit(1) wins and subsequent exit(0) uses the already-
- *      recorded code.
- *   5. Parent's waitpid() should observe exit status 1.
+ * Bug:
+ *   exit_syscall() called cage_record_exit_status(0) even though SYS_exit
+ *   is a thread-only exit (triggered by glibc start_thread when a non-main
+ *   pthread returns).  cage_record_exit_status uses first-write-wins
+ *   semantics, so if SYS_exit(0) fires before exit_group_syscall(1), the
+ *   cage's final_exit_status is locked at 0 and exit_group(1) cannot
+ *   overwrite it.  cage_finalize then reports exit code 0 to the parent.
  *
- * Before the fix:
- *   - exit_syscall (thread-only exit) also recorded cage exit status, so
- *     whichever thread ran last would overwrite the earlier code.
- *   - exit_group_syscall did not consult the CAS-recorded status, so
- *     exit(0) could clobber exit(1).
+ * Scenario that reliably triggers the bug:
+ *   1. Child forks.
+ *   2. Child creates thread A that immediately returns NULL.  glibc
+ *      start_thread does, in order:
+ *        atomic_store_release(&pd->tid, 0)  -- marks thread done
+ *        FUTEX_WAKE(&pd->tid, 1)            -- unblocks pthread_join
+ *        EXIT_SYSCALL(0)                    -- very next instruction
+ *      On the unfixed branch, exit_syscall calls cage_record_exit_status(0)
+ *      at the start of exit_syscall, before asyncify unwind.
+ *   3. pthread_join(ta) in the child main thread returns right after
+ *      FUTEX_WAKE, so thread A is still about to call EXIT_SYSCALL(0).
+ *      Main's path from pthread_join back to exit(1) requires asyncify
+ *      rewind and several library frames; thread A's
+ *      cage_record_exit_status(0) runs first and locks final_exit_status=0.
+ *   4. Child main calls exit(1).  exit_group_syscall tries to record 1
+ *      but final_exit_status is already Some(0) — no overwrite.
+ *
+ * Before fix: cage_finalize reads Some(0) → parent waitpid sees 0 (WRONG).
+ * After fix:  exit_syscall does not record status → exit_group(1) is the
+ *             first write → cage_finalize reads Some(1) → parent sees 1.
  */
 
 #include <assert.h>
 #include <pthread.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-static void *worker(void *arg)
+static void *thread_a(void *arg)
 {
     (void)arg;
-    /* Call exit(1) — this should record exit code 1 via CAS and win. */
-    exit(1);
-    return NULL; /* unreachable */
+    /*
+     * Return immediately.  glibc start_thread will call FUTEX_WAKE then
+     * EXIT_SYSCALL(0).  On the unfixed branch, exit_syscall records
+     * final_exit_status = Some(0) before main can call exit(1).
+     */
+    return NULL;
 }
 
 int main(void)
@@ -39,27 +55,33 @@ int main(void)
     assert(pid != -1 && "fork should succeed");
 
     if (pid == 0) {
-        pthread_t t;
-        int rc = pthread_create(&t, NULL, worker, NULL);
+        pthread_t ta;
+        int rc = pthread_create(&ta, NULL, thread_a, NULL);
         assert(rc == 0 && "pthread_create should succeed");
 
         /*
-         * Spin long enough for the worker to call exit(1) and have it
-         * recorded before we call exit(0).  The epoch-kill from exit(1)
-         * will terminate this thread regardless; exit(0) here should
-         * either never run or read the already-recorded status (1).
+         * pthread_join returns after FUTEX_WAKE but before EXIT_SYSCALL.
+         * Thread A will call EXIT_SYSCALL on its next instruction.
+         * Main's return path from pthread_join to exit(1) goes through
+         * asyncify rewind + multiple library frames, so on the unfixed
+         * branch thread A's cage_record_exit_status(0) reliably fires
+         * first, locking final_exit_status = Some(0).
+         *
+         * On the fixed branch exit_syscall does not call
+         * cage_record_exit_status, so exit_group(1) below records Some(1).
          */
-        sleep(1);
-        exit(0);
-        /* unreachable */
-        _exit(99);
+        pthread_join(ta, NULL);
+        exit(1);
+
+        _exit(99); /* unreachable */
     }
 
     int status;
     pid_t waited = waitpid(pid, &status, 0);
     assert(waited == pid && "waitpid should return child pid");
     assert(WIFEXITED(status) && "child should exit normally");
-    assert(WEXITSTATUS(status) == 1 && "first exit(1) should win over later exit(0)");
+    assert(WEXITSTATUS(status) == 1 &&
+           "exit_group(1) should win over thread SYS_exit(0)");
 
     printf("exit_status_first_wins: PASS\n");
     return 0;

--- a/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
+++ b/tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c
@@ -34,6 +34,7 @@
 
 #include <assert.h>
 #include <pthread.h>
+#include <stdlib.h>
 #include <stdio.h>
 #include <sys/wait.h>
 #include <unistd.h>


### PR DESCRIPTION
### Problem

When a process exited with a non-zero code (e.g. faulthandler calling
`_exit(1)`), the parent's `waitpid()` could observe exit code 0 instead.
This is the root reason of python test worker bug observed in python tests.
This was caused by three separate but related issues:

**1. `exit_syscall` recorded the cage exit status**

`exit_syscall` (SYS_exit = 60) is called by glibc's `start_thread` when a
non-main pthread returns from its thread function. It was calling
`cage_record_exit_status(0)` even though a per-thread exit has no bearing on
the process-level exit code. `cage_record_exit_status` uses first-write-wins
semantics, so if SYS_exit(0) fired before `exit_group_syscall(1)`, it locked
`final_exit_status = Some(0)` and the subsequent `exit_group(1)` could not
overwrite it. `cage_finalize` then reported exit code 0 to the parent.

The glibc thread exit sequence is:
```
atomic_store_release(&pd->tid, 0)  // marks thread done, unblocks pthread_join
FUTEX_WAKE(&pd->tid, 1)            // wakes joiner
EXIT_SYSCALL(0)                    // very next instruction
```
`pthread_join` returns right after `FUTEX_WAKE`, so the joiner's return path
(asyncify rewind + multiple library frames) loses the race to thread A's
`cage_record_exit_status(0)`, which fires at the top of `exit_syscall` before
any asyncify unwind.

**2. `exit_group_syscall` passed its own `status_arg` to the exit trampoline**

Late threads calling `exit_group_syscall(0)` after the cage was already marked
`Exited(1)` passed `status_arg = 0` to the wasmtime exit trampoline. The last
thread's exit code determines the value returned to `OnCalledAction::Finish`,
so a late `exit_group(0)` could overwrite the intended code.

**3. `signal_handler` hardcoded exit code 0 for epoch-killed threads**

When `exit_group` or a fatal signal called `epoch_kill_all`, epoch-killed
threads entered `signal_handler` and called `ctx.exit_call(caller, 0, 0)`.
This hardcoded 0 was passed to `OnCalledAction::Finish` regardless of what
exit code had been recorded.

### Fix

- **`exit_syscall`**: remove the `cage_record_exit_status` call entirely. Only
  `exit_group_syscall` determines the process-level exit code.

- **`exit_group_syscall`**: compute `canonical_status_arg` by reading
  `cage.final_exit_status` at the point of calling the exit trampoline.
  Late threads calling `exit_group(0)` after the CAS winner recorded `Exited(1)`
  will use the authoritative code.

- **`signal_handler` (epoch_kill path)**: read `cage.final_exit_status` and
  pass the recorded exit code to `ctx.exit_call` instead of hardcoding 0.

### Test

`tests/unit-tests/process_tests/deterministic/exit_status_first_wins.c`

Forks a child that creates a pthread which returns NULL (triggering
`SYS_exit(0)` via glibc `start_thread`), then calls `exit(1)` after
`pthread_join`. Because `pthread_join` returns before `EXIT_SYSCALL` fires,
thread A's `cage_record_exit_status(0)` races with the main thread's
`exit_group(1)`. Thread A wins the race on the unfixed branch (asyncify rewind
overhead delays the main thread). Parent must observe exit code 1.
