### PR TITLE
Clarify overview and getting started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ that comes with the Lind Sandbox. *You'll need [Docker installed](https://docs.d
 ```
 docker pull --platform=linux/amd64 securesystemslab/lind-wasm-dev  # this might take a while ...
 docker run --platform=linux/amd64 -it securesystemslab/lind-wasm-dev /bin/bash
+cd lind-wasm
 ```
 
 This is a development environment with tooling and source code available. Additional instructions can be found [here](contribute/dev-container.md).
@@ -34,19 +35,19 @@ int main() {
 EOF
 ```
 
-**3. Compile Lind-Wasm Runtime**
+**3. Compile the Lind-Wasm runtime**
 
-The Lind-Wasm runtime must be compiled before running the program. To compile the runtime, first go to the `lind-wasm/` directory. From there, you can choose:
+The Lind-Wasm runtime must be compiled before running the program. Use this path for a first build:
 
-3.a. Use `make all` to compile both lind-glibc and Rust code at once.
+```bash
+make lind-boot sysroot
+```
 
-3.b. Use `make lind-boot` to compile the runtime (`lind-boot`, Wasmtime, RawPOSIX, 3i, etc.), and `make sysroot` to compile lind-glibc.
+This builds the runtime (`lind-boot`, Wasmtime, RawPOSIX, 3i, etc.) and the lind-glibc sysroot.
 
-**NOTES: More options can be found in lind-wasm/Makefile**
+For a full build, including both lind-glibc and Rust code, use `make all`. More build targets are documented in `lind-wasm/Makefile`.
 
 **4. Compile and run**
-
-Use lind scripts to compile and run your program in the Lind Sandbox.
 
 Inside the development container, `lind-clang` is an alias for `scripts/lind_compile`, and `lind-wasm` is an alias for `scripts/lind_run`. If you are running outside the container, use the scripts directly or add the aliases to your shell.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ id: Overview
 
 Lind is a sandboxing system that runs multiple mutually untrusted applications within a single, unprivileged Linux process. Each application executes in an isolated execution context, called a cage, with its own memory, control flow, and system call behavior.
 
-Unlike traditional process isolation, Lind provides strong intra-process isolation while preserving POSIX semantics and avoiding kernel modifications or privileged execution.
+Unlike traditional process isolation, Lind provides strong intra-process isolation while aiming to preserve POSIX-style semantics and avoid kernel modifications or privileged execution.
 
 In Old Norse, Old High German, and Old English, a “lind” is a shield constructed with two layers of linden wood. Linden wood shields are lightweight and resistant to splitting — an appropriate metaphor for a sandboxing system built from layered isolation technologies.
 
@@ -18,7 +18,7 @@ Lind-Wasm is a realization of Lind that uses WebAssembly for software fault isol
 
 A cage is an isolated execution context within the Lind process. Conceptually, a cage is similar to a Linux process, but multiple cages coexist within a single host process.
 
-Applications are recompiled to WebAssembly and linked against a modified glibc so that all system calls are issued through 3i. Most applications require no source-level changes.
+Applications are recompiled to WebAssembly and linked against a modified glibc so that all system calls are issued through 3i. Most C/POSIX applications can be rebuilt without source-level changes.
 
 Each cage has:
 - isolated memory and control flow

--- a/docs/internal/grates.md
+++ b/docs/internal/grates.md
@@ -53,6 +53,8 @@ Grates are composable. A grate may itself have another grate beneath it that pro
 
 In Unix, programs are often composed using pipelines.
 
+The examples below use illustrative command syntax to show how grate stacks are arranged. They describe the intended ordering and routing behavior; check the current contributor docs and scripts for the exact commands supported by a given build.
+
 For example:
 
 ```sh


### PR DESCRIPTION
## Summary
- soften the overview's POSIX compatibility wording while keeping Most for source-change expectations
- make Getting Started use one primary build path before mentioning alternatives
- clarify that grates examples use illustrative command syntax

## Verification
- git diff --check origin/main..docs/fresh-clarify-overview-getting-started

Replaces #1251.