### PR TITLE
Fix stale docs links and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This monorepo combines various subprojects and dependencies that work together t
 
 | Project       | Location          | Description                                                                 |
 |---------------|-------------------|-----------------------------------------------------------------------------|
-| `glibc`       | `third_party/glibc` | Modified version of glibc to support WebAssembly and Lind interfaces       |
+| `glibc`       | `src/glibc`      | Modified version of glibc to support WebAssembly and Lind interfaces       |
 | `wasmtime`    | `src/wasmtime`    | Embedded Wasmtime runtime for running and debugging Lind-Wasm modules      |
 
 ### Third-Party Binaries
@@ -49,4 +49,3 @@ This monorepo combines various subprojects and dependencies that work together t
 | `binaryen`    | `tools/binaryen`   | Provides `wasm-opt` and other utilities used for optimizing wasm binaries |
 
 ---
-

--- a/docs/contribute/e2e-testing.md
+++ b/docs/contribute/e2e-testing.md
@@ -82,7 +82,7 @@ Runs `scripts/make_glibc_and_sysroot.sh` to:
 
 ### make test
 
-Runs `scripts/wasmtestreport.py` which:
+Runs `scripts/harnesses/wasmtestreport.py` which:
 
 - Discovers tests from the repository’s test trees and honors `skip_test_cases.txt`.
 
@@ -147,5 +147,4 @@ High level:
 - Stale artifacts → run make clean/make distclean and rebuild inside the dev (base) container.
 
 - Cache debugging → add --progress=plain to docker build to see which step invalidated.
-
 

--- a/docs/contribute/testing.md
+++ b/docs/contribute/testing.md
@@ -38,9 +38,9 @@ make lind-boot sysroot
 ```
 6. Run the test suite 
 ```
-./scripts/wasmtestreport.py
+./scripts/harnesses/wasmtestreport.py
 ```
-Run `scripts/wasmtestreport.py --help` to list available usage options.
+Run `scripts/harnesses/wasmtestreport.py --help` to list available usage options.
 
 ## Directory Structure
 
@@ -98,7 +98,7 @@ lind-wasm outputs are compared to the native gcc output.
 ### Example Combined Usage
 
 ```
-./scripts/wasmtestreport.py \
+./scripts/harnesses/wasmtestreport.py \
   --generate-html \
   --skip config_tests file_tests \
   --timeout 10 \
@@ -146,7 +146,7 @@ hello_grate.c
 
 Each grate test must:
 
-- Has dispatcher function called `pass_fptr_to_wt`
+- Register the handlers needed by the cage under test
 - Determine test success internally
 - Exit with EXIT_FAILURE if the test fails
 - Exit normally (e.g., EXIT_SUCCESS) on success
@@ -172,7 +172,7 @@ Make sure the lind-wasm runtime has already been compiled.
 **Step 1 — Compile the Grate**
 
 ```sh
-lind-clang --compile-grate <cage_name>_grate.c
+lind-clang <cage_name>_grate.c
 ```
 
 This produces `<cage_name>_grate.cwasm`

--- a/docs/contribute/toolchain.md
+++ b/docs/contribute/toolchain.md
@@ -63,4 +63,4 @@ and can be used as is.
 
 ## Next steps
 
-Automate the [build and run programs](unit-tests.md) with `Docker` and `make`.
+Automate the [build and run programs](testing.md) with `Docker` and `make`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting Started
 
 1. Make sure to read the [Basics](index.md) first.
-2. If you want to start contributing, check out the [Contributor Instructions](contribute/README.md).
+2. If you want to start contributing, check out the [Contributor Instructions](contribute/index.md).
 3. Continue reading to run a *__Hello World__* program in the Lind Sandbox.
 
 ## Hello World!
@@ -16,7 +16,7 @@ docker pull --platform=linux/amd64 securesystemslab/lind-wasm-dev  # this might 
 docker run --platform=linux/amd64 -it securesystemslab/lind-wasm-dev /bin/bash
 ```
 
-This is a development environment with tooling and source code available, additional instructions to be found [here](contribute/dev-container.md)
+This is a development environment with tooling and source code available. Additional instructions can be found [here](contribute/dev-container.md).
 
 **2. Write a program**
 
@@ -36,17 +36,19 @@ EOF
 
 **3. Compile Lind-Wasm Runtime**
 
-Lind-wasm runtime must be compiled before running the program. To compile the lind-wasm runtime, you will first go to the `lind-wasm/` directory. At there, you can choose:
+The Lind-Wasm runtime must be compiled before running the program. To compile the runtime, first go to the `lind-wasm/` directory. From there, you can choose:
 
-3.a. use `make all` to compile both lind-glibc and rust code at once.
+3.a. Use `make all` to compile both lind-glibc and Rust code at once.
 
-3.b. use `make lind-boot` to compile runtime(lind-boot/wasmtime/rawposix/3i/etc.), and `make sysroot` to compile lind-glibc.
+3.b. Use `make lind-boot` to compile the runtime (`lind-boot`, Wasmtime, RawPOSIX, 3i, etc.), and `make sysroot` to compile lind-glibc.
 
 **NOTES: More options can be found in lind-wasm/Makefile**
 
-**3. Compile and run**
+**4. Compile and run**
 
 Use lind scripts to compile and run your program in the Lind Sandbox.
+
+Inside the development container, `lind-clang` is an alias for `scripts/lind_compile`, and `lind-wasm` is an alias for `scripts/lind_run`. If you are running outside the container, use the scripts directly or add the aliases to your shell.
 
 ```bash
 lind-clang hello.c
@@ -55,10 +57,10 @@ lind-wasm hello.cwasm
 
 *Here is what happens under the hood:*
 
-1.  `lind-clang`(aka `scripts/lind_compile`) compiles `hello.c` into a WebAssembly (WASM)
-binary that is linked against *lind-glibc*, and put into lind file system root(`lind-wasm/lindfs`).
-1. `lind-wasm`(aka `scripts/lind_run`) runs the compiled wasm using *lind-wasm* runtime
-and the *lind-posix* microvisor.
+1. `lind-clang` (aka `scripts/lind_compile`) compiles `hello.c` into a WebAssembly (WASM)
+binary that is linked against *lind-glibc* and put into the Lind file system root (`lind-wasm/lindfs`).
+1. `lind-wasm` (aka `scripts/lind_run`) runs the compiled wasm using the *Lind-Wasm* runtime
+and the *RawPOSIX* microvisor.
 
 --- 
 
@@ -67,5 +69,5 @@ To compile a Rust crate into a *lind-glibc* linked WASM binary, follow this guid
 ## What's next!
 
 The Lind documentation is currently under heavy construction. Please [submit an
-issue](contribute/README.md), if something doesn't seem right or is missing.
+issue](https://github.com/Lind-Project/lind-wasm/issues), if something doesn't seem right or is missing.
 More detailed usage guides will follow soon!


### PR DESCRIPTION
## Summary
- fix broken contributor/testing links in the docs
- document the lind-clang and lind-wasm aliases in Getting Started
- update stale test harness paths and grate-test compile wording
- correct the glibc source path in the top-level README

## Verification
- git diff --check origin/main..docs/fresh-fix-stale-docs-links

Replaces #1249.