### PR TITLE
Reduce lind-wasm internal GC heap reservation

### DIFF
--- a/src/lind-boot/src/cli.rs
+++ b/src/lind-boot/src/cli.rs
@@ -77,6 +77,10 @@ pub struct CliOptions {
     /// Defaults to 64 MiB.
     #[arg(long = "thread-stack-size", default_value_t = 64 * 1024 * 1024)]
     pub thread_stack_size: usize,
+
+    /// Internal memory reservation for Lind's own use (e.g., GC Heap) in bytes.
+    #[arg(long = "lind-internal-memory-reservation", default_value_t = 10 * 1024 * 1024)]
+    pub lind_internal_memory_reservation: u64,
 }
 
 pub fn parse_env_var(s: &str) -> Result<(String, Option<String>), String> {

--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -86,8 +86,11 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
     init_vmctx_pool();
 
     // -- Initialize the Wasmtime execution environment --
-    let wt_config =
-        make_wasmtime_config(lindboot_cli.wasmtime_backtrace, lindboot_cli.enable_fpcast);
+    let wt_config = make_wasmtime_config(
+        lindboot_cli.wasmtime_backtrace,
+        lindboot_cli.enable_fpcast,
+        lindboot_cli.lind_internal_memory_reservation,
+    );
     let engine = Engine::new(&wt_config)
         .map_err(anyhow::Error::from)
         .context("failed to create execution engine")?;
@@ -886,7 +889,11 @@ pub fn precompile_module(cli: &CliOptions) -> Result<()> {
     let wasm_path = Path::new(cli.wasm_file());
     let cwasm_path = wasm_path.with_extension("cwasm");
 
-    let wt_config = make_wasmtime_config(cli.wasmtime_backtrace, false);
+    let wt_config = make_wasmtime_config(
+        cli.wasmtime_backtrace,
+        false,
+        cli.lind_internal_memory_reservation,
+    );
     let engine = Engine::new(&wt_config)
         .map_err(anyhow::Error::from)
         .context("failed to create engine")?;
@@ -1001,12 +1008,17 @@ fn invoke_func(store: &mut Store<HostCtx>, func: Func, args: &[String]) -> Resul
 
 /// Generates a wasmtime config based on the whether or not the --wasmtime-backtrace flag was
 /// provided to lind-boot.
-fn make_wasmtime_config(backtrace: bool, enable_fpcast: bool) -> wasmtime::Config {
+fn make_wasmtime_config(
+    backtrace: bool,
+    enable_fpcast: bool,
+    lind_internal_memory_reservation: u64,
+) -> wasmtime::Config {
     let mut wt_config = wasmtime::Config::new();
     wt_config.wasm_backtrace(backtrace);
     wt_config.fpcast_enabled(enable_fpcast);
     wt_config.wasm_threads(true);
     wt_config.shared_memory(true);
+    wt_config.lind_internal_memory_reservation(lind_internal_memory_reservation);
     // wasm-opt --translate-to-exnref converts clang 18's legacy EH to the standard proposal.
     // The standard EXCEPTIONS proposal is supported by Cranelift; the legacy proposal is not.
     #[cfg(not(feature = "asyncify-setjmp"))]

--- a/src/wasmtime/crates/environ/src/tunables.rs
+++ b/src/wasmtime/crates/environ/src/tunables.rs
@@ -74,6 +74,12 @@ define_tunables! {
         /// memory for growth.
         pub memory_reservation_for_growth: u64,
 
+        /// lind-wasm:
+        /// Initial reservation, in bytes, for lind-wasm internal memories
+        /// such as Wasmtime GC heap. Guest shared memory still uses
+        /// `memory_reservation`.
+        pub lind_internal_memory_reservation: u64,
+
         /// Whether or not to generate native DWARF debug information.
         pub debug_native: bool,
 
@@ -212,6 +218,7 @@ impl Tunables {
             memory_reservation: 1 << 20,
             memory_guard_size: 0,
             memory_reservation_for_growth: 0,
+            lind_internal_memory_reservation: 10 * (1 << 20),
 
             // General options which have the same defaults regardless of
             // architecture.

--- a/src/wasmtime/crates/wasmtime/src/config.rs
+++ b/src/wasmtime/crates/wasmtime/src/config.rs
@@ -1791,6 +1791,14 @@ impl Config {
         self
     }
 
+    /// lind-wasm:
+    /// Configures the reservation size for lind-wasm internal memories,
+    /// such as Wasmtime GC heap. This does not affect Lind guest shared memory.
+    pub fn lind_internal_memory_reservation(&mut self, bytes: u64) -> &mut Self {
+        self.tunables.lind_internal_memory_reservation = Some(bytes);
+        self
+    }
+
     /// Indicates whether linear memories may relocate their base pointer at
     /// runtime.
     ///

--- a/src/wasmtime/crates/wasmtime/src/engine/serialization.rs
+++ b/src/wasmtime/crates/wasmtime/src/engine/serialization.rs
@@ -318,6 +318,7 @@ impl Metadata<'_> {
 
             // This doesn't affect compilation, it's just a runtime setting.
             memory_reservation_for_growth: _,
+            lind_internal_memory_reservation: _,
 
             // This does technically affect compilation but modules with/without
             // trap information can be loaded into engines with the opposite

--- a/src/wasmtime/crates/wasmtime/src/runtime/vm/memory/mmap.rs
+++ b/src/wasmtime/crates/wasmtime/src/runtime/vm/memory/mmap.rs
@@ -54,8 +54,14 @@ impl MmapMemory {
         minimum: usize,
         mut maximum: Option<usize>,
     ) -> Result<Self> {
+        const LIND_INTERNAL_MEMORY_RESERVATION: u64 = 10 * 1024 * 1024;
+
+        let is_lind_guest_memory = ty.shared;
         // lind-wasm: we enable maximum use of memory at start
-        maximum = Some(super::MAX_MEMORY_SIZE);
+        if is_lind_guest_memory {
+            maximum = Some(super::MAX_MEMORY_SIZE);
+        }
+
         // It's a programmer error for these two configuration values to exceed
         // the host available address space, so panic if such a configuration is
         // found (mostly an issue for hypothetical 32-bit hosts).
@@ -80,8 +86,18 @@ impl MmapMemory {
         // to reserve any extra for growth.
         //
         // If the minimum size doesn't fit within this linear memory.
-        let mut alloc_bytes = tunables.memory_reservation;
-        let mut extra_to_reserve_on_growth = tunables.memory_reservation_for_growth;
+        let mut alloc_bytes = if is_lind_guest_memory {
+            tunables.memory_reservation
+        } else {
+            tunables.lind_internal_memory_reservation
+        };
+
+        let mut extra_to_reserve_on_growth = if is_lind_guest_memory {
+            tunables.memory_reservation_for_growth
+        } else {
+            0
+        };
+
         let minimum_u64 = u64::try_from(minimum).unwrap();
         if minimum_u64 <= alloc_bytes {
             if let Ok(max) = ty.maximum_byte_size() {


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Resolves #1262 

1. Keep the 4GiB reservation for Lind guest shared memory. Do not apply the same 4GiB reservation policy to Wasmtime internal memories such as GC heap.
2. Add a configurable Lind internal-memory reservation size, defaulting to something small such as 10MiB. Use that smaller reservation for shared=false internal memories.
3. Applications using a large amount of EH-based setjmp/exception state could exhaust the smaller GC heap and fail, so the value is configurable through CLI.