### PR TITLE
Fix rawposix ioctl request type for target-specific libc definitions

### DIFF
--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -4547,7 +4547,7 @@ pub extern "C" fn ioctl_syscall(
     }
 
     // handle FIOCLEX, set close_on_exec flag for the file descriptor
-    if req as u64 == FIOCLEX {
+    if req as u64 == FIOCLEX as u64 {
         let ret = match fdtables::set_cloexec(cageid, vfd_arg, true) {
             Ok(_) => 0,
             Err(_) => syscall_error(Errno::EBADF, "ioctl", "Bad File Descriptor"),
@@ -4569,7 +4569,13 @@ pub extern "C" fn ioctl_syscall(
 
     let vfd = wrappedvfd.unwrap();
 
-    let ret = unsafe { libc::ioctl(vfd.underfd as i32, req as u64, ptrunion as *mut c_void) };
+    let ret = unsafe {
+        libc::ioctl(
+            vfd.underfd as i32,
+            req as libc::Ioctl,
+            ptrunion as *mut c_void,
+        )
+    };
 
     if ret < 0 {
         let errno = get_errno();


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
## Summary

This PR updates `rawposix`'s `ioctl_syscall` to cast ioctl request values through `libc::Ioctl` instead of assuming a fixed integer type.

On some targets, such as `x86_64-unknown-linux-musl`, `libc::ioctl` expects its request argument to use the target-specific `libc::Ioctl` type. Passing `req as u64` can fail to compile when the target's libc definition does not match that exact type. 

This change makes `rawposix` compile in consumers that build Lind/Wasmtime for targets where `libc::ioctl` uses a target-specific request type, including musl-based builds.

## Changes

- Cast `req` to `libc::Ioctl` before passing it to `libc::ioctl`.
- Compare `FIOCLEX` using a matching integer type to avoid target-dependent type mismatches.

## Testing

- Passed local lind-wasm test suite
- Verified the change fixes compilation when `rawposix` is built as part of TriSeal/Enarx with the `x86_64-unknown-linux-musl` target.