### PR TITLE
fix: validate guest pointer in debug-panic host function

### DIFF
--- a/src/glibc/lind_syscall/lind_debug.c
+++ b/src/glibc/lind_syscall/lind_debug.c
@@ -1,4 +1,5 @@
-#include "addr_translation.h"
+#include <stdint.h>
+
 #include "lind_debug.h"
 
 #ifdef LIND_DEBUG
@@ -6,6 +7,9 @@
 #include <stdio.h>
 #endif
 
+// `msg` is a guest pointer, not a host address: the host adds the base and
+// bounds-checks it. Translating here would let any module name an arbitrary
+// host address. Stays 64-bit to keep the wasm import signature unchanged.
 void __lind_debug_panic(uint64_t msg) __attribute__((
     __import_module__("lind"),
     __import_name__("debug-panic")
@@ -15,7 +19,7 @@ void __lind_debug_panic(uint64_t msg) __attribute__((
 // depends on configuration, may halt or just log
 void lind_debug_panic (const char* msg)
 {
-    __lind_debug_panic(TRANSLATE_GUEST_POINTER_TO_HOST(msg));
+    __lind_debug_panic((uint64_t)(uintptr_t) msg);
 }
 
 #ifdef LIND_DEBUG

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -1,11 +1,12 @@
 #![allow(dead_code)]
 
 use anyhow::Result;
-use cage::memory::check_addr_write;
+use cage::memory::{check_addr_read, check_addr_write};
 use rand::Rng;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use sysdefs::constants::Errno;
+use sysdefs::constants::fs_const::PAGESIZE;
 use sysdefs::constants::lind_platform_const;
 use sysdefs::constants::lind_platform_const::{UNUSED_ARG, UNUSED_ID};
 use sysdefs::lind_debug_panic;
@@ -13,7 +14,6 @@ use threei::threei::{
     copy_data_between_cages, copy_handler_table_to_cage, make_syscall, register_handler,
 };
 use threei::threei_const;
-use typemap::path_conversion::get_cstr;
 use wasmtime::{AsContext, AsContextMut, AsyncifyState, Caller};
 use wasmtime_lind_dylink::DynamicLoader;
 use wasmtime_lind_multi_process::{LindHost, get_memory_base, get_memory_base_and_size};
@@ -242,6 +242,65 @@ fn add_syscall_to_linker<
     Ok(())
 }
 
+/// Read cap for guest strings; matches `lind_debug_printf`'s buffer.
+const MAX_DEBUG_STR_LEN: usize = 1024;
+
+/// Read a NUL-terminated string from the calling cage's linear memory.
+///
+/// `offset` is a guest pointer, not a host address — the host adds the base so a
+/// guest can never name an arbitrary host address.
+///
+/// The reported memory size covers the whole 4 GiB reservation, not the mapped
+/// pages, so it is only a first filter: each page is checked against the cage's
+/// vmmap *before* it is touched, the same way `_strlen_in_cage` does in threei.
+/// The scan stops at the first unmapped page or at `MAX_DEBUG_STR_LEN`.
+///
+/// `EFAULT` on an out-of-range pointer or a missing terminator. Non-UTF-8 is
+/// replaced, not rejected, so a bad message can't panic the host.
+fn read_guest_cstr<
+    T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync,
+    U: Clone + Send + 'static + std::marker::Sync,
+>(
+    caller: &mut Caller<'_, T>,
+    offset: u64,
+) -> Result<String, Errno> {
+    // Guest pointers are 32-bit.
+    if offset > u32::MAX as u64 {
+        return Err(Errno::EFAULT);
+    }
+    let off = offset as usize;
+
+    let cageid = wasmtime_lind_multi_process::current_cageid(caller) as u64;
+    let (base, mem_size) = get_memory_base_and_size(caller);
+    if off >= mem_size {
+        return Err(Errno::EFAULT);
+    }
+
+    let max_len = std::cmp::min(MAX_DEBUG_STR_LEN, mem_size - off);
+    let page_size = PAGESIZE as usize;
+    let mut out: Vec<u8> = Vec::new();
+    let mut read = 0usize;
+
+    while read < max_len {
+        let addr = off + read;
+        // Stop at the next page boundary so one unmapped page ends the scan.
+        let chunk = std::cmp::min(page_size - (addr % page_size), max_len - read);
+        check_addr_read(cageid, base + addr as u64, chunk).map_err(|_| Errno::EFAULT)?;
+
+        // Safe: the vmmap just confirmed this chunk is mapped and readable.
+        let bytes = unsafe { std::slice::from_raw_parts((base as *const u8).add(addr), chunk) };
+        if let Some(end) = bytes.iter().position(|&b| b == 0) {
+            out.extend_from_slice(&bytes[..end]);
+            return Ok(String::from_utf8_lossy(&out).into_owned());
+        }
+        out.extend_from_slice(bytes);
+        read += chunk;
+    }
+
+    // No terminator within the cap.
+    Err(Errno::EFAULT)
+}
+
 /// Register runtime introspection functions: memory base address, cage ID,
 /// setjmp/longjmp, epoch callback, and debug panic.
 fn add_runtime_to_linker<
@@ -265,10 +324,19 @@ fn add_runtime_to_linker<
         },
     )?;
 
-    linker.func_wrap("lind", "debug-panic", move |str: u64| -> () {
-        let _panic_str = unsafe { std::ffi::CStr::from_ptr(str as *const i8).to_str().unwrap() };
-        lind_debug_panic!("FROM GUEST: {}", _panic_str);
-    })?;
+    linker.func_wrap(
+        "lind",
+        "debug-panic",
+        move |mut caller: Caller<'_, T>, msg: u64| -> () {
+            match read_guest_cstr::<T, U>(&mut caller, msg) {
+                Ok(_panic_str) => lind_debug_panic!("FROM GUEST: {}", _panic_str),
+                // Still fatal either way; report the pointer, don't deref it.
+                Err(_) => {
+                    lind_debug_panic!("FROM GUEST: <unreadable message pointer {:#x}>", msg)
+                }
+            }
+        },
+    )?;
 
     #[cfg(feature = "asyncify-setjmp")]
     linker.func_wrap(
@@ -321,9 +389,9 @@ fn add_debug_to_linker<
         "debug",
         "lind_debug_str",
         move |mut caller: Caller<'_, T>, ptr: i32| -> i32 {
-            let mem_base = get_memory_base(&mut caller);
-            if let Ok(msg) = get_cstr(mem_base + (ptr as u32) as u64) {
-                eprintln!("[LIND DEBUG STR]: {}", msg);
+            match read_guest_cstr::<T, U>(&mut caller, (ptr as u32) as u64) {
+                Ok(msg) => eprintln!("[LIND DEBUG STR]: {}", msg),
+                Err(_) => eprintln!("[LIND DEBUG STR]: <unreadable pointer {:#x}>", ptr as u32),
             }
             ptr
         },

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -247,16 +247,15 @@ const MAX_DEBUG_STR_LEN: usize = 1024;
 
 /// Read a NUL-terminated string from the calling cage's linear memory.
 ///
-/// `offset` is a guest pointer, not a host address — the host adds the base so a
-/// guest can never name an arbitrary host address.
+/// `offset` is a guest pointer, not a host address. Two things keep this safe:
+/// the 32-bit bound means `base + offset` always lands inside this cage's own
+/// memory, and `check_addr_read` clears the page before we touch it — the 4 GiB
+/// reservation is mostly unmapped, so only the vmmap knows what is readable.
 ///
-/// The reported memory size covers the whole 4 GiB reservation, not the mapped
-/// pages, so it is only a first filter: each page is checked against the cage's
-/// vmmap *before* it is touched, the same way `_strlen_in_cage` does in threei.
-/// The scan stops at the first unmapped page or at `MAX_DEBUG_STR_LEN`.
-///
-/// `EFAULT` on an out-of-range pointer or a missing terminator. Non-UTF-8 is
-/// replaced, not rejected, so a bad message can't panic the host.
+/// Reads stop at the end of the starting page, so a message straddling a page
+/// boundary is truncated. That is deterministic per build and acceptable for a
+/// diagnostic. Non-UTF-8 is replaced, not rejected, so a bad message can't
+/// panic the host.
 fn read_guest_cstr<
     T: LindHost<T, U> + Clone + Send + 'static + std::marker::Sync,
     U: Clone + Send + 'static + std::marker::Sync,
@@ -264,41 +263,22 @@ fn read_guest_cstr<
     caller: &mut Caller<'_, T>,
     offset: u64,
 ) -> Result<String, Errno> {
-    // Guest pointers are 32-bit.
+    // Bounds `off` so `base + off` below cannot wrap.
     if offset > u32::MAX as u64 {
         return Err(Errno::EFAULT);
     }
     let off = offset as usize;
-
+    let base = get_memory_base(caller);
     let cageid = wasmtime_lind_multi_process::current_cageid(caller) as u64;
-    let (base, mem_size) = get_memory_base_and_size(caller);
-    if off >= mem_size {
-        return Err(Errno::EFAULT);
-    }
 
-    let max_len = std::cmp::min(MAX_DEBUG_STR_LEN, mem_size - off);
     let page_size = PAGESIZE as usize;
-    let mut out: Vec<u8> = Vec::new();
-    let mut read = 0usize;
+    let len = std::cmp::min(MAX_DEBUG_STR_LEN, page_size - (off % page_size));
+    check_addr_read(cageid, base + off as u64, len).map_err(|_| Errno::EFAULT)?;
 
-    while read < max_len {
-        let addr = off + read;
-        // Stop at the next page boundary so one unmapped page ends the scan.
-        let chunk = std::cmp::min(page_size - (addr % page_size), max_len - read);
-        check_addr_read(cageid, base + addr as u64, chunk).map_err(|_| Errno::EFAULT)?;
-
-        // Safe: the vmmap just confirmed this chunk is mapped and readable.
-        let bytes = unsafe { std::slice::from_raw_parts((base as *const u8).add(addr), chunk) };
-        if let Some(end) = bytes.iter().position(|&b| b == 0) {
-            out.extend_from_slice(&bytes[..end]);
-            return Ok(String::from_utf8_lossy(&out).into_owned());
-        }
-        out.extend_from_slice(bytes);
-        read += chunk;
-    }
-
-    // No terminator within the cap.
-    Err(Errno::EFAULT)
+    // Safe: the vmmap just confirmed this range is mapped and readable.
+    let bytes = unsafe { std::slice::from_raw_parts((base as *const u8).add(off), len) };
+    let end = bytes.iter().position(|&b| b == 0).unwrap_or(len);
+    Ok(String::from_utf8_lossy(&bytes[..end]).into_owned())
 }
 
 /// Register runtime introspection functions: memory base address, cage ID,

