### PR TITLE
Add compatibility of renameat2

### DIFF
--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -2585,28 +2585,23 @@ fn renameat_inner(
     };
 
     let ret = unsafe {
-        // if use_renameat2 {
-        //     libc::renameat2(
-        //         old_kernel_fd,
-        //         c_oldpath.as_ptr(),
-        //         new_kernel_fd,
-        //         c_newpath.as_ptr(),
-        //         flags,
-        //     )
-        // } else {
-        //     libc::renameat(
-        //         old_kernel_fd,
-        //         c_oldpath.as_ptr(),
-        //         new_kernel_fd,
-        //         c_newpath.as_ptr(),
-        //     )
-        // }
-        libc::renameat(
+        if use_renameat2 {
+            libc::syscall(
+            libc::SYS_renameat2,
             old_kernel_fd,
             c_oldpath.as_ptr(),
             new_kernel_fd,
             c_newpath.as_ptr(),
-        )
+            flags,
+        ) as libc::c_int
+        } else {
+            libc::renameat(
+                old_kernel_fd,
+                c_oldpath.as_ptr(),
+                new_kernel_fd,
+                c_newpath.as_ptr(),
+            )
+        }
     };
     if ret < 0 {
         let errno = get_errno();

--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -2585,22 +2585,28 @@ fn renameat_inner(
     };
 
     let ret = unsafe {
-        if use_renameat2 {
-            libc::renameat2(
-                old_kernel_fd,
-                c_oldpath.as_ptr(),
-                new_kernel_fd,
-                c_newpath.as_ptr(),
-                flags,
-            )
-        } else {
-            libc::renameat(
-                old_kernel_fd,
-                c_oldpath.as_ptr(),
-                new_kernel_fd,
-                c_newpath.as_ptr(),
-            )
-        }
+        // if use_renameat2 {
+        //     libc::renameat2(
+        //         old_kernel_fd,
+        //         c_oldpath.as_ptr(),
+        //         new_kernel_fd,
+        //         c_newpath.as_ptr(),
+        //         flags,
+        //     )
+        // } else {
+        //     libc::renameat(
+        //         old_kernel_fd,
+        //         c_oldpath.as_ptr(),
+        //         new_kernel_fd,
+        //         c_newpath.as_ptr(),
+        //     )
+        // }
+        libc::renameat(
+            old_kernel_fd,
+            c_oldpath.as_ptr(),
+            new_kernel_fd,
+            c_newpath.as_ptr(),
+        )
     };
     if ret < 0 {
         let errno = get_errno();

--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -2587,13 +2587,13 @@ fn renameat_inner(
     let ret = unsafe {
         if use_renameat2 {
             libc::syscall(
-            libc::SYS_renameat2,
-            old_kernel_fd,
-            c_oldpath.as_ptr(),
-            new_kernel_fd,
-            c_newpath.as_ptr(),
-            flags,
-        ) as libc::c_int
+                libc::SYS_renameat2,
+                old_kernel_fd,
+                c_oldpath.as_ptr(),
+                new_kernel_fd,
+                c_newpath.as_ptr(),
+                flags,
+            ) as libc::c_int
         } else {
             libc::renameat(
                 old_kernel_fd,


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
`renameat2` wrapper doesn't exist on some specific target rust libc (ie: musl). Update usage to have higher compatibility. 