### PR TITLE
Add sockpair addr translation in rawposix

### DIFF
--- a/src/typemap/src/network_helpers.rs
+++ b/src/typemap/src/network_helpers.rs
@@ -4,7 +4,7 @@
 //! host-usable pointer and to compute the correct socklen_t for Linux. It is used by
 //! our socket-related syscalls to bridge from per-cage virtual memory to host libc calls.
 use crate::cage_helpers::validate_cageid;
-use cage::get_cage;
+use cage::{get_cage, translate_vmmap_addr};
 use libc::{
     sa_family_t, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage, sockaddr_un, socklen_t,
     strlen,
@@ -165,7 +165,17 @@ pub fn convert_sockpair<'a>(
         }
     }
 
-    let pointer = arg as *mut SockPair;
+    let updated_arg = if arg_cageid != cageid {
+        let cage = get_cage(arg_cageid).unwrap();
+        match translate_vmmap_addr(&cage, arg) {
+            Ok(host_addr) => host_addr,
+            Err(_) => panic!("Failed to translate vmmap address for sockpair argument"),
+        }
+    } else {
+        arg
+    };
+
+    let pointer = updated_arg as *mut SockPair;
     if !pointer.is_null() {
         return Ok(unsafe { &mut *pointer });
     }


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

With introducing of fd translation in rust grates, the arguments of syscalls might be different from original cage that issues this call. Rawposix needs to perform address translation before updating the results. 

Rust grate is really hard to use address translation functions in C glibc right now, so put up fixes in rawposix instead. 