--- a/src/wasmtime/crates/lind-common/src/lib.rs
+++ b/src/wasmtime/crates/lind-common/src/lib.rs
@@ -263,8 +263,11 @@ fn read_guest_cstr<
     caller: &mut Caller<'_, T>,
     offset: u64,
 ) -> Result<String, Errno> {
-    // Bounds `off` so `base + off` below cannot wrap.
-    if offset > u32::MAX as u64 {
+    // Rejects NULL, and bounds `off` so `base + off` below cannot wrap.
+    // Guest offset 0 is mapped readable (`instance.rs:561` maps from
+    // `start_addr = 0`), so without this a NULL message would pass the
+    // `check_addr_read` below and log an empty string instead of being reported.
+    if offset == 0 || offset > u32::MAX as u64 {
         return Err(Errno::EFAULT);
     }
     let off = offset as usize;


### PR DESCRIPTION
## Summary

`src/wasmtime/crates/lind-common/src/lib.rs` registered `lind`/`debug-panic`
as `CStr::from_ptr(arg)` on a u64 straight from the guest. glibc pre-translated
the pointer (`lind_debug.c:18`), so the host dereferenced a guest-controlled
host address: arbitrary host-memory read, unbounded walk on an unterminated
string, and a `.to_str().unwrap()` panic on non-UTF-8. The read happened even
in `NO_LOGGING=1` builds, where the result is discarded.

## Fix

- glibc passes a guest pointer; the host adds the base itself.
- New read_guest_cstr bounds the offset to 32 bits, so base + offset always lands inside the cage's own memory, then calls check_addr_read before dereferencing. The memory size can't serve as the check.
- Reads are capped at 1024 bytes and at the end of the starting page; from_utf8_lossy instead of unwrap.
- `lind_debug_str` uses the same reader.

## Related issues

Should close: https://github.com/Lind-Project/lind-wasm/issues/1056

## Testing

Minimal repro — a module importing `debug-panic` directly and passing `0xdeadbeef`:

| | unpatched | patched |
|---|---|---|
| exit | 139 (SIGSEGV) | 0 |
| output | — | `FROM GUEST: <unreadable message pointer 0xdeadbeef>` |

Also checked: valid guest pointer still delivers its string; `0x1122334455667788`
rejected; real glibc call site prints `FROM GUEST: sched_getparam called but not
supported!`; default `PanicAndExit` still panics with the message (exit 101);
`lind_debug_str` verified under a `lind_debug` build.

Full `make build` + unit tests:
- math, filesystem, memory, process — 164 passed, 2 failed
- signals, networking, dynamic-linking — 77 passed, 0 failed

## User behavior related:
A message straddling a page boundary is truncated at the boundary. String literals are fixed at link time, so this is deterministic per build rather than intermittent, and it affects only diagnostic text on already-fatal paths.

## Compatibility and security impact

**Security:**. `lind`/`debug-panic` previously dereferenced a guest-controlled host address with no base addition and no bounds check, so any module could import it directly and make the runtime read arbitrary
host memory (contents land in the log) or segfault. It also walked past the end of
an unterminated string and panicked the host via `.to_str().unwrap()` on non-UTF-8.

**Performance:**  Validation costs exactly one check_addr_read per call — one vmmap lock acquisition — on paths that are already fatal or debug-only.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
- [ ] I added or updated tests where appropriate.
- [x] I ran the relevant tests locally and they pass.
- [ ] I formatted the code and ran the relevant linters.
- [ ] I updated documentation for user-visible or architectural changes.
- [ ] I disclosed security vulnerabilities privately rather than in this PR.

<!--
Project-wide contribution and review policies:
https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
-->
