### PR TITLE
docs: address native Linux review feedback

### DIFF
--- a/docs/contribute/running-on-native-linux.md
+++ b/docs/contribute/running-on-native-linux.md
@@ -301,13 +301,13 @@ The dependencies require a significant amount of storage so 15-20gb of free spac
 
 10. __Create the Lind filesystem compatibility link__
 
-    The helper commands use `$LIND_WASM_ROOT`, but the current runtime still
-    expects `lindfs` at `/home/lind/lind-wasm/lindfs`. Until the runtime path
-    is configurable, link that fixed location to `$LIND_WASM_ROOT`:
+    The current runtime expects `lindfs` at
+    `/home/lind/lind-wasm/lindfs`. When the WSL username is not `lind`,
+    create a compatibility symbolic link:
 
     ```bash
     sudo mkdir -p /home/lind
-    sudo ln -sfnT "$LIND_WASM_ROOT" /home/lind/lind-wasm
+    sudo ln -sfnT "$HOME/lind-wasm" /home/lind/lind-wasm
     ```
 
     Verify the path:

--- a/docs/contribute/running-on-native-linux.md
+++ b/docs/contribute/running-on-native-linux.md
@@ -10,7 +10,7 @@ in the WSL2 or native Linux environment.
 
 ## Tested environment
 
-The following configuration was used to run lind on WSL2 and native Linux
+The following configuration was used to run lind-wasm on WSL2 and native Linux
 
 Environment #1:
 - Windows 10 Pro
@@ -28,7 +28,7 @@ Environment #2:
 - 46 GB of free space
 
 The exact minimum disk-space requirement has not been formally measured.
-The dependencies require a significant amount of storage so 15-20gb of free space is recomended to avoid any issues during installation.
+The dependencies require a significant amount of storage so 15-20gb of free space is recommended to avoid any issues during installation.
 
 ## step by step guide on installing without Docker
 
@@ -301,13 +301,13 @@ The dependencies require a significant amount of storage so 15-20gb of free spac
 
 10. __Create the Lind filesystem compatibility link__
 
-    The current runtime expects `lindfs` at
-    `/home/lind/lind-wasm/lindfs`. When the WSL username is not `lind`,
-    create a compatibility symbolic link:
+    The helper commands use `$LIND_WASM_ROOT`, but the current runtime still
+    expects `lindfs` at `/home/lind/lind-wasm/lindfs`. Until the runtime path
+    is configurable, link that fixed location to `$LIND_WASM_ROOT`:
 
     ```bash
     sudo mkdir -p /home/lind
-    sudo ln -sfnT "$HOME/lind-wasm" /home/lind/lind-wasm
+    sudo ln -sfnT "$LIND_WASM_ROOT" /home/lind/lind-wasm
     ```
 
     Verify the path:
@@ -346,4 +346,14 @@ The dependencies require a significant amount of storage so 15-20gb of free spac
 
     ```text
     Hello, World!
+    ```
+
+12. __Run the full test suite__
+
+    From the repository root, run the full test suite. It can take a while, so
+    wait for it to finish:
+
+    ```bash
+    cd ~/lind-wasm
+    make test
     ```


### PR DESCRIPTION
## Summary

- Clarifies that the documented environments were used to run Lind-Wasm.
- Corrects the spelling of “recommended.”
- Adds a final step instructing users to run the full test suite with `make test` and wait for it to finish.

These changes address review feedback on the native Linux setup guide.

## Related issues

None.

## Testing
- Manually verified that Markdown code fences are balanced.
- Verified that the numbered installation steps are sequential.
- Confirmed that only `docs/contribute/running-on-native-linux.md` is changed.

## Compatibility and security impact

None. This is a documentation-only change.

## Checklist

- [x] I have read the
      [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
- [x] I added or updated tests where appropriate.
- [x] I ran the relevant tests locally and they pass.
- [x] I formatted the code and ran the relevant linters.
- [x] I updated documentation for user-visible or architectural changes.
- [x] I disclosed security vulnerabilities privately rather than in this PR.

<!--
Project-wide contribution and review policies:
https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
-->