### PR TITLE
Fix address truncation

### DIFF
--- a/skip_test_cases.txt
+++ b/skip_test_cases.txt
@@ -15,5 +15,4 @@ dylink_tests/deterministic/rdynamic_main.c
 dylink_tests/deterministic/rdynamic_lib.c
 process_tests/deterministic/fork_max_cages.c
 ci/deterministic/ci_intentional_failure_tmp.c
-memory_tests/deterministic/mmap_address_truncation.c
 memory_tests/deterministic/mmap_null_address_mapping.c

--- a/src/cage/src/memory/vmmap.rs
+++ b/src/cage/src/memory/vmmap.rs
@@ -301,7 +301,10 @@ impl Vmmap {
     /// Returns the rounded up page number
     fn round_page_num_up_to_map_multiple(&self, npages: u32, pages_per_map: u32) -> u32 {
         // Add (pages_per_map - 1) to npages and mask off lower bits to round up
-        (npages + pages_per_map - 1) & !(pages_per_map - 1)
+        npages
+        .checked_add(pages_per_map - 1)
+        .map(|n| n & !(pages_per_map - 1))
+        .unwrap_or(u32::MAX & !(pages_per_map - 1)) // clamp to max aligned value
     }
 
     /// Truncates a page number down to the nearest multiple of pages_per_map
@@ -341,7 +344,9 @@ impl Vmmap {
     /// Returns the corresponding system address
     pub fn user_to_sys(&self, address: u32) -> usize {
         // Add base address to user address to get system address
-        address as usize + self.base_address.unwrap()
+        let base = self.base_address.unwrap();
+        (address as usize).checked_add(base)
+            .expect("user_to_sys: address overflow")
     }
 
     /// Converts a system address to a user address
@@ -352,7 +357,11 @@ impl Vmmap {
     /// Returns the corresponding user space address
     pub fn sys_to_user(&self, address: usize) -> u32 {
         // Subtract base address from system address to get user address
-        (address as usize - self.base_address.unwrap()) as u32
+        let base = self.base_address.unwrap();
+        let user = address.checked_sub(base)
+            .expect("sys_to_user: address underflow");
+        assert!(user <= u32::MAX as usize, "sys_to_user: result exceeds 32-bit space");
+        user as u32
     }
 
     // Visits each entry in the vmmap, applying a visitor function to each entry
@@ -626,7 +635,13 @@ impl VmmapOps for Vmmap {
         }
 
         // Calculate page range
-        let new_region_end_page = page_num + npages;
+        let new_region_end_page = match page_num.checked_add(npages) {
+            Some(end) => end,
+            None => return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "page_num + npages overflows 32-bit address space",
+            )),
+        };
         let new_region_start_page = page_num;
 
         // Create new entry if not removing
@@ -675,7 +690,7 @@ impl VmmapOps for Vmmap {
     /// - Updates protection flags for fully contained pages
     fn change_prot(&mut self, page_num: u32, npages: u32, new_prot: i32) {
         // Calculate page range
-        let new_region_end_page = page_num + npages;
+        let new_region_end_page = page_num.saturating_add(npages).min(self.end_address); //if addition overflows, clamp to maximum integer value instead of wrapping
         let new_region_start_page = page_num;
 
         // Collect information about overlapping entries that need to be modified
@@ -778,7 +793,10 @@ impl VmmapOps for Vmmap {
     /// - false if mapping doesn't exist or protection is incompatible
     fn check_existing_mapping(&self, page_num: u32, npages: u32, prot: i32) -> bool {
         // Calculate end page and create interval for region
-        let region_end_page = page_num + npages;
+        let region_end_page = match page_num.checked_add(npages) {
+            Some(end) => end,
+            None => return false,
+        };
         let region_interval = ie(page_num, region_end_page);
 
         // Case 1: No overlapping entries exist
@@ -790,7 +808,7 @@ impl VmmapOps for Vmmap {
 
         // Iterate over overlapping intervals
         for (_interval, entry) in self.entries.overlapping(region_interval) {
-            let ent_end_page = entry.page_num + entry.npages;
+            let ent_end_page = entry.page_num.saturating_add(entry.npages);
             let flags = entry.maxprot;
 
             // Case 2: Region is fully inside existing entry
@@ -835,11 +853,14 @@ impl VmmapOps for Vmmap {
     /// - Handles partial overlaps and gaps
     fn check_addr_mapping(&mut self, page_num: u32, npages: u32, prot: i32) -> Option<u32> {
         // Calculate end page of region
-        let region_end_page = page_num + npages;
+        let region_end_page = match page_num.checked_add(npages) {
+            Some(end) => end,
+            None => return None,
+        };
 
         // Case 1: Check cached entry first for performance
         if let Some(ref cached_entry) = self.cached_entry {
-            let ent_end_page = cached_entry.page_num + cached_entry.npages;
+            let ent_end_page = cached_entry.page_num.saturating_add(cached_entry.npages);
             let mut flags = cached_entry.prot;
 
             // Enforce PROT_READ if any protection exists
@@ -858,7 +879,7 @@ impl VmmapOps for Vmmap {
         // Case 2: Check overlapping entries if cache miss
         let mut current_page = page_num;
         for (_, entry) in self.entries.overlapping(ie(page_num, region_end_page)) {
-            let ent_end_page = entry.page_num + entry.npages;
+            let ent_end_page = entry.page_num.saturating_add(entry.npages);
             let mut flags = entry.prot;
 
             // Enforce PROT_READ if any protection exists
@@ -1011,7 +1032,7 @@ impl VmmapOps for Vmmap {
             .filter(|(_, entry)| !matches!(entry.backing, MemoryBackingType::SharedMemory(_)))
             .map(|(interval, _)| {
                 let act_start = interval.start().max(req_start);
-                let act_end = (interval.end() + 1).min(req_end);
+                let act_end = interval.end().saturating_add(1).min(req_end);
                 (act_start, act_end)
             })
             .collect()

--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -897,11 +897,11 @@ pub extern "C" fn mmap_syscall(
 
         // pick an address of appropriate size, anywhere
         if useraddr == 0 {
-            result = vmmap.find_map_space(rounded_length as u32 >> PAGESHIFT, 1);
+            result = vmmap.find_map_space((rounded_length >> PAGESHIFT) as u32, 1);
         } else {
             // use address user provided as hint to find address
             result = vmmap.find_map_space_with_hint(
-                rounded_length as u32 >> PAGESHIFT,
+                (rounded_length >> PAGESHIFT) as u32,
                 1,
                 addr as u32 >> PAGESHIFT,
             );
@@ -914,6 +914,10 @@ pub extern "C" fn mmap_syscall(
 
         let space = result.unwrap();
         useraddr = (space.start() << PAGESHIFT) as u32;
+    }
+
+    if (useraddr as u64) + rounded_length > 0x100000000u64 {
+        return syscall_error(Errno::EINVAL, "mmap", "address range overflows 32-bit space");
     }
 
     flags |= MAP_FIXED as i32;
@@ -1117,8 +1121,12 @@ pub extern "C" fn munmap_syscall(
 
     let mut vmmap = cage.vmmap.write();
 
-    let req_start: u32 = vmmap.sys_to_user(rounded_addr) >> PAGESHIFT;
-    let req_end: u32 = req_start + (rounded_length as u32 >> PAGESHIFT);
+    let req_start: u32 = (vmmap.sys_to_user(rounded_addr) >> PAGESHIFT) as u32;
+    let page_count: u32 = (rounded_length >> PAGESHIFT) as u32;
+    let req_end: u32 = match req_start.checked_add(page_count) {
+        Some(end) => end,
+        None => return syscall_error(Errno::EINVAL, "munmap", "address range overflows 32-bit space"),
+    };
 
     let overlaps = vmmap.find_unmappable_ranges(req_start, req_end);
 
@@ -1263,11 +1271,24 @@ pub extern "C" fn brk_syscall(
         heap.file_size,
         heap.cage_id,
     );
+    
 
-    let old_heap_end_usr = (old_brk_page * PAGESIZE) as u32;
+    let old_heap_end_u64 = (old_brk_page as u64) * (PAGESIZE as u64);
+    let new_heap_end_u64 = (brk_page as u64) * (PAGESIZE as u64);
+
+    // Prevent 32-bit address-space overflow
+    if old_heap_end_u64 > 0xFFFF_FFFFu64 || new_heap_end_u64 > 0xFFFF_FFFFu64 {
+        return syscall_error(
+            Errno::ENOMEM,
+            "brk",
+            "heap end address overflows 32-bit space",
+        );
+    }
+
+    let old_heap_end_usr = old_heap_end_u64 as u32;
     let old_heap_end_sys = vmmap.user_to_sys(old_heap_end_usr) as *mut u8;
 
-    let new_heap_end_usr = (brk_page * PAGESIZE) as u32;
+    let new_heap_end_usr = new_heap_end_u64 as u32;
     let new_heap_end_sys = vmmap.user_to_sys(new_heap_end_usr) as *mut u8;
 
     drop(vmmap);
@@ -4904,6 +4925,10 @@ pub extern "C" fn shmat_syscall(
     let space = result.unwrap();
     // Update the user address to the start of the allocated memory space.
     useraddr = (space.start() << PAGESHIFT) as u32;
+
+    if (useraddr as u64) + rounded_length > 0x100000000u64 {
+        return syscall_error(Errno::EINVAL, "shmat", "address range overflows 32-bit space");
+    }
 
     // Convert the user address into a system address.
     // Read the virtual memory map to access the user address space.


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

# Fix 32-bit integer overflow and interval boundary bugs in vmmap and syscall handling
 
## Purpose
 
Fixes silent 32-bit integer overflow in `addr + len` calculations causing pages to wrap to low memory causing `mprotect`/`munmap` to silently affect adjacent mappings.
 
## Files Changed
 
- `fs_calls.rs` — overflow guards on address arithmetic in `mmap`, `munmap`, `brk`, and `shmat` syscall handlers
- `vmmap.rs` — overflow check added in arithmetic throughout page range calculations. It might prevent the wrap around by clamping to the maximum within the range or it can throw an error where clamping to the max value is not ideal

