### PR TITLE
Restore guest clone_args after clone3 syscall in glibc

### DIFF
--- a/src/glibc/sysdeps/unix/sysv/linux/i386/clone3.c
+++ b/src/glibc/sysdeps/unix/sysv/linux/i386/clone3.c
@@ -14,7 +14,10 @@ int __GI___clone3 (struct clone_args *cl_args, size_t size, int (*func)(void *),
   int pid = MAKE_LEGACY_SYSCALL(CLONE_SYSCALL, "syscall|clone3",
                          host_cl_args,
                          NOTUSED, NOTUSED, NOTUSED, NOTUSED, NOTUSED, TRANSLATE_ERRNO_ON);
-
+  
+  /* Restore guest-visible clone_args. */
+  cl_args->child_tid = guest_child_tid;
+  
   if (pid == 0) {
     // Reinitialize address translation only for fork (new cage).
     // For threads (CLONE_VM), the address space is shared with the parent,


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

The clone3 wrapper temporarily replaces the guest `child_tid` pointer with a host-translated pointer before invoking the legacy clone syscall. Previously, that translated value was left in the guest-visible `clone_args` struct after the syscall returned. This can pollute guest memory with a host address. It may not always fail immediately if the temporary struct is not reused or checked, but under stricter memory-boundary checks or paths that later inspect `child_tid`, the stale host pointer can lead to invalid guest addresses or incorrect synchronization behavior.