### PR TITLE
ci: refactor e2e, release workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,9 @@ name: End-to-end testing
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  push:
-    branches:
-      - main
+  # NOTE: push(main) trigger removed.
+  # This workflow is a CI gate for PRs only.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -18,12 +18,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    # If the workflow was triggered by anything other than a pull_request event 
-    # (e.g., push, workflow_dispatch, schedule, pull_request_target), 
-    # github.event_name != 'pull_request' is true.
-    # github.event.pull_request is only populated on pull_request events. 
-    # It is true when the PR is not a draft (i.e., “Ready for review”).
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    # This workflow is triggered by pull_request events only.
+    # Skip draft PRs; run only when the PR is "Ready for review".
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
       REPORT_LOCAL_DIR: test-reports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release on Docker Hub
 
 on:
   workflow_dispatch:
-  schedule:
+  push:
     branches: [main]
 
 # Serialize releases on the same ref.
@@ -12,8 +12,6 @@ concurrency:
   cancel-in-progress: false
 
 permissions: {}
-
-name: Test and release on Docker Hub
 
 jobs:
   # Release job: build the 'release' image and publish to Docker Hub.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,25 @@
-name: Test and release on Docker Hub
+name: Release on Docker Hub
 
 on:
   workflow_dispatch:
   schedule:
-  - cron: "0 8 * * 1" # Run at 08:00, every Monday
+    branches: [main]
+
+# Serialize releases on the same ref.
+# Do NOT cancel in-progress runs: a cancelled run could abort a push and leave Docker Hub in a partial state.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions: {}
 
+name: Test and release on Docker Hub
+
 jobs:
-  docker:
+  # Release job: build the 'release' image and publish to Docker Hub.
+  release:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     environment: dockerhub
     steps:
@@ -20,14 +31,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      # Build 'test' stage (default) to run tests
-      - name: Test
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          platforms: linux/amd64
-          cache-from: type=gha
-          file: Docker/Dockerfile.e2e
 
       # Configure Docker release tags:
       # - securesystemslab/lind-wasm:sha-<short commit id>
@@ -43,7 +46,7 @@ jobs:
           flavor: |
             latest=true
 
-      # Build 'release' stage and push to Dockerhub
+      # Build 'release' stage and push to Docker Hub.
       - name: Release and push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
@@ -51,5 +54,6 @@ jobs:
           push: true
           platforms: linux/amd64
           cache-from: type=gha
+          cache-to: type=gha,mode=max
           file: Docker/Dockerfile.e2e
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### Description

Refactored `e2e.yml` and `release.yml` 

### Changes

1. `e2e.yml` — triggered on PR open/update

- Runs on every PR open and update
- Workflow: build → test → report

2. `release.yml` — triggered on push to main

- Runs when a PR is merged into main
- Builds the release image from the latest code and pushes it to Docker Hub

**Differences from the previous workflow**

- The release image was pushed on a weekly schedule.
- `e2e.yml` was triggered on both PR open/update and main push, but changes merged into main were never reflected in the release image at that point.


Related: #1216 