### PR TITLE
Expose lind-boot as a library and support module loading by bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ e2e_status
 reports/
 report.html
 
+**/*.so
+
 #Ignore python cache
 __pycache__/
 

--- a/src/lind-boot/src/cli.rs
+++ b/src/lind-boot/src/cli.rs
@@ -39,6 +39,14 @@ pub struct CliOptions {
     #[arg(long = "enable-fpcast")]
     pub enable_fpcast: bool,
 
+    /// Optional in-memory Wasm module bytes.
+    ///
+    /// This is not parsed from the command line. When present, lind-boot loads
+    /// the main module from these bytes instead of reading `WASM_FILE` from disk.
+    /// `WASM_FILE` is still used as guest argv[0].
+    #[arg(skip)]
+    pub wasm_bytes: Option<Vec<u8>>,
+
     /// First item is WASM file (argv[0]), rest are program args (argv[1..])
     ///
     /// Example:

--- a/src/lind-boot/src/lib.rs
+++ b/src/lind-boot/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod cli;
+pub mod lind_wasmtime;
+
+pub use cli::CliOptions;
+pub use lind_wasmtime::{execute_wasmtime, precompile_module};

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -86,13 +86,12 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
     init_vmctx_pool();
 
     // -- Initialize the Wasmtime execution environment --
-    let wasm_file_path = Path::new(lindboot_cli.wasm_file());
     let wt_config =
         make_wasmtime_config(lindboot_cli.wasmtime_backtrace, lindboot_cli.enable_fpcast);
     let engine = Engine::new(&wt_config)
         .map_err(anyhow::Error::from)
         .context("failed to create execution engine")?;
-    let module = read_wasm_or_cwasm(&engine, wasm_file_path)?;
+    let module = read_main_wasm_or_cwasm(&engine, &lindboot_cli)?;
 
     // -- Run the first module in the first cage --
     let result = execute_with_lind(
@@ -236,7 +235,6 @@ pub fn execute_with_lind(
     let mut modules = Vec::new();
     modules.push((String::new(), String::new(), module.clone()));
     for (name, path) in lind_boot.preloads.iter() {
-        // Read the wasm module binary either as `*.wat` or a raw binary
         let module = read_wasm_or_cwasm(&engine, path)?;
         modules.push((
             name.clone(),
@@ -903,6 +901,37 @@ pub fn precompile_module(cli: &CliOptions) -> Result<()> {
 
     eprintln!("OK: {}", cwasm_path.display());
     Ok(())
+}
+
+/// Load the main Wasm module using the source selected by `CliOptions`.
+///
+/// The default is path-based loading from `WASM_FILE`. If `cli.wasm_bytes` is
+/// present, those in-memory bytes take precedence while `WASM_FILE` remains the
+/// guest-visible argv[0].
+fn read_main_wasm_or_cwasm(engine: &Engine, cli: &CliOptions) -> Result<Module> {
+    match cli.wasm_bytes.as_ref() {
+        Some(bytes) => read_wasm_or_cwasm_bytes(engine, bytes, cli.wasm_file()),
+        None => read_wasm_or_cwasm(engine, Path::new(cli.wasm_file())),
+    }
+}
+
+/// Load a Wasm module from raw bytes, supporting both `.wasm` and precompiled `.cwasm` bytes.
+pub(crate) fn read_wasm_or_cwasm_bytes(
+    engine: &Engine,
+    bytes: &[u8],
+    source_name: &str,
+) -> Result<Module> {
+    match Engine::detect_precompiled(bytes) {
+        Some(Precompiled::Module) => unsafe { Module::deserialize(engine, bytes) }
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("failed to deserialize precompiled module {source_name}")),
+        Some(Precompiled::Component) => bail!(
+            "failed to load {source_name}: precompiled components are not supported as Lind modules"
+        ),
+        None => Module::from_binary(engine, bytes)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("failed to compile module {source_name}")),
+    }
 }
 
 /// Load a Wasm module from disk, supporting both `.wasm` and precompiled `.cwasm` files.


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
Make `lind-boot` usable both as a binary and as a Rust library, and add support for loading the main Lind-Wasm module from bytes.

## Changes

- Add a `lind-boot` library interface for external Rust callers
- Export `CliOptions`, `execute_wasmtime`, and `precompile_module`
- Add an optional `wasm_bytes` field to `CliOptions`
- Route main module loading based on `CliOptions`:
  - use `wasm_bytes` when provided
  - otherwise load from the existing `WASM_FILE` path
- Add a bytes-based module loader using:
  - `Engine::detect_precompiled`
  - `Module::deserialize`
  - `Module::from_binary`
- Keep the existing path-based loader using:
  - `Engine::detect_precompiled_file`
  - `Module::deserialize_file`
  - `Module::from_file`
- Keep `precompile_module` path-based only

