### PR TITLE
Add ISO-003 cross-cage vmmap escape tests

### DIFF
--- a/src/cage/src/memory/vmmap.rs
+++ b/src/cage/src/memory/vmmap.rs
@@ -2503,4 +2503,48 @@ mod tests {
         let result = vmmap.calculate_page_range(0, 1);
         assert_eq!(result, Some((0, 1)), "1 byte should still be 1 page");
     }
+    #[test]
+    // ISO-003: a length large enough to overflow the range-arithmetic must be rejected
+    fn test_check_addr_write_negative_length_overflow_rejected() {
+        let mut vmmap = Vmmap::new();
+        vmmap.set_base_address(0);
+        vmmap.start_address = 0;
+        vmmap.end_address = 1000;
+
+        vmmap
+            .add_entry_with_overwrite(
+                10,
+                10,
+                PROT_READ | PROT_WRITE,
+                PROT_READ | PROT_WRITE,
+                0,
+                MemoryBackingType::Anonymous,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+
+        let addr = (10 << PAGESHIFT) as u64;
+        let huge_len = usize::MAX;
+
+        assert!(
+            !vmmap.check_addr_write(addr, huge_len),
+            "Should reject a length large enough to overflow range calculation"
+        );
+    }
+
+    #[test]
+    // Targeting calculate_page_range directly
+    fn test_calculate_page_range_overflow_returns_none() {
+        let mut vmmap = Vmmap::new();
+        vmmap.set_base_address(0);
+
+        let result = vmmap.calculate_page_range(0, usize::MAX);
+
+        assert_eq!(
+            result, None,
+            "Overflowing length should not produce a page range"
+        );
+    }
 }

--- a/src/cage/src/memory/vmmap.rs
+++ b/src/cage/src/memory/vmmap.rs
@@ -2506,8 +2506,7 @@ mod tests {
     #[test]
     // ISO-003: a length large enough to overflow the range-arithmetic must be rejected
     fn test_check_addr_write_negative_length_overflow_rejected() {
-        let mut vmmap = Vmmap::new();
-        vmmap.set_base_address(0);
+        let vmmap = test_vmmap();
         vmmap.start_address = 0;
         vmmap.end_address = 1000;
 
@@ -2537,8 +2536,7 @@ mod tests {
     #[test]
     // Targeting calculate_page_range directly
     fn test_calculate_page_range_overflow_returns_none() {
-        let mut vmmap = Vmmap::new();
-        vmmap.set_base_address(0);
+        let mut vmmap = test_vmmap();
 
         let result = vmmap.calculate_page_range(0, usize::MAX);
 

--- a/tests/unit-tests/memory_tests/deterministic/cross_cage_vmmap_escape.c
+++ b/tests/unit-tests/memory_tests/deterministic/cross_cage_vmmap_escape.c
@@ -1,0 +1,69 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define PAGESIZE 4096
+
+static void assert_pipe_still_clean(int read_fd, int write_fd) {
+    char canary = 'K';
+    assert(write(write_fd, &canary, 1) == 1);
+    char received = 0;
+    assert(read(read_fd, &received, 1) == 1);
+    assert(received == canary);
+}
+
+int main() {
+    int fds[2];
+    assert(pipe(fds) == 0);
+
+    unsigned char *region = mmap(NULL, 2*PAGESIZE, PROT_READ | PROT_WRITE, 
+        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    assert(region != MAP_FAILED);
+
+    assert(munmap(region + PAGESIZE, PAGESIZE) == 0);
+
+    // Positive control
+    region[0] = 0xAB;
+    errno = 0;
+    ssize_t ret0 = write(fds[1], region, 1);
+    assert(ret0 == 1);
+    char received_control = 0;
+    assert(read(fds[0], &received_control, 1) == 1);
+    assert((unsigned char) received_control == 0xAB);
+
+    // Test 1
+    errno = 0;
+    ssize_t ret1 = write(fds[1], region+PAGESIZE, PAGESIZE);
+    assert(ret1 == -1);
+    assert(errno == EFAULT);
+    assert_pipe_still_clean(fds[0], fds[1]);
+
+    // Test 2
+    unsigned char *straddle_ptr = region+PAGESIZE-16;
+    errno = 0;
+    ssize_t ret2 = write(fds[1], straddle_ptr, 32);
+    assert(ret2 == -1);
+    assert(errno == EFAULT);
+    assert_pipe_still_clean(fds[0], fds[1]);
+
+    // Test 3
+    
+    int32_t neg_len = -1;
+    size_t huge_count = (size_t)(uint32_t)neg_len;
+    errno = 0;
+
+    ssize_t ret3 = write(fds[1], straddle_ptr, huge_count);
+    assert(ret3 == -1);
+    assert(errno == EFAULT);
+    assert_pipe_still_clean(fds[0], fds[1]);
+
+    assert(munmap(region, PAGESIZE) == 0);
+    close(fds[0]);
+    close(fds[1]);
+
+    printf("cross_cage_vmmap_escape test: PASS\n");
+    return 0;
+}

--- a/tests/unit-tests/memory_tests/deterministic/vmmap_escape.c
+++ b/tests/unit-tests/memory_tests/deterministic/vmmap_escape.c
@@ -41,6 +41,18 @@ int main() {
     assert(errno == EFAULT);
     assert_pipe_still_clean(fds[0], fds[1]);
 
+    /*
+    Tests 2 and 3 assume the host kernel rejects a write() whose
+    buffer straddles a valid/invalid page boundary with a full EFAULT,
+    touching nothing, rather than the POSIX-permitted alternative of 
+    a partial write covering just the valid prefix. 
+
+    This held on the kernel tested against, but POSIX doesn't guarantee it.
+    A kernel that does incremental copy-then-fault could return a short 
+    byte count instead. If this test starts failing on a different host, that's 
+    the first thing to check.
+    */
+
     // Test 2
     unsigned char *straddle_ptr = region+PAGESIZE-16;
     errno = 0;
@@ -60,10 +72,23 @@ int main() {
     assert(errno == EFAULT);
     assert_pipe_still_clean(fds[0], fds[1]);
 
+    // Test 4
+    char read_marker = 'R';
+    assert(write(fds[1], &read_marker, 1) == 1);
+
+    errno = 0;
+    ssize_t ret4 = read(fds[0], region+PAGESIZE, 1);
+    assert(ret4 == -1);
+    assert(errno == EFAULT);
+    
+    char read_received;
+    assert(read(fds[0], &read_received, 1) == 1);
+    assert(read_received == read_marker);
+
     assert(munmap(region, PAGESIZE) == 0);
     close(fds[0]);
     close(fds[1]);
 
-    printf("cross_cage_vmmap_escape test: PASS\n");
+    printf("vmmap_escape test: PASS\n");
     return 0;
 }


### PR DESCRIPTION
Adds ISO-003 tests to verify that invalid memory ranges cannot escape the cage memory boundaries.

Changes
Added cross_cage_vmmap_escape.c unit test:
- Verifies that writing from a fully unmapped region returns EFAULT
- Verifies that writing across a mapped/unmapped page boundary is rejected
- Verifies that extremely large lengths that could overflow range calculations are rejected
- Uses a pipe canary check to ensure failed writes do not partially modify the destination

Added vmmap unit tests:
- Added coverage for rejecting address range calculations with overflowing lengths
- Added coverage for calculate_page_range returning None when the requested range overflows