### PR TITLE
Implement copy_file_range syscall

### DIFF
--- a/src/glibc/lind_syscall/lind_syscall_num.h
+++ b/src/glibc/lind_syscall/lind_syscall_num.h
@@ -140,6 +140,7 @@
 #define PWRITEV_SYSCALL 296
 #define PRLIMIT64_SYSCALL 302
 #define GETRANDOM_SYSCALL 318
+#define COPY_FILE_RANGE_SYSCALL 326
 
 /* Lind-specific syscalls (not part of the Linux syscall table) */
 #define REGISTER_HANDLER_SYSCALL 1001

--- a/src/glibc/sysdeps/unix/sysv/linux/copy_file_range.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/copy_file_range.c
@@ -18,16 +18,30 @@
 
 #include <errno.h>
 #include <unistd.h>
+#include <stdint.h>
+#include <syscall-template.h>
+#include <lind_syscall_num.h>
+#include <addr_translation.h>
 
 ssize_t
 copy_file_range (int infd, __off64_t *pinoff,
                  int outfd, __off64_t *poutoff,
                  size_t length, unsigned int flags)
 {
-  // BUG: we currently cannot support this syscall
-  //      so instead of letting it crash directly,
-  //      let's just set the errno and return - Qianxi Chen
-  __set_errno (ENOSYS);
-  return -1;
+  uint64_t host_pinoff = pinoff == NULL
+                         ? 0
+                         : TRANSLATE_GUEST_POINTER_TO_HOST (pinoff);
+  uint64_t host_poutoff = poutoff == NULL
+                          ? 0
+                          : TRANSLATE_GUEST_POINTER_TO_HOST (poutoff);
+
+  return MAKE_LEGACY_SYSCALL (COPY_FILE_RANGE_SYSCALL,
+                              "syscall|copy_file_range",
+                              (uint64_t) infd,
+                              host_pinoff,
+                              (uint64_t) outfd,
+                              host_poutoff,
+                              (uint64_t) length,
+                              (uint64_t) flags,
+                              TRANSLATE_ERRNO_ON);
 }
-stub_warning (copy_file_range)

--- a/src/rawposix/src/fs_calls.rs
+++ b/src/rawposix/src/fs_calls.rs
@@ -3868,6 +3868,71 @@ pub extern "C" fn pwrite_syscall(
     ret
 }
 
+/// Reference to Linux: https://man7.org/linux/man-pages/man2/copy_file_range.2.html
+///
+/// Linux `copy_file_range()` copies up to `len` bytes from one file descriptor
+/// to another. If `off_in` or `off_out` is NULL, the corresponding file offset
+/// is used and updated by the kernel. If they are non-NULL, they point to file
+/// offsets and the file offsets of the descriptors are not changed.
+pub extern "C" fn copy_file_range_syscall(
+    cageid: u64,
+    fd_in_arg: u64,
+    fd_in_cageid: u64,
+    off_in_arg: u64,
+    off_in_cageid: u64,
+    fd_out_arg: u64,
+    fd_out_cageid: u64,
+    off_out_arg: u64,
+    off_out_cageid: u64,
+    len_arg: u64,
+    len_cageid: u64,
+    flags_arg: u64,
+    flags_cageid: u64,
+) -> i32 {
+    let fd_in = convert_fd_to_host(fd_in_arg, fd_in_cageid, cageid);
+    if fd_in < 0 {
+        return handle_errno(-fd_in, "copy_file_range");
+    }
+
+    let fd_out = convert_fd_to_host(fd_out_arg, fd_out_cageid, cageid);
+    if fd_out < 0 {
+        return handle_errno(-fd_out, "copy_file_range");
+    }
+
+    let off_in = if off_in_arg == 0 {
+        std::ptr::null_mut()
+    } else {
+        sc_convert_buf(off_in_arg, off_in_cageid, cageid) as *mut libc::loff_t
+    };
+
+    let off_out = if off_out_arg == 0 {
+        std::ptr::null_mut()
+    } else {
+        sc_convert_buf(off_out_arg, off_out_cageid, cageid) as *mut libc::loff_t
+    };
+
+    let len = sc_convert_sysarg_to_usize(len_arg, len_cageid, cageid);
+    let flags = sc_convert_sysarg_to_u32(flags_arg, flags_cageid, cageid);
+
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_copy_file_range as libc::c_long,
+            fd_in,
+            off_in,
+            fd_out,
+            off_out,
+            len,
+            flags,
+        ) as i32
+    };
+
+    if ret < 0 {
+        return handle_errno(get_errno(), "copy_file_range");
+    }
+
+    ret
+}
+
 /// Reference to Linux: https://man7.org/linux/man-pages/man2/chdir.2.html
 ///
 /// Linux `chdir()` syscall changes the current working directory of the calling process to the directory

