### PR TITLE
fix dockerfile.dev - update version of libtinfo5

### DIFF
--- a/Docker/Dockerfile.dev
+++ b/Docker/Dockerfile.dev
@@ -76,9 +76,9 @@ RUN groupadd --gid 1000 ${USERNAME} && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # --- Install libtinfo5 as root ---
-RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb && \
-    apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
-
+RUN wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.2_amd64.deb && \
+    apt install ./libtinfo5_6.3-2ubuntu0.2_amd64.deb
+    
 # --- Switch to user ASAP ---
 USER ${USERNAME}
 WORKDIR /home/${USERNAME}


### PR DESCRIPTION
Cause
Ubuntu released a security update on security.ubuntu.com that replaced the libtinfo5_6.3-2ubuntu0.1_amd64.deb package. Dockerfile.dev was still pulling the removed version, causing the pipeline to fail.

Fix
Updated Dockerfile.dev to download the updated package version.