### PR TITLE
use process_vm_writev to copy memory in fork_vmmap

### DIFF
--- a/src/cage/src/memory/memory.rs
+++ b/src/cage/src/memory/memory.rs
@@ -75,8 +75,8 @@ pub fn is_mmap_error(ret: usize) -> bool {
 /// 2. **Shared memory regions**:
 ///    - The function uses the `mremap` syscall to replicate shared memory efficiently. Refer to `man 2 mremap` for details.
 /// 3. **Private memory regions**:
-///    - The function uses `std::ptr::copy_nonoverlapping` to copy the memory contents directly.
-///    - **TODO**: Investigate whether using `writev` could improve performance for this case.
+///    - The function uses `process_vm_writev` to copy memory contents from the parent into
+///      the child's address space.
 ///
 /// # Arguments
 /// * `parent_cageid` - cageid of parent
@@ -125,9 +125,7 @@ pub fn fork_vmmap(parent_cageid: u64, child_cageid: u64) {
                     PROT_READ | PROT_WRITE,
                 );
 
-                // write parent data using process_vm_writev for ~25% speedup over memcpy
-                // on cold pages (fewer TLB shootdowns via kernel copy path); fall back to
-                // copy_nonoverlapping if the syscall is unavailable or returns an error.
+                // write parent data
                 let local_iov = libc::iovec {
                     iov_base: parent_st as *mut libc::c_void,
                     iov_len: addr_len,
@@ -138,9 +136,11 @@ pub fn fork_vmmap(parent_cageid: u64, child_cageid: u64) {
                 };
                 let ret = libc::process_vm_writev(libc::getpid(), &local_iov, 1, &remote_iov, 1, 0);
                 if ret < 0 {
-                    std::ptr::copy_nonoverlapping(
-                        parent_st as *const u8,
-                        child_st as *mut u8,
+                    panic!(
+                        "process_vm_writev failed with errno {} (parent_st=0x{:x}, child_st=0x{:x}, len={})",
+                        *libc::__errno_location(),
+                        parent_st,
+                        child_st,
                         addr_len,
                     );
                 }

--- a/src/cage/src/memory/memory.rs
+++ b/src/cage/src/memory/memory.rs
@@ -5,7 +5,7 @@
 //! address translation and validation related to vmmap
 use crate::cage::{get_cage, Cage};
 use crate::memory::VmmapOps;
-use sysdefs::constants::err_const::Errno;
+use sysdefs::constants::err_const::{get_errno, Errno};
 use sysdefs::constants::fs_const::{
     MAP_SHARED, MREMAP_FIXED, MREMAP_MAYMOVE, PAGESHIFT, PAGESIZE, PROT_NONE, PROT_READ, PROT_WRITE,
 };
@@ -138,7 +138,7 @@ pub fn fork_vmmap(parent_cageid: u64, child_cageid: u64) {
                 if ret < 0 {
                     panic!(
                         "process_vm_writev failed with errno {} (parent_st=0x{:x}, child_st=0x{:x}, len={})",
-                        *libc::__errno_location(),
+                        get_errno(),
                         parent_st,
                         child_st,
                         addr_len,

--- a/src/cage/src/memory/memory.rs
+++ b/src/cage/src/memory/memory.rs
@@ -125,13 +125,25 @@ pub fn fork_vmmap(parent_cageid: u64, child_cageid: u64) {
                     PROT_READ | PROT_WRITE,
                 );
 
-                // write parent data
-                // TODO: replace copy_nonoverlapping with writev for potential performance boost
-                std::ptr::copy_nonoverlapping(
-                    parent_st as *const u8,
-                    child_st as *mut u8,
-                    addr_len,
-                );
+                // write parent data using process_vm_writev for ~25% speedup over memcpy
+                // on cold pages (fewer TLB shootdowns via kernel copy path); fall back to
+                // copy_nonoverlapping if the syscall is unavailable or returns an error.
+                let local_iov = libc::iovec {
+                    iov_base: parent_st as *mut libc::c_void,
+                    iov_len: addr_len,
+                };
+                let remote_iov = libc::iovec {
+                    iov_base: child_st as *mut libc::c_void,
+                    iov_len: addr_len,
+                };
+                let ret = libc::process_vm_writev(libc::getpid(), &local_iov, 1, &remote_iov, 1, 0);
+                if ret < 0 {
+                    std::ptr::copy_nonoverlapping(
+                        parent_st as *const u8,
+                        child_st as *mut u8,
+                        addr_len,
+                    );
+                }
 
                 // revert child's memory region prot
                 libc::mprotect(child_st as *mut libc::c_void, addr_len, entry.prot);


### PR DESCRIPTION
replace `copy_nonoverlapping` with `process_vm_writev` for better performance, this shows decent performance gain especially for large memory regions (probably 2x boost), but it still does not fix the fundamental cost of memory copying. A modest increase in the amount of memory copied could easily offset the performance benefit of `process_vm_writev`.

intentionally panic if `process_vm_writev` failed for better debugging purpose, for better standardlization, I hope we can get a logging system in lind working (https://github.com/Lind-Project/lind-wasm/issues/1178), then we can gracefully place a fallback routine if `process_vm_writev` failed (e.g. use old `copy_nonoverlapping` routine) and simply log the event. This should give both debug flexibility and runtime stability