--- a/src/rawposix/src/syscall_table.rs
+++ b/src/rawposix/src/syscall_table.rs
@@ -5,19 +5,19 @@
 //! Keep these in sync with glibc's lind_syscall_num.h
 use super::fs_calls::{
     access_syscall, brk_syscall, chdir_syscall, chmod_syscall, chown_syscall,
-    clock_gettime_syscall, close_syscall, dup2_syscall, dup3_syscall, dup_syscall,
-    faccessat_syscall, fchdir_syscall, fchmod_syscall, fchmodat_syscall, fchownat_syscall,
-    fcntl_syscall, fdatasync_syscall, flock_syscall, fstat_syscall, fstatat_syscall,
-    fstatfs_syscall, fsync_syscall, ftruncate_syscall, futex_syscall, getcwd_syscall,
-    getdents_syscall, getrandom_syscall, ioctl_syscall, lchown_syscall, link_syscall,
-    listxattr_syscall, lseek_syscall, lstat_syscall, mkdir_syscall, mknod_syscall, mmap_syscall,
-    mprotect_syscall, munmap_syscall, nanosleep_time64_syscall, open_syscall, openat_syscall,
-    pipe2_syscall, pipe_syscall, pread_syscall, preadv_syscall, pwrite_syscall, pwritev_syscall,
-    read_syscall, readlink_syscall, readlinkat_syscall, readv_syscall, rename_syscall,
-    renameat2_syscall, renameat_syscall, rmdir_syscall, setxattr_syscall, shmat_syscall,
-    shmctl_syscall, shmdt_syscall, shmget_syscall, stat_syscall, statfs_syscall, symlink_syscall,
-    symlinkat_syscall, sync_file_range_syscall, truncate_syscall, unlink_syscall, unlinkat_syscall,
-    utimensat_syscall, write_syscall, writev_syscall,
+    clock_gettime_syscall, close_syscall, copy_file_range_syscall, dup2_syscall, dup3_syscall,
+    dup_syscall, faccessat_syscall, fchdir_syscall, fchmod_syscall, fchmodat_syscall,
+    fchownat_syscall, fcntl_syscall, fdatasync_syscall, flock_syscall, fstat_syscall,
+    fstatat_syscall, fstatfs_syscall, fsync_syscall, ftruncate_syscall, futex_syscall,
+    getcwd_syscall, getdents_syscall, getrandom_syscall, ioctl_syscall, lchown_syscall,
+    link_syscall, listxattr_syscall, lseek_syscall, lstat_syscall, mkdir_syscall, mknod_syscall,
+    mmap_syscall, mprotect_syscall, munmap_syscall, nanosleep_time64_syscall, open_syscall,
+    openat_syscall, pipe2_syscall, pipe_syscall, pread_syscall, preadv_syscall, pwrite_syscall,
+    pwritev_syscall, read_syscall, readlink_syscall, readlinkat_syscall, readv_syscall,
+    rename_syscall, renameat2_syscall, renameat_syscall, rmdir_syscall, setxattr_syscall,
+    shmat_syscall, shmctl_syscall, shmdt_syscall, shmget_syscall, stat_syscall, statfs_syscall,
+    symlink_syscall, symlinkat_syscall, sync_file_range_syscall, truncate_syscall, unlink_syscall,
+    unlinkat_syscall, utimensat_syscall, write_syscall, writev_syscall,
 };
 use super::init::RawCallFunc;
 use super::net_calls::{
@@ -179,4 +179,8 @@ pub const SYSCALL_TABLE: &[(u64, RawCallFunc)] = &[
     (syscall_const::PRLIMIT64_SYSCALL as u64, prlimit64_syscall),
     (syscall_const::RENAMEAT2_SYSCALL as u64, renameat2_syscall),
     (syscall_const::GETRANDOM_SYSCALL as u64, getrandom_syscall),
+    (
+        syscall_const::COPY_FILE_RANGE_SYSCALL as u64,
+        copy_file_range_syscall,
+    ),
 ];

--- a/src/sysdefs/src/constants/syscall_const.rs
+++ b/src/sysdefs/src/constants/syscall_const.rs
@@ -118,4 +118,5 @@ pub const DUP3_SYSCALL: i32 = 292;
 pub const PIPE2_SYSCALL: i32 = 293;
 pub const RENAMEAT2_SYSCALL: i32 = 316;
 pub const GETRANDOM_SYSCALL: i32 = 318;
+pub const COPY_FILE_RANGE_SYSCALL: i32 = 326;
 pub const STATX_SYSCALL: i32 = 332;

--- a/tests/unit-tests/file_tests/deterministic/copy_file_range.c
+++ b/tests/unit-tests/file_tests/deterministic/copy_file_range.c
@@ -1,0 +1,108 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#define INPUT_FILE "testfiles/copy_file_range_unit_in.txt"
+#define OUTPUT_FILE "testfiles/copy_file_range_unit_out.txt"
+
+static void cleanup(void)
+{
+    unlink(INPUT_FILE);
+    unlink(OUTPUT_FILE);
+}
+
+int main(void)
+{
+    cleanup();
+
+    int in = open(INPUT_FILE, O_CREAT | O_RDWR | O_TRUNC, 0644);
+    int out = open(OUTPUT_FILE, O_CREAT | O_RDWR | O_TRUNC, 0644);
+
+    if (in < 0 || out < 0) {
+        perror("open");
+        cleanup();
+        return 1;
+    }
+
+    const char *msg = "0123456789";
+    size_t len = strlen(msg);
+
+    if (write(in, msg, len) != (ssize_t)len) {
+        perror("write");
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    long long in_off = 2;
+    long long out_off = 0;
+
+    ssize_t copied = copy_file_range(in, &in_off, out, &out_off, 4, 0);
+    if (copied != 4) {
+        fprintf(stderr, "copy_file_range copied %d bytes, expected 4\n", (int)copied);
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    if (in_off != 6 || out_off != 4) {
+        fprintf(stderr, "unexpected offsets: in_off=%lld out_off=%lld\n", in_off, out_off);
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    char buf[16] = {0};
+
+    if (lseek(out, 0, SEEK_SET) < 0) {
+        perror("lseek");
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    ssize_t bytes_read = read(out, buf, sizeof(buf) - 1);
+    if (bytes_read < 0) {
+        perror("read");
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    if (strcmp(buf, "2345") != 0) {
+        fprintf(stderr, "unexpected copied content: '%s'\n", buf);
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    errno = 0;
+    copied = copy_file_range(in, &in_off, out, &out_off, 1, 1);
+    if (copied != -1 || errno != EINVAL) {
+        fprintf(stderr, "nonzero flags should fail with EINVAL, got copied=%d errno=%d\n",
+                (int)copied, errno);
+        close(in);
+        close(out);
+        cleanup();
+        return 1;
+    }
+
+    close(in);
+    close(out);
+    cleanup();
+
+    printf("copy_file_range unit test passed\n");
+    fflush(stdout);
+
+    return 0;
+}


### PR DESCRIPTION
## Purpose

This PR implements support for the Linux copy_file_range syscall in Lind-Wasm. The syscall was previously unavailable through Lind: the glibc-side copy_file_range() implementation returned ENOSYS, which caused Python-related tests that rely on file-copy behavior to fail.

The implementation wires copy_file_range through the full Lind syscall path:

```c
glibc copy_file_range()
  -> MAKE_LEGACY_SYSCALL(COPY_FILE_RANGE_SYSCALL)
  -> Lind syscall trampoline
  -> RawPOSIX syscall table
  -> copy_file_range_syscall()
  -> host SYS_copy_file_range
```

## Related Issue

Fixes #1240.

## Changes

* Added COPY_FILE_RANGE_SYSCALL with the Linux x86_64 syscall number 326.
* Added the syscall number to both:
    * src/sysdefs/src/constants/syscall_const.rs
    * src/glibc/lind_syscall/lind_syscall_num.h
* Replaced the existing glibc copy_file_range ENOSYS stub with a Lind MAKE_LEGACY_SYSCALL wrapper.
* Added copy_file_range_syscall in RawPOSIX.
* Registered copy_file_range_syscall in the RawPOSIX syscall dispatcher table.
* Preserved support for:
    * explicit input/output offset pointers
    * NULL offset pointers
    * errno translation through the existing Lind syscall wrapper path

## Testing

Tested locally with:

```c
cargo fmt --check --all --manifest-path src/wasmtime/Cargo.toml
make sysroot
make lind-boot
```

I also manually verified the syscall with small Lind-compiled C programs covering:

1. Basic file copy through copy_file_range.
2. Nonzero flags returning EINVAL.
3. Explicit off_in and off_out pointer behavior, including offset updates and copied content validation.

Observed outputs included:

```c
copy_file_range ok
copy_file_range flags test ok
copy_file_range offsets test ok
```

## Notes for Reviewers

The previous glibc implementation intentionally returned ENOSYS, so RawPOSIX was never reached when guest programs called copy_file_range(). This PR updates both sides of the syscall path: the glibc wrapper and the RawPOSIX dispatcher/handler.

The RawPOSIX implementation currently delegates to the host SYS_copy_file_range after translating Lind virtual file descriptors to host file descriptors. This matches the existing style used by nearby file syscalls such as pread, pwrite, and lseek, which similarly translate descriptors and then invoke the host libc/syscall layer.