### PR TITLE
rawposix_shutdown: Clear exiting table, unset stack arenas

### DIFF
--- a/src/rawposix/src/init.rs
+++ b/src/rawposix/src/init.rs
@@ -15,8 +15,8 @@ use sysdefs::constants::{
 };
 use threei::{
     copy_data_between_cages, copy_handler_table_to_cage, register_handler,
-    COPY_DATA_BETWEEN_CAGES_SYSCALL, COPY_HANDLER_TABLE_TO_CAGE_SYSCALL, REGISTER_HANDLER_SYSCALL,
-    RUNTIME_TYPE_WASMTIME,
+    COPY_DATA_BETWEEN_CAGES_SYSCALL, COPY_HANDLER_TABLE_TO_CAGE_SYSCALL, EXITING_TABLE,
+    REGISTER_HANDLER_SYSCALL, RUNTIME_TYPE_WASMTIME,
 };
 
 /// Function signature for a RawPOSIX syscall handler.
@@ -358,4 +358,10 @@ pub fn rawposix_shutdown() {
             UNUSED_ID,
         );
     }
+
+    for cage in EXITING_TABLE.iter() {
+        sysdefs::constants::lind_platform_const::unset_stack_arena_base(*cage as usize);
+    }
+
+    EXITING_TABLE.clear();
 }


### PR DESCRIPTION
The current `rawposix_shutdown` does not properly clear the `EXITING_TABLE` or unset the stack arenas that these cages occupy. 

`lind-perf` (#846  etc.) require `rawposix_shutdown` to perform a complete reset of state such that once `rawposix_shutdown` is called followed by `rawposix_init`, any cage that is run behaves as if it's being run on a fresh `lind-boot` invocation. 

This PR fixes that.