### PR TITLE
minor fix for signal_callback

### DIFF
--- a/scripts/lind-wasm-opt
+++ b/scripts/lind-wasm-opt
@@ -10,6 +10,7 @@ set -Eeuo pipefail
 # Exactly one of --target or --static must be given:
 #   --target=main      Dynamic main-module binary.
 #   --target=library   Dynamic shared-library binary.
+#   --target=libc      libc shared library (already owns signal_callback; omits epoch-main-module).
 #   --static           Static (non-dynamic) binary.
 #
 # Options:
@@ -22,6 +23,7 @@ set -Eeuo pipefail
 # Examples:
 #   lind-wasm-opt --target=main    input.wasm -o output.wasm
 #   lind-wasm-opt --target=library input.wasm -o output.wasm
+#   lind-wasm-opt --target=libc    libc.so -o libc.so
 #   lind-wasm-opt --static         input.wasm -o output.wasm
 #   lind-wasm-opt --target=main --fpcast-emu input.wasm -o output.wasm
 #   lind-wasm-opt --static --fpcast-emu      input.wasm -o output.wasm
@@ -41,11 +43,11 @@ PRINT_CMD="false"
 # --- option parsing ---
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
-    --target=main|--target=library)
+    --target=main|--target=library|--target=libc)
       TARGET="${1#--target=}"
       ;;
     --target=*)
-      echo "error: unknown target '${1#--target=}' (expected: main, library)" >&2
+      echo "error: unknown target '${1#--target=}' (expected: main, library, libc)" >&2
       usage
       exit 2
       ;;
@@ -86,7 +88,7 @@ if [[ "${STATIC}" == "true" && -n "${TARGET}" ]]; then
 fi
 
 if [[ "${STATIC}" == "false" && -z "${TARGET}" ]]; then
-  echo "error: one of --target=main, --target=library, or --static is required" >&2
+  echo "error: one of --target=main, --target=library, --target=libc, or --static is required" >&2
   usage
   exit 2
 fi
@@ -168,7 +170,7 @@ elif [[ "${TARGET}" == "main" ]]; then
   # --enable-reference-types is required because --translate-to-exnref emits (ref exn) blocks
   # (via catch_all_ref) when setjmp frames are nested across function calls.
   [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]] && LIND_FLAGS+=(--translate-to-exnref)
-else  # library
+elif [[ "${TARGET}" == "library" ]]; then
   if [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]]; then
     LIND_FLAGS+=(--enable-bulk-memory --enable-threads --enable-exception-handling --enable-reference-types)
   else
@@ -183,10 +185,22 @@ else  # library
   if [[ "${WITH_FPCAST}" == "true" ]]; then
     LIND_FLAGS+=(--fpcast-emu --pass-arg=relocatable-fpcast)
   fi
-  # Convert clang 18 legacy EH (try/catch/throw) to standard EH (try_table/throw) after
-  # asyncify: asyncify handles legacy EH natively but Cranelift only supports standard EH.
-  # --enable-reference-types is required because --translate-to-exnref emits (ref exn) blocks
-  # (via catch_all_ref) when setjmp frames are nested across function calls.
+  [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]] && LIND_FLAGS+=(--translate-to-exnref)
+else  # libc — owns signal_callback; inject epoch calls without redefining/reimporting it
+  if [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]]; then
+    LIND_FLAGS+=(--enable-bulk-memory --enable-threads --enable-exception-handling --enable-reference-types)
+  else
+    LIND_FLAGS+=(--enable-bulk-memory --enable-threads)
+  fi
+  if [[ "${WITHOUT_EPOCH}" == "false" ]]; then
+    LIND_FLAGS+=(--epoch-injection --pass-arg=epoch-import)
+  fi
+  if [[ "${WITHOUT_ASYNCIFY}" == "false" ]]; then
+    LIND_FLAGS+=(--asyncify --pass-arg=asyncify-import-globals)
+  fi
+  if [[ "${WITH_FPCAST}" == "true" ]]; then
+    LIND_FLAGS+=(--fpcast-emu --pass-arg=relocatable-fpcast)
+  fi
   [[ -z "${LIND_ASYNCIFY_SETJMP:-}" ]] && LIND_FLAGS+=(--translate-to-exnref)
 fi
 

