### PR TITLE
Fold E2E PR report sections by harness

### DIFF
--- a/scripts/generate/render_e2e_templates.py
+++ b/scripts/generate/render_e2e_templates.py
@@ -15,20 +15,18 @@ def strip_top_h1(html: str) -> str:
     return re.sub(r'(?is)<\s*h1\b[^>]*>.*?</\s*h1\s*>', '', html, count=1)
 
 def wrap_sections_as_details(html: str) -> str:
-    
-    #Wrap each <div class="test-section">…</div> as:
-    #  <details><summary>{h2 text}</summary>…(section content without the h2)…</details>
-    
+    # Wrap each <section>/<div class="test-section"> from its h2 title:
+    #   <details><summary>{h2 text}</summary>…(content without the h2)…</details>
     pattern = re.compile(
         r"""
-        <div
+        <(?P<tag>section|div)
             [^>]*
             class="[^"]*\btest-section\b[^"]*"
             [^>]*>
             \s*
             (?:<h2[^>]*>(?P<title>.*?)</h2>)?
             (?P<body>.*?)
-        </div>
+        </(?P=tag)>
         """,
         re.IGNORECASE | re.DOTALL | re.VERBOSE,
     )


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
Update the E2E PR comment renderer to fold each harness section from its `h2`.

This makes report comments consistent across harnesses instead of only folding sections that happen to contain `h3 + table` markup.
