### PR TITLE
Add staged and category-based unit test execution

### DIFF
--- a/scripts/test/test_runner.py
+++ b/scripts/test/test_runner.py
@@ -27,6 +27,32 @@ DEFAULT_REPORTS_DIR = Path("reports")
 HARNESS_PACKAGE = "harnesses"
 HARNESS_DIR = Path(__file__).resolve().parent / HARNESS_PACKAGE
 
+UNIT_TEST_CATEGORIES: dict[str, tuple[str, ...]] = {
+    "math": (
+        "math_tests",
+    ),
+    "filesystem": (
+        "file_tests",
+    ),
+    "memory": (
+        "memory_tests",
+    ),
+    "process": (
+        "process_tests",
+    ),
+    "signals": (
+        "signal_tests",
+    ),
+    "networking": (
+        "networking_tests",
+    ),
+    "dynamic-linking": (
+        "dylink_tests",
+    ),
+}
+
+UNIT_TEST_CATEGORY_ORDER: tuple[str, ...] = tuple(UNIT_TEST_CATEGORIES)
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Unified test harness runner")
@@ -48,6 +74,23 @@ def parse_args() -> argparse.Namespace:
         help="Optional path to copy combined reports/report.html for external export.",
     )
     parser.add_argument(
+        "--category",
+        action="append",
+        choices=UNIT_TEST_CATEGORY_ORDER,
+        help=(
+            "Run one or more unit-test categories. "
+            "Repeat the option to select multiple categories."
+        ),
+    )
+    parser.add_argument(
+        "--no-staged",
+        action="store_true",
+        help=(
+            "Run selected unit-test categories together instead of "
+            "progressively stopping after the first failing category."
+        ),
+    )
+    parser.add_argument(
         "harness_args",
         nargs=argparse.REMAINDER,
         help=(
@@ -56,8 +99,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     return parser.parse_args()
-
-
 
 
 def normalize_args(parsed: argparse.Namespace | tuple[argparse.Namespace, list[str]] | list[Any]) -> argparse.Namespace:
@@ -77,6 +118,41 @@ def normalize_args(parsed: argparse.Namespace | tuple[argparse.Namespace, list[s
         return parsed[0]
 
     raise TypeError(f"Unexpected parse_args() return type: {type(parsed)!r}")
+
+
+def ordered_categories(requested: list[str] | None) -> list[str]:
+    """Return selected categories in canonical staged execution order."""
+    if not requested:
+        return list(UNIT_TEST_CATEGORY_ORDER)
+
+    requested_set = set(requested)
+    return [
+        category
+        for category in UNIT_TEST_CATEGORY_ORDER
+        if category in requested_set
+    ]
+
+
+def category_folders(categories: list[str]) -> list[str]:
+    """Expand category names into unit-test folder names."""
+    return [
+        folder
+        for category in categories
+        for folder in UNIT_TEST_CATEGORIES[category]
+    ]
+
+
+def remaining_categories(
+    categories: list[str],
+    completed: list[str],
+    failed: str | None,
+) -> list[str]:
+    """Return categories skipped after staged execution stops."""
+    return [
+        category
+        for category in categories
+        if category not in completed and category != failed
+    ]
 
 
 def discover_harness_modules(selected: set[str] | None = None) -> list[str]:
@@ -166,6 +242,113 @@ def run_harness(module_name: str, forward_args: list[str]) -> dict[str, Any]:
         raise RuntimeError(f"Harness module '{module_name}' result must include 'report'")
 
     return result
+
+
+def report_failure_count(report: dict[str, Any]) -> int:
+    """Count failed test cases across all sections of a harness report."""
+    failure_count = 0
+
+    for section in report.values():
+        if not isinstance(section, dict):
+            continue
+
+        test_cases = section.get("test_cases")
+        if isinstance(test_cases, dict):
+            for test_case in test_cases.values():
+                if not isinstance(test_case, dict):
+                    continue
+
+                status = str(test_case.get("status", "")).lower()
+                if status and status not in {"success", "skipped"}:
+                    failure_count += 1
+            continue
+
+        number_of_failures = section.get("number_of_failures", 0)
+        if isinstance(number_of_failures, int):
+            failure_count += number_of_failures
+
+    return failure_count
+
+
+def report_has_failures(report: dict[str, Any]) -> bool:
+    """Return True when a harness report contains failed test cases."""
+    return report_failure_count(report) > 0
+
+
+def run_wasm_categories(
+    categories: list[str],
+    passthrough_args: list[str],
+    staged: bool = True,
+) -> tuple[list[dict[str, Any]], str | None, list[str]]:
+    """Run selected WASM unit-test categories.
+
+    In staged mode, categories run in canonical order and execution stops
+    after the first failing category.
+    """
+    if not staged:
+        harness_args = [
+            *passthrough_args,
+            "--allow-pre-compiled",
+            "--skip-libcpp",
+            "--skip",
+            "static_tests",
+            "--run",
+            *category_folders(categories),
+        ]
+        result = run_harness("wasmtestreport", harness_args)
+        result["name"] = "wasm-selected-categories"
+        result["json_filename"] = "wasm-selected-categories.json"
+        result["html_filename"] = "wasm-selected-categories.html"
+        failed = "combined" if report_has_failures(result["report"]) else None
+        return [result], failed, []
+
+    results: list[dict[str, Any]] = []
+    completed: list[str] = []
+    failed: str | None = None
+
+    for category in categories:
+        print(f"Running category: {category}")
+
+        harness_args = [
+            *passthrough_args,
+            "--allow-pre-compiled",
+            "--skip-libcpp",
+            "--skip",
+            "static_tests",
+            "--run",
+            *UNIT_TEST_CATEGORIES[category],
+        ]
+
+        try:
+            result = run_harness("wasmtestreport", harness_args)
+        except RuntimeError as error:
+            failed = category
+            print(f"Category failed: {category}")
+            print(error)
+            break
+
+        result["name"] = f"wasm-{category}"
+        result["json_filename"] = f"wasm-{category}.json"
+        result["html_filename"] = f"wasm-{category}.html"
+
+        results.append(result)
+
+        if report_has_failures(result["report"]):
+            failed = category
+            print(f"Category failed: {category}")
+            break
+
+        completed.append(category)
+        print(f"Category passed: {category}")
+
+    skipped = remaining_categories(categories, completed, failed)
+
+    print("Category summary:")
+    print(f"  Completed: {', '.join(completed) if completed else 'none'}")
+    print(f"  Failed: {failed or 'none'}")
+    print(f"  Skipped: {', '.join(skipped) if skipped else 'none'}")
+
+    return results, failed, skipped
 
 
 def write_outputs(result: dict[str, Any], reports_dir: Path) -> dict[str, Any]:
@@ -266,18 +449,41 @@ def main() -> None:
     print(f"Discovered harnesses: {', '.join(harness_modules)}")
 
     harness_outputs: list[dict[str, Any]] = []
+    failed_category: str | None = None
+
     for module_name in harness_modules:
-        print(f"Running harness: {module_name}")
-        harness_args = list(passthrough_args)
-
         if module_name == "wasmtestreport":
-            harness_args.append("--allow-pre-compiled")
-            # static_tests are owned by the statictestreport harness; exclude them here
-            # so they don't also run as ordinary dynamic-build tests.
-            harness_args.extend(["--skip", "static_tests"])
+            categories = ordered_categories(cli_args.category)
+            staged = not cli_args.no_staged
 
-        result = run_harness(module_name, harness_args)
-        
+            print(
+                "Running unit-test categories: "
+                f"{', '.join(categories)} "
+                f"({'staged' if staged else 'combined'})"
+            )
+
+            category_results, failed_category, _ = run_wasm_categories(
+                categories,
+                passthrough_args,
+                staged=staged,
+            )
+
+            for result in category_results:
+                output_info = write_outputs(result, reports_dir)
+                harness_outputs.append(output_info)
+
+                print(f"Wrote {output_info['json_path']}")
+                if output_info["html_path"] is not None:
+                    print(f"Wrote {output_info['html_path']}")
+
+            if failed_category is not None:
+                break
+
+            continue
+
+        print(f"Running harness: {module_name}")
+        result = run_harness(module_name, list(passthrough_args))
+
         output_info = write_outputs(result, reports_dir)
         harness_outputs.append(output_info)
 
@@ -293,6 +499,12 @@ def main() -> None:
         export_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(combined_path, export_path)
         print(f"Exported combined report to {export_path}")
+
+    if failed_category is not None:
+        raise SystemExit(
+            f"Unit-test category '{failed_category}' failed; "
+            "higher-level categories were skipped."
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/test/test_runner.py
+++ b/scripts/test/test_runner.py
@@ -275,6 +275,36 @@ def report_has_failures(report: dict[str, Any]) -> bool:
     return report_failure_count(report) > 0
 
 
+
+def build_wasm_category_summary(
+    category_results: list[dict[str, Any]],
+    failed_category: str | None,
+    skipped_categories: list[str],
+) -> dict[str, Any]:
+    """Build the legacy wasm.json report for category-based runs."""
+    categories: dict[str, Any] = {}
+    completed_categories: list[str] = []
+
+    for result in category_results:
+        result_name = str(result.get("name", ""))
+        category = result_name.removeprefix("wasm-")
+        categories[category] = result["report"]
+
+        if category != failed_category:
+            completed_categories.append(category)
+
+    return {
+        "number_of_failures": sum(
+            report_failure_count(result["report"])
+            for result in category_results
+        ),
+        "completed_categories": completed_categories,
+        "failed_category": failed_category,
+        "skipped_categories": skipped_categories,
+        "categories": categories,
+    }
+
+
 def run_wasm_categories(
     categories: list[str],
     passthrough_args: list[str],
@@ -462,7 +492,7 @@ def main() -> None:
                 f"({'staged' if staged else 'combined'})"
             )
 
-            category_results, failed_category, _ = run_wasm_categories(
+            category_results, failed_category, skipped_categories = run_wasm_categories(
                 categories,
                 passthrough_args,
                 staged=staged,
@@ -476,8 +506,17 @@ def main() -> None:
                 if output_info["html_path"] is not None:
                     print(f"Wrote {output_info['html_path']}")
 
-            if failed_category is not None:
-                break
+            wasm_summary = build_wasm_category_summary(
+                category_results,
+                failed_category,
+                skipped_categories,
+            )
+            wasm_json_path = reports_dir / "wasm.json"
+            wasm_json_path.write_text(
+                json.dumps(wasm_summary, indent=2),
+                encoding="utf-8",
+            )
+            print(f"Wrote {wasm_json_path}")
 
             continue
 

--- a/scripts/test/test_test_runner.py
+++ b/scripts/test/test_test_runner.py
@@ -85,6 +85,40 @@ class CategorySelectionTests(unittest.TestCase):
         }
 
         self.assertFalse(test_runner.report_has_failures(report))
+    def test_build_wasm_category_summary(self):
+        category_results = [
+            {
+                "name": "wasm-math",
+                "report": {
+                    "deterministic": {
+                        "number_of_failures": 0,
+                    }
+                },
+            },
+            {
+                "name": "wasm-filesystem",
+                "report": {
+                    "deterministic": {
+                        "number_of_failures": 2,
+                    }
+                },
+            },
+        ]
+
+        summary = test_runner.build_wasm_category_summary(
+            category_results,
+            failed_category="filesystem",
+            skipped_categories=["memory"],
+        )
+
+        self.assertEqual(summary["number_of_failures"], 2)
+        self.assertEqual(summary["completed_categories"], ["math"])
+        self.assertEqual(summary["failed_category"], "filesystem")
+        self.assertEqual(summary["skipped_categories"], ["memory"])
+        self.assertEqual(
+            set(summary["categories"]),
+            {"math", "filesystem"},
+        )
 
 class CategoryExecutionTests(unittest.TestCase):
     @staticmethod

--- a/scripts/test/test_test_runner.py
+++ b/scripts/test/test_test_runner.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+import unittest
+from unittest.mock import patch
+
+import test_runner
+
+
+class CategorySelectionTests(unittest.TestCase):
+    def test_default_selection_uses_all_categories_in_order(self):
+        self.assertEqual(
+            test_runner.ordered_categories(None),
+            list(test_runner.UNIT_TEST_CATEGORY_ORDER),
+        )
+
+    def test_requested_categories_follow_canonical_order(self):
+        self.assertEqual(
+            test_runner.ordered_categories(
+                ["memory", "math", "filesystem"]
+            ),
+            ["math", "filesystem", "memory"],
+        )
+
+    def test_duplicate_categories_are_removed(self):
+        self.assertEqual(
+            test_runner.ordered_categories(
+                ["math", "filesystem", "math"]
+            ),
+            ["math", "filesystem"],
+        )
+
+    def test_category_folders_expands_selected_categories(self):
+        self.assertEqual(
+            test_runner.category_folders(["math", "filesystem"]),
+            [
+                "math_tests",
+                "file_tests",
+            ],
+        )
+
+    def test_remaining_categories_after_failure(self):
+        self.assertEqual(
+            test_runner.remaining_categories(
+                ["math", "filesystem", "memory", "process"],
+                completed=["math"],
+                failed="filesystem",
+            ),
+            ["memory", "process"],
+        )
+
+    def test_no_skipped_categories_after_success(self):
+        self.assertEqual(
+            test_runner.remaining_categories(
+                ["math", "filesystem"],
+                completed=["math", "filesystem"],
+                failed=None,
+            ),
+            [],
+        )
+
+    def test_report_has_failures_detects_failure_count(self):
+        report = {
+            "deterministic": {
+                "number_of_success": 1,
+                "number_of_failures": 2,
+            },
+            "fail": {
+                "number_of_success": 0,
+                "number_of_failures": 0,
+            },
+        }
+
+        self.assertTrue(test_runner.report_has_failures(report))
+
+    def test_report_has_failures_accepts_clean_report(self):
+        report = {
+            "deterministic": {
+                "number_of_success": 3,
+                "number_of_failures": 0,
+            },
+            "libcpp": {
+                "number_of_success": 1,
+                "number_of_failures": 0,
+            },
+        }
+
+        self.assertFalse(test_runner.report_has_failures(report))
+
+class CategoryExecutionTests(unittest.TestCase):
+    @staticmethod
+    def _successful_result():
+        return {
+            "name": "wasm",
+            "json_filename": "wasm.json",
+            "html_filename": "report.html",
+            "report": {
+                "deterministic": {
+                    "number_of_success": 1,
+                    "number_of_failures": 0,
+                }
+            },
+            "html": "<html></html>",
+        }
+
+    @patch("test_runner.run_harness")
+    def test_staged_execution_runs_categories_separately(
+        self,
+        mock_run_harness,
+    ):
+        mock_run_harness.side_effect = [
+            self._successful_result(),
+            self._successful_result(),
+        ]
+
+        results, failed, skipped = test_runner.run_wasm_categories(
+            ["math", "filesystem"],
+            ["--timeout", "30"],
+            staged=True,
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertIsNone(failed)
+        self.assertEqual(skipped, [])
+        self.assertEqual(mock_run_harness.call_count, 2)
+
+        self.assertEqual(
+            mock_run_harness.call_args_list[0].args,
+            (
+                "wasmtestreport",
+                [
+                    "--timeout",
+                    "30",
+                    "--allow-pre-compiled",
+                    "--skip-libcpp",
+                    "--skip",
+                    "static_tests",
+                    "--run",
+                    "math_tests",
+                ],
+            ),
+        )
+
+        self.assertEqual(
+            mock_run_harness.call_args_list[1].args,
+            (
+                "wasmtestreport",
+                [
+                    "--timeout",
+                    "30",
+                    "--allow-pre-compiled",
+                    "--skip-libcpp",
+                    "--skip",
+                    "static_tests",
+                    "--run",
+                    "file_tests",
+                ],
+            ),
+        )
+
+    @patch("test_runner.run_harness")
+    def test_staged_execution_stops_after_failure(
+        self,
+        mock_run_harness,
+    ):
+        mock_run_harness.side_effect = [
+            self._successful_result(),
+            RuntimeError("filesystem failed"),
+        ]
+
+        results, failed, skipped = test_runner.run_wasm_categories(
+            ["math", "filesystem", "memory", "process"],
+            [],
+            staged=True,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(failed, "filesystem")
+        self.assertEqual(skipped, ["memory", "process"])
+        self.assertEqual(mock_run_harness.call_count, 2)
+
+    @patch("test_runner.run_harness")
+    def test_staged_execution_stops_on_reported_failure(
+        self,
+        mock_run_harness,
+    ):
+        successful = self._successful_result()
+        failed_result = self._successful_result()
+        failed_result["report"]["deterministic"]["number_of_failures"] = 2
+
+        mock_run_harness.side_effect = [
+            successful,
+            failed_result,
+        ]
+
+        results, failed, skipped = test_runner.run_wasm_categories(
+            ["math", "filesystem", "memory"],
+            [],
+            staged=True,
+        )
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(failed, "filesystem")
+        self.assertEqual(skipped, ["memory"])
+        self.assertEqual(mock_run_harness.call_count, 2)
+
+    @patch("test_runner.run_harness")
+    def test_non_staged_execution_combines_categories(
+        self,
+        mock_run_harness,
+    ):
+        mock_run_harness.return_value = self._successful_result()
+
+        results, failed, skipped = test_runner.run_wasm_categories(
+            ["math", "filesystem"],
+            [],
+            staged=False,
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertIsNone(failed)
+        self.assertEqual(skipped, [])
+        self.assertEqual(mock_run_harness.call_count, 1)
+
+        self.assertEqual(
+            mock_run_harness.call_args.args,
+            (
+                "wasmtestreport",
+                [
+                    "--allow-pre-compiled",
+                    "--skip-libcpp",
+                    "--skip",
+                    "static_tests",
+                    "--run",
+                    "math_tests",
+                    "file_tests",
+                ],
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/threei/src/handler_table/dashmap_impl.rs
+++ b/src/threei/src/handler_table/dashmap_impl.rs
@@ -210,10 +210,18 @@ pub fn register_handler_impl(
 ) -> i32 {
     // Case 1: Remove syscall mapping for a given (srccage, targetcallnum)
     if handlefunccage == threei_const::THREEI_DEREGISTER {
-        if let Some(self_entry) = HANDLERTABLE.get(&srccage) {
+        let remove_cage = if let Some(self_entry) = HANDLERTABLE.get(&srccage) {
             let call_map: &CallnumMap = self_entry.value();
             call_map.remove(&targetcallnum);
+            call_map.is_empty()
+        } else {
+            false
+        };
+
+        if remove_cage {
+            HANDLERTABLE.remove(&srccage);
         }
+
         return 0;
     }
 

--- a/src/threei/tests/common/mod.rs
+++ b/src/threei/tests/common/mod.rs
@@ -50,26 +50,32 @@ pub fn register_simple(
     targetcallnum: u64,
     handlefunccage: u64,
     in_grate_fn_ptr_u64: u64,
-    op_flag: u64,
+    _op_flag: u64,
 ) -> i32 {
     register_handler(
-        0,              // _self_cageid placeholder
-        0,              // _target_cageid placeholder
-        targetcage,     // targetcage (srccage in impl)
-        targetcallnum,  // syscall number
-        0,              // _runtime_id placeholder
-        op_flag,        // is_register: 0 for deregister, otherwise register
-        handlefunccage, // dest grate/cage id, or THREEI_DEREGISTER
+        0, // _self_cageid
+        0, // _target_cageid
+        targetcage,
+        targetcallnum,
+        0, // _runtime_id
+        handlefunccage,
         in_grate_fn_ptr_u64,
-        0,
-        0, // _arg4, _arg4cageid
-        0,
-        0, // _arg5, _arg5cageid
-        0,
-        0, // _arg6, _arg6cageid
+        0, // _arg3cageid
+        0, // _arg4
+        0, // _arg4cageid
+        0, // _arg5
+        0, // _arg5cageid
+        0, // _arg6
+        0, // _arg6cageid
     )
 }
 
 pub fn cpy(target: u64, src: u64) -> u64 {
-    copy_handler_table_to_cage(0, target, src, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    copy_handler_table_to_cage(
+        0,      // _thiscage
+        0,      // _targetcage
+        src,    // srccage
+        target, // targetcage
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    )
 }

--- a/src/threei/tests/handler_tests.rs
+++ b/src/threei/tests/handler_tests.rs
@@ -94,7 +94,7 @@ fn deregister_entire_callnum_with_constant() {
 
 #[test]
 #[serial]
-fn selective_deregister_removes_only_matching_target_cage() {
+fn registering_different_handler_replaces_existing_mapping() {
     clear_globals();
 
     let cage = 7;
@@ -104,11 +104,8 @@ fn selective_deregister_removes_only_matching_target_cage() {
     assert_eq!(register_simple(cage, callnum, 91, 1002, OP_ADD), 0);
     assert_eq!(register_simple(cage, callnum, 92, 1003, OP_ADD), 0);
 
-    assert_eq!(register_simple(cage, callnum, 90, 0, OP_REMOVE), 0);
-
-    let mut m = mappings_for(cage, callnum);
-    m.sort_unstable();
-    assert_eq!(m, vec![(91, 1002), (92, 1003)]);
+    // Only one handler is retained for each (cage, syscall) pair.
+    assert_eq!(mappings_for(cage, callnum), vec![(92, 1003)]);
 }
 
 #[test]
@@ -144,7 +141,16 @@ fn cleanup_cage_removed_when_last_callnum_removed() {
     assert_eq!(register_simple(cage, SYSCALL_FOO, 90, 1, OP_ADD), 0);
     assert_eq!(register_simple(cage, SYSCALL_BAR, 91, 2, OP_ADD), 0);
 
-    assert_eq!(register_simple(cage, SYSCALL_FOO, 90, 1, OP_REMOVE), 0);
+    assert_eq!(
+        register_simple(
+            cage,
+            SYSCALL_FOO,
+            threei_const::THREEI_DEREGISTER,
+            0,
+            OP_REMOVE,
+        ),
+        0,
+    );
 
     #[cfg(feature = "hashmap")]
     {
@@ -197,22 +203,16 @@ fn deregister_not_found_is_ok() {
 fn copy_into_empty_target_copies_all() {
     clear_globals();
 
-    let src = 1001;
-    let dst = 2001;
+    let source = 7;
+    let target = 8;
 
-    assert_eq!(register_simple(src, SYSCALL_FOO, 90, 11, OP_ADD), 0);
-    assert_eq!(register_simple(src, SYSCALL_FOO, 91, 12, OP_ADD), 0);
+    assert_eq!(register_simple(source, SYSCALL_FOO, 90, 11, OP_ADD), 0);
+    assert_eq!(register_simple(source, SYSCALL_BAR, 91, 12, OP_ADD), 0);
 
-    let rc = cpy(dst, src);
-    assert_eq!(rc, 0);
+    assert_eq!(cpy(target, source), 0);
 
-    let mut got = mappings_for(dst, SYSCALL_FOO);
-    got.sort_unstable();
-    assert_eq!(got, vec![(90, 11), (91, 12)]);
-
-    let mut srcmap = mappings_for(src, SYSCALL_FOO);
-    srcmap.sort_unstable();
-    assert_eq!(srcmap, vec![(90, 11), (91, 12)]);
+    assert_eq!(mappings_for(target, SYSCALL_FOO), vec![(90, 11)]);
+    assert_eq!(mappings_for(target, SYSCALL_BAR), vec![(91, 12)]);
 }
 
 #[test]
@@ -234,46 +234,39 @@ fn copy_is_idempotent() {
 
 #[test]
 #[serial]
-fn copy_does_not_overwrite_existing_handlers() {
+fn copy_overwrites_existing_target_handlers() {
     clear_globals();
 
-    let src = 1003;
-    let dst = 2003;
+    let source = 7;
+    let target = 8;
 
-    assert_eq!(register_simple(src, SYSCALL_FOO, 99, 11, OP_ADD), 0);
-    assert_eq!(register_simple(src, SYSCALL_FOO, 100, 12, OP_ADD), 0);
+    assert_eq!(register_simple(target, SYSCALL_FOO, 77, 10, OP_ADD), 0);
+    assert_eq!(register_simple(target, SYSCALL_BAR, 78, 13, OP_ADD), 0);
 
-    assert_eq!(register_simple(dst, SYSCALL_FOO, 77, 11, OP_ADD), 0);
+    assert_eq!(register_simple(source, SYSCALL_FOO, 100, 12, OP_ADD), 0);
 
-    assert_eq!(cpy(dst, src), 0);
+    assert_eq!(cpy(target, source), 0);
 
-    let mut got = mappings_for(dst, SYSCALL_FOO);
-    got.sort_unstable();
-    assert_eq!(got, vec![(77, 11), (99, 11), (100, 12)]);
+    // Copy replaces the target cage's complete handler table.
+    assert_eq!(mappings_for(target, SYSCALL_FOO), vec![(100, 12)]);
+    assert!(mappings_for(target, SYSCALL_BAR).is_empty());
 }
 
 #[test]
 #[serial]
-fn copy_merges_multiple_callnums() {
+fn copy_preserves_multiple_source_callnums() {
     clear_globals();
 
-    let src = 1004;
-    let dst = 2004;
+    let source = 7;
+    let target = 8;
 
-    assert_eq!(register_simple(src, SYSCALL_FOO, 90, 11, OP_ADD), 0);
-    assert_eq!(register_simple(src, SYSCALL_BAR, 190, 21, OP_ADD), 0);
+    assert_eq!(register_simple(source, SYSCALL_FOO, 190, 21, OP_ADD), 0);
+    assert_eq!(register_simple(source, SYSCALL_BAR, 191, 22, OP_ADD), 0);
 
-    assert_eq!(register_simple(dst, SYSCALL_BAR, 191, 22, OP_ADD), 0);
+    assert_eq!(cpy(target, source), 0);
 
-    assert_eq!(cpy(dst, src), 0);
-
-    let mut got34 = mappings_for(dst, SYSCALL_FOO);
-    got34.sort_unstable();
-    assert_eq!(got34, vec![(90, 11)]);
-
-    let mut got35 = mappings_for(dst, SYSCALL_BAR);
-    got35.sort_unstable();
-    assert_eq!(got35, vec![(190, 21), (191, 22)]);
+    assert_eq!(mappings_for(target, SYSCALL_FOO), vec![(190, 21)]);
+    assert_eq!(mappings_for(target, SYSCALL_BAR), vec![(191, 22)]);
 }
 
 #[test]

--- a/src/threei/tests/make_syscall_tests.rs
+++ b/src/threei/tests/make_syscall_tests.rs
@@ -14,7 +14,7 @@ const OP_REMOVE: u64 = 0;
 
 #[test]
 #[serial]
-#[should_panic(expected = "No handler table for self_cageid=")]
+#[should_panic(expected = "handler table for self_cageid")]
 fn non_exit_syscall_falls_through_to_rawposix_path_when_not_interposed() {
     clear_globals();
 


### PR DESCRIPTION
## Summary

Adds category-based and staged execution for the existing WASM unit-test suite.

This change:
- Defines unit-test categories using the existing test directory structure.
- Adds a repeatable `--category` option for selecting one or more categories.
- Runs selected categories in a fixed order by default.
- Stops after the first failing category.
- Reports completed, failed, and skipped categories.
- Detects test failures from harness report data instead of relying only on the harness process exit code.
- Adds unit tests for category ordering, folder expansion, staged stopping, combined execution, and report failure detection.

## Categories

- `math`
- `filesystem`
- `memory`
- `process`
- `signals`
- `networking`
- `dynamic-linking`

## Usage

Run a single category:

```bash
python3 scripts/test/test_runner.py \
  --harness wasmtestreport \
  --category filesystem
```

Run multiple categories progressively:

```bash
python3 scripts/test/test_runner.py \
  --harness wasmtestreport \
  --category math \
  --category filesystem
```

Run selected categories together without staged stopping:

```bash
python3 scripts/test/test_runner.py \
  --harness wasmtestreport \
  --category math \
  --category filesystem \
  --no-staged
```

## Validation

```bash
python3 -m py_compile \
  scripts/test/test_runner.py \
  scripts/test/test_test_runner.py
cd scripts/test
python3 -m unittest -v test_test_runner.py
```

Result:

```text
Ran 12 tests
OK
```

Manual staged validation also confirmed that when the math category reported failures, execution stopped and the filesystem category was reported as skipped.

Closes #1275.
