### PR TITLE
add security.md

### DIFF
--- a/docs/contribute/security.md
+++ b/docs/contribute/security.md
@@ -1,7 +1,0 @@
-# Security Issues and Bugs
-
-Security issues can be reported to maintainers [privately via GitHub](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability):
-
-- [**Report new vulnerability**](https://github.com/Lind-Project/lind-wasm/security/advisories/new)
-
-Please do not use the GitHub issue tracker to submit vulnerability reports. The issue tracker is intended for bug reports and to make feature requests.

--- a/security.md
+++ b/security.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+We currently only support the latest code on our primary branch. Security fixes are not backported to older commits.
+
+| Branch           | Supported          |
+| ---------------- | ------------------ |
+| main             | Yes                |
+
+
+
+## Reporting a Vulnerability
+
+We take the security of our project seriously. If you discover a security vulnerability, please do not open a public issue or pull request. Publicly disclosing a vulnerability exposes the project and its users to exploits before a patch can be issued.
+
+Please report all security vulnerabilities privately by sending an email to our Security Point of Contact at **[admin@email.com]**.
+
+To help us investigate and resolve the issue as quickly as possible, please include the following information in your email:
+* A detailed description of the vulnerability and its potential impact.
+* Step-by-step instructions to reproduce the issue (including proof-of-concept code, logs, or screenshots).
+* The specific environment or configuration under which the vulnerability occurs.
+
+## Disclosure Process & Timeline
+
+Upon receiving a report, we handle the process as follows:
+
+* Response Timeline: We will acknowledge receipt of your email within 3 business days.
+* Disclosure Process: Valid vulnerabilities will be investigated and patched privately. We will publicly disclose the details only after a fix is available on the `main` branch.

--- a/security.md
+++ b/security.md
@@ -8,22 +8,20 @@ We currently only support the latest code on our primary branch. Security fixes 
 | ---------------- | ------------------ |
 | main             | Yes                |
 
-
-
 ## Reporting a Vulnerability
 
-We take the security of our project seriously. If you discover a security vulnerability, please do not open a public issue or pull request. Publicly disclosing a vulnerability exposes the project and its users to exploits before a patch can be issued.
+We take the security of our project seriously. If you discover a security vulnerability, please **do not open a public issue or pull request**. Publicly disclosing a vulnerability exposes the project and its users to exploits before a patch can be issued.
 
-Please report all security vulnerabilities privately by sending an email to our Security Point of Contact at **[admin@email.com]**.
+Please report all security vulnerabilities privately via [**Report new vulnerability**](https://github.com/Lind-Project/lind-wasm/security/advisories/new)
 
-To help us investigate and resolve the issue as quickly as possible, please include the following information in your email:
+To help us investigate and resolve the issue as quickly as possible, please include the following information:
 * A detailed description of the vulnerability and its potential impact.
-* Step-by-step instructions to reproduce the issue (including proof-of-concept code, logs, or screenshots).
+* Step-by-step instructions to reproduce the issue.
 * The specific environment or configuration under which the vulnerability occurs.
 
 ## Disclosure Process & Timeline
 
 Upon receiving a report, we handle the process as follows:
 
-* Response Timeline: We will acknowledge receipt of your email within 3 business days.
-* Disclosure Process: Valid vulnerabilities will be investigated and patched privately. We will publicly disclose the details only after a fix is available on the `main` branch.
+* Response Timeline: We will acknowledge receipt of the report within 3 business days.
+* Disclosure Process: Valid vulnerabilities will be investigated and patched privately within a GitHub Security Advisory. We will publicly disclose the details only after a fix is available on the `main` branch.


### PR DESCRIPTION
Adds a `SECURITY.md` file, which is a mandatory prerequisite for filing for the ORCA Sandbox. 

Following the OpenSSF policy guidelines, the file is intentionally kept minimal and accurate to satisfy the Sandbox tier's essential requirements, while its structure allows us to easily expand it as the project scales up.

### Included
* Supported Versions: Specifies that only the active `main` branch receives security fixes.
* Reporting a Vulnerability: Outlines instructions for private reporting via email to prevent premature public disclosure.
    * The file currently uses an email (`[admin@email.com]`). We need to decide on a maintainer email address to route these private security reports. 
* Disclosure Process & Timeline: Establishes a clean, realistic response window and a private patching workflow.

Relates to #1247 