### PR TITLE
Pin nightly version to 2026-07-16

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,8 +19,7 @@ security implications, or performance impact. Write "None" when not applicable.
 
 ## Checklist
 
-- [ ] I have read the
-      [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
+- [ ] I have read the [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
 - [ ] I added or updated tests where appropriate.
 - [ ] I ran the relevant tests locally and they pass.
 - [ ] I formatted the code and ran the relevant linters.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2026-07-16"
 components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

Yesterday's newest rust nightly version breaks lind-boot build. Pin the nightly version to the latest working version instead.

## Related issues

None

## Testing

`make test` /  `make lind-boot`

## Compatibility and security impact

None

## Checklist

- [x] I have read the
      [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
- [x] I added or updated tests where appropriate.
- [x] I ran the relevant tests locally and they pass.
- [x] I formatted the code and ran the relevant linters.
- [x] I updated documentation for user-visible or architectural changes.
- [x] I disclosed security vulnerabilities privately rather than in this PR.

<!--
Project-wide contribution and review policies:
https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
-->
