### PR TITLE
Add addr translation for pipe in rawposix

### DIFF
--- a/src/typemap/src/datatype_conversion.rs
+++ b/src/typemap/src/datatype_conversion.rs
@@ -7,7 +7,7 @@
 //! - All functions starting with `sc_` are **public APIs** exposed to other libraries. Example: `sc_convert_sysarg_to_i32`.
 //! - All other functions are **internal helpers** (inner functions) used only inside this library.
 use crate::cage_helpers::validate_cageid;
-use cage::get_cage;
+use cage::{get_cage, translate_vmmap_addr};
 use std::error::Error;
 use std::os::raw::c_char;
 use sysdefs::constants::lind_platform_const::{MAX_CAGEID, PATH_MAX};
@@ -679,7 +679,17 @@ pub fn sc_convert_addr_to_pipearray<'a>(
         }
     }
 
-    let pointer = arg as *mut PipeArray;
+    let updated_arg = if arg_cageid != cageid {
+        let cage = get_cage(arg_cageid).unwrap();
+        match translate_vmmap_addr(&cage, arg) {
+            Ok(host_addr) => host_addr,
+            Err(_) => panic!("Failed to translate vmmap address for sockpair argument"),
+        }
+    } else {
+        arg
+    };
+
+    let pointer = updated_arg as *mut PipeArray;
     Ok(unsafe { &mut *pointer })
 }
 


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

With introducing of fd translation in rust grates, the arguments of syscalls might be different from original cage that issues this call. Rawposix needs to perform address translation before updating the results. 

Rust grate is really hard to use address translation functions in C glibc right now, so put up fixes in rawposix instead. 