--- a/scripts/lind-wasm-opt
+++ b/scripts/lind-wasm-opt
@@ -175,7 +175,7 @@ else  # library
     LIND_FLAGS+=(--enable-bulk-memory --enable-threads)
   fi
   if [[ "${WITHOUT_EPOCH}" == "false" ]]; then
-    LIND_FLAGS+=(--epoch-injection --pass-arg=epoch-import)
+    LIND_FLAGS+=(--epoch-injection --pass-arg=epoch-import --pass-arg=epoch-main-module)
   fi
   if [[ "${WITHOUT_ASYNCIFY}" == "false" ]]; then
     LIND_FLAGS+=(--asyncify --pass-arg=asyncify-import-globals)

--- a/scripts/make_shared_glibc.sh
+++ b/scripts/make_shared_glibc.sh
@@ -76,8 +76,8 @@ $REPO_ROOT/tools/add-export-tool/add-export-tool "$SYSROOT/lib/wasm32-wasi/libc.
 $REPO_ROOT/tools/add-export-tool/add-export-tool $REPO_ROOT/lindfs/lib/libc.so $REPO_ROOT/lindfs/lib/libc.so __wasm_apply_global_relocs func __wasm_apply_global_relocs
 $REPO_ROOT/tools/add-export-tool/add-export-tool $REPO_ROOT/lindfs/lib/libc.so $REPO_ROOT/lindfs/lib/libc.so __stack_pointer global __stack_pointer
 
-# apply wasm-opt
-$REPO_ROOT/scripts/lind-wasm-opt --target=library $FPCAST_FLAG $REPO_ROOT/lindfs/lib/libc.so -o $REPO_ROOT/lindfs/lib/libc.so
+# apply wasm-opt (use --target=libc: libc owns signal_callback, so epoch-main-module must be omitted)
+$REPO_ROOT/scripts/lind-wasm-opt --target=libc $FPCAST_FLAG $REPO_ROOT/lindfs/lib/libc.so -o $REPO_ROOT/lindfs/lib/libc.so
 
 # do precompile (call lind-boot directly to avoid lind_compile copying to lindfs root)
 rm -f $REPO_ROOT/lindfs/lib/libc.cwasm

--- a/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/linker.rs
@@ -52,6 +52,17 @@ pub(crate) fn is_dylink_internal_symbol(name: &str) -> bool {
     )
 }
 
+/// Symbols that may be exported by multiple shared libraries (e.g. as re-exports of
+/// an import they received from libc). The first definition wins; subsequent duplicates
+/// are silently ignored rather than causing a "defined twice" error.
+pub(crate) fn is_dylink_dedup_symbol(name: &str) -> bool {
+    matches!(
+        name,
+        // Provided by libc; other libraries re-export it via GOT but must not redefine it.
+        "signal_callback"
+    )
+}
+
 /// Structure used to link wasm modules/instances together.
 ///
 /// This structure is used to assist in instantiating a [`Module`]. A [`Linker`]
@@ -1028,11 +1039,16 @@ impl<T> Linker<T> {
                 } else {
                     self.import_key(module_name, Some(name))
                         .ok()
-                        .map(|key| (key, e.into_extern()))
+                        .map(|key| (key, e.into_extern(), name.to_string()))
                 }
             })
             .collect::<Vec<_>>();
-        for (key, export) in exports {
+        for (key, export, name) in exports {
+            // For dedup symbols, silently skip if already defined (first definition wins).
+            if module_name == "env" && is_dylink_dedup_symbol(&name) && self.map.get(&key).is_some()
+            {
+                continue;
+            }
             self.insert(key, Definition::new(store.0, export))?;
         }
         Ok(self)


### PR DESCRIPTION
minor refactor of `signal_callback` handling model in dynamic build: now `signal_callback` is only exported by libc.so, while all other libraries and main binary are importing `signal_callback` from libc.so. This fixed some edge case use of signals in dynamic build programs

One remaining problem about `signal_callback` is that, if there are so files that are supposed to be loaded even before libc, `signal_callback` will cause unknown import error. But this is a pretty rare situation and we can handle it when we really encountered the scenario, opened an issue for tracking: https://github.com/Lind-Project/lind-wasm/issues/1215