### PR TITLE
chore(community): align contributor workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug report
+description: Report a reproducible problem in Lind-Wasm
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Lind-Wasm. Do not report security
+        vulnerabilities here; use the private reporting link in our security
+        policy instead.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: This report does not disclose a security vulnerability.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem
+      description: Describe what happened and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the smallest reproducible example and exact commands.
+      placeholder: |
+        1. Build with ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include the commit, OS, architecture, Docker version, and relevant configuration.
+      placeholder: |
+        Lind-Wasm commit:
+        Host OS:
+        Architecture:
+        Docker version:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and additional context
+      description: Paste relevant logs or attach files. Remove secrets and private data.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Lind-Project/lind-wasm/security/advisories/new
+    about: Report vulnerabilities privately. Do not open a public issue.
+  - name: Lind community and governance
+    url: https://github.com/Lind-Project/community
+    about: Find project-wide policies, maintainers, Slack, and community meetings.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,26 @@
+name: Documentation issue
+description: Report missing, unclear, or incorrect documentation
+title: "docs: "
+labels:
+  - documentation
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Documentation location
+      description: Link the page or provide the repository path.
+      placeholder: https://lind-project.github.io/lind-wasm/...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Explain what is missing, unclear, outdated, or incorrect.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested improvement
+      description: Describe the change that would make the documentation clearer.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose an improvement to Lind-Wasm
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions for similar proposals.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem would this feature solve, and who would benefit?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or interface you would like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe workarounds or alternative designs you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, design notes, or related links.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,33 @@
-<!-- Before submitting a PR, make sure:
+## Summary
 
-* new code is tested
-* tests pass locally
-* docs are up-to-date
+<!-- What does this PR change, and why is the change needed? -->
 
-For details, see https://lind-project.github.io/lind-wasm/contribute/
+## Related issues
 
-Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->
+<!-- Use "Closes #123" when this PR should close an issue. -->
+
+## Testing
+
+<!-- List the commands, test cases, or manual checks used to verify the change. -->
+
+## Compatibility and security impact
+
+<!--
+Describe user-visible behavior changes, compatibility concerns, new syscalls,
+security implications, or performance impact. Write "None" when not applicable.
+-->
+
+## Checklist
+
+- [ ] I have read the
+      [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
+- [ ] I added or updated tests where appropriate.
+- [ ] I ran the relevant tests locally and they pass.
+- [ ] I formatted the code and ran the relevant linters.
+- [ ] I updated documentation for user-visible or architectural changes.
+- [ ] I disclosed security vulnerabilities privately rather than in this PR.
+
+<!--
+Project-wide contribution and review policies:
+https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
+-->

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,35 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
+  validate:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material mkdocs-section-index
+      - run: mkdocs build --strict
+
   deploy:
+    if: github.event_name != 'pull_request'
+    needs: validate
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,12 @@ Thanks for your interest in contributing to Lind! Lind is a community-driven,
 open-source project, and it grows through the people who use it, file issues,
 improve the docs, and send patches. Contributions of every size are welcome.
 
-This guide explains how to get started, what you can work on, and how we review
-and merge changes. For deeper, topic-specific guidance, see the
-[contributor documentation](https://lind-project.github.io/lind-wasm/contribute/).
+Project-wide contribution policies, review requirements, governance, and
+community expectations are maintained in the
+[Lind community repository](https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md).
+This guide supplements those policies with the setup, testing, and code-style
+information specific to `lind-wasm`. For deeper, topic-specific guidance, see
+the [contributor documentation](https://lind-project.github.io/lind-wasm/contribute/).
 
 ## Our Vision
 
@@ -31,7 +34,7 @@ built in the open.
 - **Star and share** the [repository](https://github.com/Lind-Project/lind-wasm)
   to help others find the project.
 - To report a **security vulnerability**, please follow the
-  [Security Policy](security.md) rather than opening a public issue.
+  [Security Policy](SECURITY.md) rather than opening a public issue.
 
 ### Set up your development environment
 
@@ -153,20 +156,17 @@ for details.
 ## Becoming a Maintainer
 
 Maintainers are contributors who have shown sustained, high-quality involvement
-in the project, through code implementation, review, documentation, and helping others. What
-matters is consistent, thoughtful contribution and adherence to the
-[Code of Conduct](https://lind-project.github.io/lind-wasm/community/conduct/),
-not the raw number of PRs.
-
-New maintainers are nominated by existing maintainers. A nomination is discussed
-by the current maintainers, and confirmed by consensus. If you're interested in
-taking on a larger role, the best path is to keep contributing and reviewing, and
-to let a maintainer know.
+in the project through code implementation, review, documentation, issue
+triage, testing, design work, and community support. The authoritative process
+for becoming a maintainer is defined in the Lind
+[Governance](https://github.com/Lind-Project/community/blob/main/GOVERNANCE.md)
+document. Current maintainers and their focus areas are listed in
+[MAINTAINER.md](https://github.com/Lind-Project/community/blob/main/MAINTAINER.md).
 
 ## Code of Conduct
 
 Participation in the Lind community is governed by our
-[Code of Conduct](https://lind-project.github.io/lind-wasm/community/conduct/).
+[Code of Conduct](https://github.com/Lind-Project/community/blob/main/CODE_OF_CONDUCT.md).
 By participating, you agree to uphold it.
 
 ## License
@@ -180,6 +180,6 @@ the same license as the project. See [LICENSE](LICENSE) for details.
   [GitHub issue](https://github.com/Lind-Project/lind-wasm/issues) or discussion.
 - **Documentation:** browse the
   [Lind docs](https://lind-project.github.io/lind-wasm/).
-- **Community:** see the
-  [community page](https://lind-project.github.io/lind-wasm/community/) to connect
-  with the team.
+- **Community:** see
+  [COMMUNITY.md](https://github.com/Lind-Project/community/blob/main/COMMUNITY.md)
+  for Slack and community meeting information.

--- a/README.md
+++ b/README.md
@@ -48,4 +48,21 @@ This monorepo combines various subprojects and dependencies that work together t
 |---------------|--------------------|----------------------------------------------------------------------------|
 | `binaryen`    | `tools/binaryen`   | Provides `wasm-opt` and other utilities used for optimizing wasm binaries |
 
----
+## Contributing and Community
+
+Contributions are welcome. See the repository-specific
+[contribution guide](CONTRIBUTING.md) for development setup, testing, and code
+style. Project-wide policies and community information are maintained in the
+[Lind community repository](https://github.com/Lind-Project/community):
+
+- [Governance](https://github.com/Lind-Project/community/blob/main/GOVERNANCE.md)
+- [Maintainers](https://github.com/Lind-Project/community/blob/main/MAINTAINER.md)
+- [Community channels and meetings](https://github.com/Lind-Project/community/blob/main/COMMUNITY.md)
+- [Code of Conduct](https://github.com/Lind-Project/community/blob/main/CODE_OF_CONDUCT.md)
+
+Please report vulnerabilities privately according to our
+[Security Policy](SECURITY.md).
+
+## License
+
+Lind-Wasm is licensed under the [Apache License 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,9 @@
 # Security Policy
 
+Project-wide security reporting guidance is maintained in the
+[Lind community repository](https://github.com/Lind-Project/community/blob/main/SECURITY.md).
+The supported versions and response timeline below are specific to `lind-wasm`.
+
 ## Supported Versions
 
 We currently only support the latest code on our primary branch. Security fixes are not backported to older commits.

--- a/docs/contribute/index.md
+++ b/docs/contribute/index.md
@@ -6,7 +6,9 @@ in the [`lind-wasm/docs`](https://github.com/Lind-Project/lind-wasm/tree/main/do
 subdirectory. Please contribute to the Lind project by submitting issues or pull
 requests to these repositories.
 
-To report a security issue, please refer to the [Security Policy](security.md)!
+To report a security issue, please follow the repository's
+[Security Policy](https://github.com/Lind-Project/lind-wasm/security/policy)
+rather than opening a public issue.
 
 Continue reading the pages in this section for detailed guidelines about
 writing code, tests, documentation, and more.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,11 +25,15 @@ nav:
     - Multi-Processing: internal/multiprocess-support.md
     - Signals: internal/signals.md
     - Memory: internal/memory.md
+    - setjmp / longjmp: internal/setjmp.md
+    - Logging: internal/logging.md
+    - C++ support: internal/libcpp.md
   - Contributing:
     - contribute/index.md
     - Development setup: contribute/dev-container.md
     - Rust style guide: contribute/styleguide.md
     - Lind toolchain: contribute/toolchain.md
+    - Compiling Rust programs: contribute/compile-with-rust.md
     - Testing: contribute/testing.md
     - Debug programs: contribute/debug-programs.md
     - Adding to the docs: contribute/add-docs.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,16 +33,12 @@ nav:
     - Testing: contribute/testing.md
     - Debug programs: contribute/debug-programs.md
     - Adding to the docs: contribute/add-docs.md
-    - Security policy: contribute/security.md
+    - Security policy: https://github.com/Lind-Project/lind-wasm/security/policy
     - Docker Hub release workflow: contribute/docker-release-workflow.md
     - End-to-End Testing: contribute/e2e-testing.md
     - Pipelines:
       - Overview: contribute/pipelines/overview.md
       - lind-wasm: contribute/pipelines/lind-wasm.md
-  - Community:
-    - community/index.md
-    - Team: community/team.md
-    - Code of conduct: community/conduct.md
 
 extra_css:
   - stylesheets/img.css


### PR DESCRIPTION
<!-- Before submitting a PR, make sure:

* new code is tested
* tests pass locally
* docs are up-to-date

For details, see https://lind-project.github.io/lind-wasm/contribute/

Please describe **PURPOSE**, reference related **ISSUES**, and include any information that might be helpful to **REVIEWERS** below this line. -->

Align `lind-wasm` contributor workflows with the centralized
[Lind community repository](https://github.com/Lind-Project/community).

This PR:

- adds structured issue forms for bug reports, feature requests, and documentation issues;
- adds private security-reporting and community contact links to the new-issue page while continuing to allow blank issues;
- replaces the previous hidden-only PR template with visible summary, testing, compatibility, and checklist sections;
- updates `README.md`, `CONTRIBUTING.md`, and `SECURITY.md` to reference the centralized community, governance, maintainer, and security policies;
- removes documentation navigation entries for deleted community pages;
- links the documentation site to the repository security policy;
- validates MkDocs with `mkdocs build --strict` on documentation PRs and grants repository write permission only to the deployment job.