### PR TITLE
Improve wasm test runner progress reporting

### DIFF
--- a/scripts/test/harnesses/wasmtestreport.py
+++ b/scripts/test/harnesses/wasmtestreport.py
@@ -402,14 +402,14 @@ def add_test_result(result, file_path, status, error_type, output, timing_info=N
     if status.lower() == "success":
         result["number_of_success"] += 1
         result["success"].append(file_path)
-        logger.info("SUCCESS")
+        logger.debug("SUCCESS")
     else:
         result["number_of_failures"] += 1
         result["failures"].append(file_path)
         
         error_message = error_types.get(error_type, "Undefined Failure")
 
-        logger.error(f"FAILURE: {error_message}")
+        logger.debug(f"FAILURE: {error_message}")
         if error_type in error_types:
             result[f"number_of_{error_type}"] += 1
             result[error_type].append(file_path)
@@ -1298,7 +1298,7 @@ def is_file_in_folder(file_path, folder_list):
 # ----------------------------------------------------------------------
 def should_run_file(file_path, run_folders, skip_folders, skip_test_cases):
     if file_path in skip_test_cases:
-        logger.info(f"Skipping {file_path}")
+        logger.debug(f"Skipping {file_path}")
         return False
 
     if skip_folders and is_file_in_folder(file_path, skip_folders):
@@ -1580,24 +1580,97 @@ def get_test_mode(source_file):
 #          results - results dictionary, timeout_sec - timeout for tests
 # - Output: None (modifies results dictionary)
 # ----------------------------------------------------------------------
+def _get_new_test_case(result, before_test_cases):
+    """Return the newly recorded test case after running one test, if any."""
+    after_test_cases = set(result["test_cases"].keys())
+    new_cases = list(after_test_cases - before_test_cases)
+    if not new_cases:
+        return None, None
+    test_name = new_cases[0]
+    return test_name, result["test_cases"][test_name]
+
+
+def _print_failure_details(failed_tests):
+    """Print deferred failure details after the compact progress line."""
+    if not failed_tests:
+        return
+
+    print("\nFailures:", flush=True)
+    for test_name, test_case in failed_tests:
+        print(f"\n{test_name}", flush=True)
+        error_type = test_case.get("error_type")
+        if error_type:
+            print(f"Error type: {error_type}", flush=True)
+
+        output = test_case.get("output", "")
+        if output:
+            print(output.rstrip(), flush=True)
+
+
 def run_tests(config, artifacts_root, results, timeout_sec):
-    """Execute all tests"""
+    """Execute all tests with compact progress and deferred failure details."""
     total_count = len(config['tests_to_run'])
+    failed_tests = []
+    skipped_count = 0
+
+    print(f"Running {total_count} tests")
     
-    for i, original_source in enumerate(config['tests_to_run']):
-        logger.info(f"[{i+1}/{total_count}] {original_source}")
-        
+    for original_source in config['tests_to_run']:
         dest_source = setup_test_file_in_artifacts(original_source, artifacts_root)
         
         # Determine test type and run appropriate test
         test_mode = get_test_mode(original_source)
+        if test_mode not in ("deterministic", "fail"):
+            logger.debug(f"Test file {original_source} is not in a deterministic or fail folder - skipping")
+            print("S", end="", flush=True)
+            skipped_count += 1
+            continue
+
+        result_bucket = results[test_mode]
+        before_test_cases = set(result_bucket["test_cases"].keys())
+
         if test_mode == "deterministic":
-            test_single_file_deterministic(dest_source, results["deterministic"], timeout_sec, allow_precompiled=config['allow_precompiled'])
-        elif test_mode == "fail":
-            test_single_file_fail(dest_source, results["fail"], timeout_sec, allow_precompiled=config['allow_precompiled'])
+            test_single_file_deterministic(
+                dest_source,
+                result_bucket,
+                timeout_sec,
+                allow_precompiled=config['allow_precompiled'],
+            )
         else:
-            # Log warning for tests not in deterministic/fail folders
-            logger.warning(f"Test file {original_source} is not in a deterministic or fail folder - skipping")
+            test_single_file_fail(
+                dest_source,
+                result_bucket,
+                timeout_sec,
+                allow_precompiled=config['allow_precompiled'],
+            )
+
+        test_name, test_case = _get_new_test_case(result_bucket, before_test_cases)
+        if test_case is None:
+            print("S", end="", flush=True)
+            skipped_count += 1
+            continue
+
+        if str(test_case.get("status", "")).lower() == "success":
+            print(".", end="", flush=True)
+        else:
+            print("X", end="", flush=True)
+            failed_tests.append((str(original_source), test_case))
+
+    print("\n", flush=True)
+
+    passed_count = sum(results[k]["number_of_success"] for k in ("deterministic", "fail"))
+    failed_count = sum(results[k]["number_of_failures"] for k in ("deterministic", "fail"))
+
+    summary_parts = [
+        f"{passed_count} passed",
+        f"{failed_count} failed",
+    ]
+    if skipped_count:
+        summary_parts.append(f"{skipped_count} skipped")
+
+    print(", ".join(summary_parts), flush=True)
+    _print_failure_details(failed_tests)
+    sys.stdout.flush()
 
 def build_fail_message(case: str, native_output: str, wasm_output: str, native_retcode=None, wasm_retcode=None) -> str:
     """

--- a/scripts/test/test_runner.py
+++ b/scripts/test/test_runner.py
@@ -91,11 +91,34 @@ def discover_harness_modules(selected: set[str] | None = None) -> list[str]:
     return modules
 
 
-def execute_with_echo(command: list[str], cwd: Path, prefix: str) -> tuple[int, str]:
-    """Run command and stream output lines with a prefix.
+def _is_compact_test_progress_line(line: str) -> bool:
+    """Return True for compact test-progress lines that should be passed through unchanged."""
+    stripped = line.strip()
 
-    Returns:
-        tuple(return_code, combined_output)
+    if not stripped:
+        return True
+
+    if re.fullmatch(r"Running \d+ tests", stripped):
+        return True
+
+    if re.fullmatch(r"[.XS]+", stripped):
+        return True
+
+    if re.fullmatch(r"\d+ passed, \d+ failed(, \d+ skipped)?", stripped):
+        return True
+
+    if stripped == "Failures:":
+        return True
+
+    return False
+
+
+def execute_with_echo(command: list[str], cwd: Path, prefix: str) -> tuple[int, str]:
+    """Run command and stream output.
+
+    Compact test-progress lines are passed through unchanged so targets such as
+    `make test` show the same concise progress output as the underlying harness.
+    Other lines keep a harness prefix for context.
     """
     output_lines: list[str] = []
     env = os.environ.copy()
@@ -114,7 +137,10 @@ def execute_with_echo(command: list[str], cwd: Path, prefix: str) -> tuple[int, 
 
     assert proc.stdout is not None
     for line in proc.stdout:
-        print(f"[{prefix}] {line}", end="")
+        if prefix == "wasmtestreport" or _is_compact_test_progress_line(line):
+            print(line, end="")
+        else:
+            print(f"[{prefix}] {line}", end="")
         output_lines.append(line)
 
     proc.wait()


### PR DESCRIPTION
## Purpose

This PR improves the progress and failure reporting for the wasm test runner.

Previously, the runner printed per-test success/failure messages and made it harder to quickly identify which tests failed. This update changes the runtime output to a compact progress format where each passing test prints ., each failing test prints X, and skipped/unknown cases print S.

At the end of the run, the runner now prints a summary and defers detailed failure output to a dedicated `Failures` section.

## Related Issue

Fixes #1274.

## Changes

* Added compact progress reporting to `wasmtestreport.py.`
* Prints:
    * . for passed tests
    * X for failed tests
    * S for skipped or unrecorded tests
* Defers detailed failure output until after all tests complete.
* Prints a final summary with passed, failed, and skipped counts.
* Lowers per-test success/failure logging from `info/error` to debug so normal output stays concise.
* Lowers skip logging to debug to reduce noise when using `--run`.

## Example Output

```c
Running 73 tests
......................................X............................XX...X
69 passed, 4 failed
Failures:
/home/lind/lind-wasm/tests/unit-tests/file_tests/deterministic/unlinkat.c
Error type: Failure_native_running
Native execution: Failed to create file in subdirectory: Permission denied
```

## Testing

Ran syntax validation:

```c
python3 -m py_compile scripts/test/harnesses/wasmtestreport.py
```

Also tested the updated reporting with:

```c
python3 scripts/test/harnesses/wasmtestreport.py \
  --run file_tests \
  --allow-pre-compiled \
  --skip-libcpp
```

Observed the expected compact progress line, summary, and deferred failure details.

Note: the local `file_tests` run reported 69 passed and 4 failed. The failures appear related to local filesystem/test environment state, such as permission errors and pre-existing files, rather than the reporting change itself.