### PR TITLE
fix dockerfile.e2e - update version of libtinfo5

### DIFF
--- a/Docker/Dockerfile.e2e
+++ b/Docker/Dockerfile.e2e
@@ -91,9 +91,8 @@ ENV PATH="/${CLANG}/bin:${PATH}"
 ENV MATH_TEST_DIR="math_tests"
 
 # --- Install libtinfo5 ---
-RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
-    apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
-
+RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb && \
+    apt install ./libtinfo5_6.3-2ubuntu0.2_amd64.deb
 
 # Install rust
 # --profile minimal tells rustup to install only the essentials for the toolchain


### PR DESCRIPTION
### Cause
Ubuntu released a security update on security.ubuntu.com that replaced the `libtinfo5_6.3-2ubuntu0.1_amd64.deb` package. Dockerfile.e2e was still pulling the removed version, causing the pipeline to fail.

### Fix
Updated Dockerfile.e2e to download the updated package version.