### PR TITLE
Add semaphore test that uses slow call path in glibc

### DIFF
--- a/tests/unit-tests/process_tests/deterministic/sem_slow_path.c
+++ b/tests/unit-tests/process_tests/deterministic/sem_slow_path.c
@@ -1,9 +1,10 @@
-/* Test case for cross-process semaphore synchronization 
-* This test will create a semaphore in shared memory, 
-* fork a child process, and ensure that the child waits 
-* on the semaphore until the parent posts it, demonstrating 
+/* Test case for cross-process semaphore synchronization
+* This test will create a semaphore in shared memory,
+* fork a child process, and ensure that the child waits
+* on the semaphore until the parent posts it, demonstrating
 * cross-process synchronization.
 */
+#include <assert.h>
 #include <errno.h>
 #include <semaphore.h>
 #include <stdio.h>
@@ -23,31 +24,19 @@ int main(void)
         0
     );
 
-    if (sem == MAP_FAILED) {
-        perror("mmap");
-        return 1;
-    }
+    assert(sem != MAP_FAILED);
 
     // pshared=1 and initial value=0 force cross-process synchronization.
-    if (sem_init(sem, 1, 0) != 0) {
-        perror("sem_init");
-        return 1;
-    }
+    assert(sem_init(sem, 1, 0) == 0);
 
     pid_t pid = fork();
-    if (pid < 0) {
-        perror("fork");
-        return 1;
-    }
+    assert(pid >= 0);
 
     if (pid == 0) {
         printf("[child] waiting\n");
         fflush(stdout);
 
-        if (sem_wait(sem) != 0) {
-            perror("sem_wait");
-            _exit(1);
-        }
+        assert(sem_wait(sem) == 0);
 
         printf("[child] awakened\n");
         fflush(stdout);
@@ -59,14 +48,15 @@ int main(void)
     printf("[parent] posting\n");
     fflush(stdout);
 
-    if (sem_post(sem) != 0) {
-        perror("sem_post");
-        return 1;
-    }
+    assert(sem_post(sem) == 0);
 
-    waitpid(pid, NULL, 0);
-    sem_destroy(sem);
-    munmap(sem, sizeof(*sem));
+    int status;
+    assert(waitpid(pid, &status, 0) == pid);
+    assert(WIFEXITED(status));
+    assert(WEXITSTATUS(status) == 0);
+
+    assert(sem_destroy(sem) == 0);
+    assert(munmap(sem, sizeof(*sem)) == 0);
 
     printf("[parent] done\n");
     return 0;

--- a/tests/unit-tests/process_tests/deterministic/sem_slow_path.c
+++ b/tests/unit-tests/process_tests/deterministic/sem_slow_path.c
@@ -1,0 +1,73 @@
+/* Test case for cross-process semaphore synchronization 
+* This test will create a semaphore in shared memory, 
+* fork a child process, and ensure that the child waits 
+* on the semaphore until the parent posts it, demonstrating 
+* cross-process synchronization.
+*/
+#include <errno.h>
+#include <semaphore.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+int main(void)
+{
+    sem_t *sem = mmap(
+        NULL,
+        sizeof(*sem),
+        PROT_READ | PROT_WRITE,
+        MAP_SHARED | MAP_ANONYMOUS,
+        -1,
+        0
+    );
+
+    if (sem == MAP_FAILED) {
+        perror("mmap");
+        return 1;
+    }
+
+    // pshared=1 and initial value=0 force cross-process synchronization.
+    if (sem_init(sem, 1, 0) != 0) {
+        perror("sem_init");
+        return 1;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 1;
+    }
+
+    if (pid == 0) {
+        printf("[child] waiting\n");
+        fflush(stdout);
+
+        if (sem_wait(sem) != 0) {
+            perror("sem_wait");
+            _exit(1);
+        }
+
+        printf("[child] awakened\n");
+        fflush(stdout);
+        _exit(0);
+    }
+
+    sleep(1);
+
+    printf("[parent] posting\n");
+    fflush(stdout);
+
+    if (sem_post(sem) != 0) {
+        perror("sem_post");
+        return 1;
+    }
+
+    waitpid(pid, NULL, 0);
+    sem_destroy(sem);
+    munmap(sem, sizeof(*sem));
+
+    printf("[parent] done\n");
+    return 0;
+}


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

[Our current semaphore test case](https://github.com/Lind-Project/lind-wasm/blob/main/tests/unit-tests/process_tests/deterministic/sem_forks.c) only tests pshared=0, which is no need for shared memory, and the futex slow path is essentially never entered; each child simply operates on its own copy of the semaphore.

Adding a new test to create a semaphore in shared memory, and testing whether cross-cage synchronization is correct. 