### PR TITLE
docs: update outdated 3i comment

### DIFF
--- a/src/threei/src/handler_table/dashmap_impl.rs
+++ b/src/threei/src/handler_table/dashmap_impl.rs
@@ -7,16 +7,16 @@ use sysdefs::lind_log;
 /// HANDLERTABLE:
 /// A nested hash map used to define fine-grained per-syscall interposition rules.
 ///
-/// <self_cageid, <callnum, (dest_grateid, in_grate_addr)>
-/// Keys are the grate, the value is a HashMap with a key of the callnum
-/// and the values are a (dest_grateid, in_grate_addr) tuple for the actual handlers...
+/// <self_cageid, <callnum, <dest_grateid, in_grate_addr>>>
+/// Keys are the IDs of the cages whose syscalls are interposed; each value is a
+/// DashMap keyed by callnum whose values map the destination grate ID to the
+/// handler function address inside that grate (a single entry per callnum).
 type TargetCageMap = DashMap<u64, u64>; // Maps dest_grateid to destfunc in grate addr
 type CallnumMap = DashMap<u64, TargetCageMap>; // Maps targetcallnum to TargetCageMap
 type CageHandlerTable = DashMap<u64, CallnumMap>; // Maps self_cageid to CallnumMap
 
 lazy_static::lazy_static! {
-    // <self_cageid, <callnum, (dest_grateid, in_grate_addr)>>
-    // callnum is mapped to addr, not self
+    // <self_cageid, <callnum, <dest_grateid, in_grate_addr>>>
     pub static ref HANDLERTABLE: CageHandlerTable = DashMap::new();
 }
 
@@ -60,10 +60,10 @@ pub fn _check_cage_handler_exists(cageid: u64) -> bool {
     HANDLERTABLE.contains_key(&cageid)
 }
 
-/// Lookup the interposed handler for a given (self_cageid, syscall_num, target_cageid).
+/// Lookup the interposed handler for a given (self_cageid, syscall_num).
 ///
 /// 1. The lookup path is:
-///        HANDLERTABLE[self_cageid][syscall_num][target_cageid]
+///        HANDLERTABLE[self_cageid][syscall_num]
 ///
 /// 2. The registration logic guarantees that for a given (cageid, syscall_num)
 /// pair there will be only one handler stored in the map. Thus we can
@@ -72,15 +72,16 @@ pub fn _check_cage_handler_exists(cageid: u64) -> bool {
 /// ## Arguments:
 /// - `self_cageid`: The ID of the calling cage (the one executing the syscall).
 /// - `syscall_num`: The number of the syscall being invoked.
-/// - `target_cageid`: The ID of the target cage for the syscall.
+/// - `target_cageid`: The ID of the target cage for the syscall. Not used for
+/// the lookup itself; only included in panic diagnostics.
 ///
 /// ## Returns:
-///     Some((actual_target_cageid, handler_addr))
+///     Some((dest_grateid, in_grate_addr))
 ///
 /// ## Panics:
 ///     - If no entry exists for `self_cageid`.
 ///     - If no entry exists for `syscall_num`.
-///    - If no handler entry exists for the given `target_cageid` (or any fallback) under this syscall.
+///     - If no handler entry exists under this syscall.
 pub fn _get_handler(self_cageid: u64, syscall_num: u64, target_cageid: u64) -> Option<(u64, u64)> {
     // Grab the per-cage map guard.
     let self_entry = HANDLERTABLE.get(&self_cageid).unwrap_or_else(|| {
@@ -100,6 +101,8 @@ pub fn _get_handler(self_cageid: u64, syscall_num: u64, target_cageid: u64) -> O
 
     let target_map = call_entry.value();
 
+    // Registration keeps a single handler per (self_cageid, syscall_num) pair,
+    // so the first entry is the only one.
     if let Some(any) = target_map.iter().next() {
         let gid = *any.key();
         let addr = *any.value();
@@ -155,13 +158,13 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 ///
 /// ## Implementation details:
 ///
-/// This function supports three distinct behaviors according to the value of
-/// `handlefunccage` and `register_flag`.
+/// This function supports two distinct behaviors according to the value of
+/// `handlefunccage`.
 ///
-/// Case 1: Remove handler for (srccage, targetcallnum)
+/// Case 1: Remove handler for (targetcage, targetcallnum)
 ///
 /// If `handlefunccage` equals `THREEI_DEREGISTER`, the entire syscall entry
-/// under `(srccage, targetcallnum)` is removed. This means that all registered
+/// under `(targetcage, targetcallnum)` is removed. This means that all registered
 /// target cages for this syscall are cleared at once. After removal, the code
 /// performs structural cleanup so that empty intermediate maps are deleted in
 /// order to keep the table compact and avoid stale containers.
@@ -173,7 +176,7 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 /// Case 2: Register or overwrite handler
 ///
 /// In all other cases, the function performs registration or overwrite. The
-/// `(srccage, targetcallnum)` containers are created if they do not already
+/// `(targetcage, targetcallnum)` containers are created if they do not already
 /// exist. The handler is then inserted into the innermost map, replacing any
 /// previous handler registered for the same `handlefunccage`. This ensures that RAWPOSIX
 /// behaves strictly as a fallback dispatch target and does not shadow a more specific
@@ -184,7 +187,7 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 /// `self_cageid`. From the perspective of the glibc cage, every
 /// syscall is therefore dispatched toward RAWPOSIX by default. This
 /// means that even if a grate has already registered an interposed
-/// handler for a given `(srccage, syscall)`, the cage itself has no
+/// handler for a given `(targetcage, syscall)`, the cage itself has no
 /// prior knowledge of that registration. The grate knows, and 3i knows,
 /// but the cage does not.
 ///
@@ -198,19 +201,19 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 ///
 /// To reduce complexity and avoid ambiguous runtime inference, we adopt
 /// a simpler registration policy. Whenever a specific grate handler is
-/// registered for a `(srccage, syscall)` pair any entry is removed and
+/// registered for a `(targetcage, syscall)` pair any entry is removed and
 /// replaced. By enforcing this rule at registration time, we eliminate
 /// the need for complicated dispatch disambiguation logic later in 3i
 /// and keep the runtime decision path deterministic and structurally clean.
 pub fn register_handler_impl(
-    srccage: u64,
+    targetcage: u64,
     targetcallnum: u64,
     handlefunccage: u64,
     in_grate_fn_ptr_u64: u64,
 ) -> i32 {
-    // Case 1: Remove syscall mapping for a given (srccage, targetcallnum)
+    // Case 1: Remove syscall mapping for a given (targetcage, targetcallnum)
     if handlefunccage == threei_const::THREEI_DEREGISTER {
-        let remove_cage = if let Some(self_entry) = HANDLERTABLE.get(&srccage) {
+        let remove_cage = if let Some(self_entry) = HANDLERTABLE.get(&targetcage) {
             let call_map: &CallnumMap = self_entry.value();
             call_map.remove(&targetcallnum);
             call_map.is_empty()
@@ -219,20 +222,20 @@ pub fn register_handler_impl(
         };
 
         if remove_cage {
-            HANDLERTABLE.remove(&srccage);
+            HANDLERTABLE.remove(&targetcage);
         }
 
         return 0;
     }
 
     // Case 2: register or overwrite handler
-    let call_map_ref = HANDLERTABLE.entry(srccage).or_insert_with(DashMap::new);
+    let call_map_ref = HANDLERTABLE.entry(targetcage).or_insert_with(DashMap::new);
     let call_map: &CallnumMap = &*call_map_ref;
 
     let target_map_ref = call_map.entry(targetcallnum).or_insert_with(DashMap::new);
     let target_map: &TargetCageMap = &*target_map_ref;
 
-    // Each (srccage, targetcallnum) pair keeps only one handler entry,
+    // Each (targetcage, targetcallnum) pair keeps only one handler entry,
     // so we clear any existing mapping and replace it directly.
     target_map.clear();
 

--- a/src/threei/src/handler_table/hashmap_impl.rs
+++ b/src/threei/src/handler_table/hashmap_impl.rs
@@ -7,16 +7,16 @@ use sysdefs::lind_log;
 /// HANDLERTABLE:
 /// A nested hash map used to define fine-grained per-syscall interposition rules.
 ///
-/// <self_cageid, <callnum, (dest_grateid, in_grate_addr)>
-/// Keys are the grate, the value is a HashMap with a key of the callnum
-/// and the values are a (dest_grateid, in_grate_addr) tuple for the actual handlers...
+/// <self_cageid, <callnum, <dest_grateid, in_grate_addr>>>
+/// Keys are the IDs of the cages whose syscalls are interposed; each value is a
+/// HashMap keyed by callnum whose values map the destination grate ID to the
+/// handler function address inside that grate (a single entry per callnum).
 type TargetCageMap = HashMap<u64, u64>; // Maps dest_grateid to destfunc in grate addr
 type CallnumMap = HashMap<u64, TargetCageMap>; // Maps targetcallnum to TargetCageMap
 type CageHandlerTable = HashMap<u64, CallnumMap>; // Maps self_cageid to CallnumMap
 
 lazy_static::lazy_static! {
-    // <self_cageid, <callnum, (dest_grateid, in_grate_addr)>
-    // callnum is mapped to addr, not self
+    // <self_cageid, <callnum, <dest_grateid, in_grate_addr>>>
     pub static ref HANDLERTABLE: Mutex<CageHandlerTable> = Mutex::new(HashMap::new());
 }
 
@@ -56,10 +56,10 @@ pub fn _check_cage_handler_exists(cageid: u64) -> bool {
     handler_table.contains_key(&cageid)
 }
 
-/// Lookup the interposed handler for a given (self_cageid, syscall_num, target_cageid).
+/// Lookup the interposed handler for a given (self_cageid, syscall_num).
 ///
 /// 1. The lookup path is:
-///        HANDLERTABLE[self_cageid][syscall_num][target_cageid]
+///        HANDLERTABLE[self_cageid][syscall_num]
 ///
 /// 2. The registration logic guarantees that for a given (cageid, syscall_num)
 /// pair there will be only one handler stored in the map. Thus we can
@@ -68,10 +68,11 @@ pub fn _check_cage_handler_exists(cageid: u64) -> bool {
 /// ## Arguments:
 /// - `self_cageid`: The ID of the calling cage (the one executing the syscall).
 /// - `syscall_num`: The number of the syscall being invoked.
-/// - `target_cageid`: The ID of the target cage for the syscall.
+/// - `target_cageid`: The ID of the target cage for the syscall. Not used for
+/// the lookup itself; only included in panic diagnostics.
 ///
 /// ## Returns:
-///     Some((actual_target_cageid, handler_addr))
+///     Some((dest_grateid, in_grate_addr))
 ///
 /// ## Panics:
 ///     - If no entry exists for `self_cageid`.
@@ -81,20 +82,21 @@ pub fn _get_handler(self_cageid: u64, syscall_num: u64, target_cageid: u64) -> O
 
     let call_map = handler_table.get(&self_cageid).unwrap_or_else(|| {
         panic!(
-            "[3i|_get_handler] no handler table for self_cageid: {}",
-            self_cageid
+            "[3i|_get_handler] no handler table for self_cageid: {} (syscall_num={}, target_cageid={})",
+            self_cageid, syscall_num, target_cageid
         )
     });
     let target_map = call_map.get(&syscall_num).unwrap_or_else(|| {
         panic!(
-            "[3i|_get_handler] no handler for syscall_num: {} in self_cageid: {}",
-            syscall_num, self_cageid
+            "[3i|_get_handler] no handler for syscall_num: {} in self_cageid: {} (target_cageid={})",
+            syscall_num, self_cageid, target_cageid
         )
     });
 
+    // Registration keeps a single handler per (self_cageid, syscall_num) pair,
+    // so the first entry is the only one.
     let grateid = target_map.keys().next().copied()?;
     let addr = target_map.values().next().copied()?;
-    // Otherwise fallback to any registered handler
     return Some((grateid, addr));
 }
 
@@ -141,13 +143,13 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 ///
 /// ## Implementation details:
 ///
-/// This function supports three distinct behaviors according to the value of
-/// `handlefunccage` and `register_flag`.
+/// This function supports two distinct behaviors according to the value of
+/// `handlefunccage`.
 ///
-/// Case 1: Remove handler for (srccage, targetcallnum)
+/// Case 1: Remove handler for (targetcage, targetcallnum)
 ///
 /// If `handlefunccage` equals `THREEI_DEREGISTER`, the entire syscall entry
-/// under `(srccage, targetcallnum)` is removed. This means that all registered
+/// under `(targetcage, targetcallnum)` is removed. This means that all registered
 /// target cages for this syscall are cleared at once. After removal, the code
 /// performs structural cleanup so that empty intermediate maps are deleted in
 /// order to keep the table compact and avoid stale containers.
@@ -159,7 +161,7 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 /// Case 2: Register or overwrite handler
 ///
 /// In all other cases, the function performs registration or overwrite. The
-/// `(srccage, targetcallnum)` containers are created if they do not already
+/// `(targetcage, targetcallnum)` containers are created if they do not already
 /// exist. The handler is then inserted into the innermost map, replacing any
 /// previous handler registered for the same `handlefunccage`. This ensures that RAWPOSIX
 /// behaves strictly as a fallback dispatch target and does not shadow a more specific
@@ -170,7 +172,7 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 /// `self_cageid`. From the perspective of the glibc cage, every
 /// syscall is therefore dispatched toward RAWPOSIX by default. This
 /// means that even if a grate has already registered an interposed
-/// handler for a given `(srccage, syscall)`, the cage itself has no
+/// handler for a given `(targetcage, syscall)`, the cage itself has no
 /// prior knowledge of that registration. The grate knows, and 3i knows,
 /// but the cage does not.
 ///
@@ -184,37 +186,37 @@ pub fn _rm_cage_from_handler(cageid: u64) {
 ///
 /// To reduce complexity and avoid ambiguous runtime inference, we adopt
 /// a simpler registration policy. Whenever a specific grate handler is
-/// registered for a `(srccage, syscall)` pair any entry is removed and
+/// registered for a `(targetcage, syscall)` pair any entry is removed and
 /// replaced. By enforcing this rule at registration time, we eliminate
 /// the need for complicated dispatch disambiguation logic later in 3i
 /// and keep the runtime decision path deterministic and structurally clean.
 pub fn register_handler_impl(
-    srccage: u64,
+    targetcage: u64,
     targetcallnum: u64,
     handlefunccage: u64,
     in_grate_fn_ptr_u64: u64,
 ) -> i32 {
     let mut table = HANDLERTABLE.lock().expect("HANDLERTABLE mutex poisoned");
 
-    // Case 1: Remove syscall mapping for a given (srccage, targetcallnum)
+    // Case 1: Remove syscall mapping for a given (targetcage, targetcallnum)
     // If `handlefunccage == THREEI_DEREGISTER`, remove the entire callnum entry
     // for the given (targetcage, targetcallnum).
     if handlefunccage == threei_const::THREEI_DEREGISTER {
-        if let Some(call_map) = table.get_mut(&srccage) {
+        if let Some(call_map) = table.get_mut(&targetcage) {
             call_map.remove(&targetcallnum);
 
             if call_map.is_empty() {
-                table.remove(&srccage);
+                table.remove(&targetcage);
             }
         }
         return 0;
     }
 
     // Case 2: Register or overwrite handler
-    let call_map = table.entry(srccage).or_insert_with(HashMap::new);
+    let call_map = table.entry(targetcage).or_insert_with(HashMap::new);
     let target_map = call_map.entry(targetcallnum).or_insert_with(HashMap::new);
 
-    // Each (srccage, targetcallnum) pair keeps only one handler entry,
+    // Each (targetcage, targetcallnum) pair keeps only one handler entry,
     // so we clear any existing mapping and replace it directly.
     target_map.clear();
 
@@ -235,11 +237,11 @@ pub fn copy_handler_table_to_cage_impl(srccage: u64, targetcage: u64) -> u64 {
         let target_entry = handler_table.get_mut(&targetcage).unwrap();
         for (callnum, callnum_map) in src_entry {
             let target_callnum_map = target_entry.entry(callnum).or_insert_with(HashMap::new);
-            for (handlefunc, handlefunccage) in callnum_map {
+            for (handlefunccage, in_grate_addr) in callnum_map {
                 // If not already present, insert
                 target_callnum_map
-                    .entry(handlefunc)
-                    .or_insert(handlefunccage);
+                    .entry(handlefunccage)
+                    .or_insert(in_grate_addr);
             }
         }
         0

--- a/src/threei/src/threei.rs
+++ b/src/threei/src/threei.rs
@@ -9,19 +9,18 @@ use once_cell::sync::Lazy;
 use std::sync::RwLock;
 use sysdefs::constants::err_const::Errno;
 use sysdefs::constants::lind_platform_const;
-use sysdefs::constants::{PROT_READ, PROT_WRITE}; // Used in `copy_data_between_cages`
 use sysdefs::lind_log;
-use typemap::datatype_conversion::sc_convert_uaddr_to_host;
 
 use crate::handler_table::{
-    _check_cage_handler_exists, _get_handler, _rm_cage_from_handler, _rm_grate_from_handler,
-    copy_handler_table_to_cage_impl, print_handler_table, register_handler_impl,
+    _get_handler, _rm_cage_from_handler, _rm_grate_from_handler, copy_handler_table_to_cage_impl,
+    register_handler_impl,
 };
 use crate::threei_const;
 
 pub use sysdefs::constants::sys_const::{EXIT_GROUP_SYSCALL, EXIT_SYSCALL};
 
-/// Function pointer type for rawposix syscall functions in SYSCALL_TABLE.
+/// Function pointer type for rawposix syscall functions registered in the
+/// handler table (under `RAWPOSIX_CAGEID` / `WASMTIME_CAGEID`).
 pub type RawCallFunc = extern "C" fn(
     target_cageid: u64,
     arg1: u64,
@@ -57,6 +56,30 @@ pub type GrateTrampolineFn = extern "C" fn(
     arg5cageid: u64,
     arg6: u64,
     arg6cageid: u64,
+) -> i32;
+
+/// Function pointer type for threei's own interposable calls (e.g.
+/// `register_handler`, `copy_handler_table_to_cage`) registered in the handler
+/// table under `THREEI_CAGEID`.
+///
+/// This has the same shape as `GrateTrampolineFn` (fourteen `u64` arguments),
+/// but the first two arguments carry the calling cage and the target cage
+/// instead of a grate function pointer and a grate ID.
+pub type ThreeiCallFunc = extern "C" fn(
+    self_cageid: u64,
+    target_cageid: u64,
+    arg1: u64,
+    arg1_cageid: u64,
+    arg2: u64,
+    arg2_cageid: u64,
+    arg3: u64,
+    arg3_cageid: u64,
+    arg4: u64,
+    arg4_cageid: u64,
+    arg5: u64,
+    arg5_cageid: u64,
+    arg6: u64,
+    arg6_cageid: u64,
 ) -> i32;
 
 #[derive(Clone, Copy, Debug)]
@@ -177,7 +200,7 @@ pub fn remove_cage_runtime(cageid: u64) -> Option<u64> {
 
 /// This function is the core grate-call dispatch entry point in the 3i library.
 ///
-/// · does not execute grate code itself. Instead, it performs runtime resolution and delegates
+/// It does not execute grate code itself. Instead, it performs runtime resolution and delegates
 /// the actual execution of the grate function to the runtime associated with the target grate.
 ///
 /// Given a `grateid`, this function first determines which runtime is responsible for executing
@@ -215,7 +238,7 @@ fn _call_grate_func(
     arg5_cageid: u64,
     arg6: u64,
     arg6_cageid: u64,
-) -> Option<i32> {
+) -> i32 {
     let runtimeid = match get_cage_runtime(grateid) {
         Some(r) => r,
         None => panic!(
@@ -232,7 +255,7 @@ fn _call_grate_func(
         ),
     };
 
-    let rc = (trampoline)(
+    (trampoline)(
         in_grate_fn_ptr_u64,
         grateid,
         arg1,
@@ -247,16 +270,14 @@ fn _call_grate_func(
         arg5_cageid,
         arg6,
         arg6_cageid,
-    );
-
-    Some(rc)
+    )
 }
 
 /// EXITING_TABLE:
 ///
 /// A grate/cage does not need to know the upper-level grate/cage information, but only needs
-/// to manage where the call goes. I use a global variable table to represent the cage/grate
-/// that is exiting. This table will be removed after the corresponding grate/cage performs
+/// to manage where the call goes. This global table records the cages/grates that are
+/// exiting. An entry is removed after the corresponding grate/cage performs
 /// `exit_syscall`. During the execution of the corresponding operation, all other 3i calls
 /// that want to operate the corresponding syscall will be blocked (additional check).
 ///
@@ -267,31 +288,34 @@ pub static EXITING_TABLE: Lazy<DashSet<u64>> = Lazy::new(|| DashSet::new());
 /// a handler function in a destination grate or cage. Used for creating per-syscall routing rules
 /// that enable one cage to interpose or handle syscalls on behalf of another.
 ///
-/// For example:
-/// I want cage 7 to have system call 34 call into my cage's function foo
+/// For example, to make cage 7's system call 34 call into function `foo`
+/// (at address `foo_addr`) inside grate `mygrateid`:
 ///
-/// Example:
 /// register_handler(
-///     foo_addr, 7,  34, SOME_ENTRY_PTR,
-///    1, mycagenum,
-///    ...)
+///     0, 0,       // _self_cageid, _target_cageid (unused)
+///     7,          // targetcage
+///     34,         // targetcallnum
+///     0,          // _runtime_id (unused)
+///     mygrateid,  // handlefunccage
+///     foo_addr,   // in_grate_fn_ptr_u64
+///     0, 0, 0, 0, 0, 0, 0,
+/// )
 ///
-///
-/// If a conflicting mapping exists, the function panics to prevent accidental overwrite.
-///
-/// If a handler is already registered for this (syscall number, in grate function address) pair with the same
-/// destination cage, the call is treated as a no-op.
+/// Each (targetcage, targetcallnum) pair keeps exactly one handler entry. If a
+/// handler is already registered for the pair, it is replaced (see
+/// `register_handler_impl` for the rationale). Passing `THREEI_DEREGISTER` as
+/// `handlefunccage` removes the entry instead.
 ///
 /// ## Arguments:
 /// - in_grate_fn_ptr_u64: Pointer to the function inside the grate that will handle this syscall.
 /// - targetcage: The ID of the cage whose syscall table is being modified (i.e., the source of the syscall).
 /// - targetcallnum: The syscall number to interpose on (can be treated as a match-all in some configurations).
-/// - handlefunccage: The cage (typically a grate) that owns the destination function to be called.
+/// - handlefunccage: The cage (typically a grate) that owns the destination function to be called,
+/// or `THREEI_DEREGISTER` to remove the existing entry.
 ///
 /// ## Returns:
 /// 0 on success.
 /// ELINDESRCH if either the source (targetcage) or destination (handlefunccage) is in the EXITING state.
-/// Panics if there is an attempt to overwrite an existing handler with a different destination cage.
 pub fn register_handler(
     _self_cageid: u64, // place holder to fit make_syscall's argument pattern, currently not used in the function
     _target_cageid: u64, // place holder to fit make_syscall's argument pattern, currently not used in the function
@@ -375,27 +399,31 @@ pub fn copy_handler_table_to_cage(
 /// could be changed, but it doesn't seem useful to do so.
 ///
 /// This is the main entry point used by cages or grates to invoke system calls through the
-/// 3i layer. The function inspects the caller’s interposition configuration (if any) and
-/// either routes the syscall to a grate for handling or directly invokes the corresponding
-/// function in the RawPOSIX layer.
+/// 3i layer. The function looks up the handler registered for (self_cageid, syscall_num)
+/// in the handler table and dispatches to it. RawPOSIX is not a separate fallback path:
+/// direct RawPOSIX syscalls are themselves handler-table entries registered under
+/// `RAWPOSIX_CAGEID`.
 ///
 /// ## Behavior:
-/// If the target_cageid is in the process of exiting and the syscall is not `EXIT_SYSCALL`,
-/// the call is aborted early with `ELINDESRCH`
+/// If the target_cageid is dead or in the process of exiting, the syscall is not
+/// `EXIT_SYSCALL` / `EXIT_GROUP_SYSCALL`, and the caller is not the target itself,
+/// the call is aborted early with `-ESRCH`.
 ///
-/// If the calling self_cageid has any handlers registered, the call is redirected to the
-/// corresponding grate closure
+/// If the registered handler is a RawPOSIX or Wasmtime entry (`RAWPOSIX_CAGEID` /
+/// `WASMTIME_CAGEID`), the stored function pointer is invoked directly.
 ///
-/// If the syscall is EXIT_SYSCALL, performs global cleanup
+/// If the registered handler is a threei entry (`THREEI_CAGEID`), the stored function
+/// pointer is invoked directly with (self_cageid, target_cageid) as the first two arguments.
 ///
-/// If direct RawPOSIX call, falls back to invoking the syscall from SYSCALL_TABLE directly by number.
+/// Otherwise, the call is dispatched to the registered grate through the runtime
+/// trampoline (see `_call_grate_func`).
 ///
 /// ## Arguments:
 /// - self_cageid: The ID of the cage issuing the syscall (used to look up interposition rules
 /// and access memory).
 /// - syscall_num: Numeric syscall identifier, used to determine routing and rawposix function.
 /// - syscall_name: A pointer (in Wasm memory) to the UTF-8 encoded string representing the
-/// syscall name. Only relevant for grate calls.
+/// syscall name. Currently unused.
 /// - target_cageid: The target of the syscall (typically same as self_cageid, but may differ
 /// in inter-cage calls).
 /// - arg1..arg6: The six argument values passed to the syscall.
@@ -403,12 +431,11 @@ pub fn copy_handler_table_to_cage(
 /// each argument.
 ///
 /// Returns:
-/// - `i32` syscall result.
-/// - Returns `ELINDESRCH` if the target cage is in `EXITING_TABLE` and the syscall is not an exit.
-/// - Returns `ELINDAPIABORTED` if the syscall number does not exist in the known syscall table.
-/// - Returns the result of the interposed or rawposix syscall if executed successfully.
-/// - Panics if the syscall was routed to a grate, but the corresponding exported function could
-/// not be resolved.
+/// - `i32` syscall result of the dispatched handler.
+/// - Returns `-ESRCH` if the target cage is dead or in `EXITING_TABLE` (unless the syscall
+/// is an exit variant or the caller is the target itself), or if the destination grate is
+/// already dead.
+/// - Panics if no handler is registered for (self_cageid, syscall_num).
 pub fn make_syscall(
     self_cageid: u64, // is required to get the cage instance
     syscall_num: u64,
@@ -480,11 +507,11 @@ pub fn make_syscall(
                 arg6_cageid,
             );
         }
-        // Threei special case: if the call is an interposed 3i call
+        // Threei special case: if the call is an interposed 3i call,
+        // directly call the function pointer
         if grateid == lind_platform_const::THREEI_CAGEID {
-            // threei special case: directly call the function pointer
-            let func: GrateTrampolineFn =
-                unsafe { std::mem::transmute::<u64, GrateTrampolineFn>(in_grate_fn_ptr_u64) };
+            let func: ThreeiCallFunc =
+                unsafe { std::mem::transmute::<u64, ThreeiCallFunc>(in_grate_fn_ptr_u64) };
             return func(
                 self_cageid,
                 target_cageid,
@@ -552,22 +579,13 @@ pub fn make_syscall(
                 .fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
         });
 
-        if let Some(ret) = grate_result {
-            return ret;
-        } else {
-            // syscall has been registered to register_handler but grate's entry function
-            // doesn't provide
-            // Panic here because this indicates error happens in wasmtime side when attaching
-            // the module closure, which is a system-level error
-            panic!(
-                "[3i|make_syscall] grate call not found! grateid: {}",
-                grateid
-            );
-        }
+        return grate_result;
     }
 
     // _get_handler returned None — the target_map for this
     // (self_cageid, syscall_num) exists but has no dest_grateid entry.
+    // (Only reachable with the hashmap backend; the dashmap backend panics
+    // inside _get_handler in this case.)
     panic!(
         "[3i|make_syscall] _get_handler returned None for self_cageid={} syscall_num={}",
         self_cageid, syscall_num
@@ -779,7 +797,8 @@ fn _validate_range_rw(cage: u64, addr: u64, len: usize, what: &str) -> Result<()
 /// C-style strings across cage boundaries.
 ///
 /// ## Arguments:
-/// - src: A raw pointer to the beginning of the string in the source cage's memory.
+/// - cageid: The ID of the cage whose memory is scanned.
+/// - srcaddr: The address of the beginning of the string in the source cage's memory.
 /// - max_len: The maximum number of bytes to scan, acting as a bound to prevent
 /// overflow.
 ///
@@ -888,9 +907,9 @@ pub fn copy_data_between_cages(
     }
 
     // Reject requests where `len` exceeds the maximum allowed linear memory size
-    // (`MAX_LIND_SIZE`), since such a copy would exceed the Wasm 32-bit address space.
+    // (`MAX_LINEAR_MEMORY_SIZE`), since such a copy would exceed the Wasm 32-bit address space.
     if let Err(code) = _validate_len(len, lind_platform_const::MAX_LINEAR_MEMORY_SIZE) {
-        lind_log!(THREEI, "[3i|copy] length too large or zero: {}", len);
+        lind_log!(THREEI, "[3i|copy] length too large: {}", len);
         return code;
     }
     // destaddr must be provided (no dynamic allocation support)
@@ -957,12 +976,13 @@ pub fn copy_data_between_cages(
         return code;
     }
 
-    // Translate user virtual addrs to host pointers
+    // The addresses are used directly as host pointers (no translation is
+    // performed here); just guard against NULL before the copy.
     let host_src_addr = srcaddr;
     let host_dest_addr = destaddr;
     if host_src_addr == 0 || host_dest_addr == 0 {
         // src addr or dest addr is null
-        lind_log!(THREEI, "[3i|copy] host addr translate failed");
+        lind_log!(THREEI, "[3i|copy] src or dest addr is null");
         return threei_const::ELINDAPIABORTED;
     }
 

--- a/src/threei/src/threei_const.rs
+++ b/src/threei/src/threei_const.rs
@@ -11,8 +11,8 @@ pub const THREEI_MATCHALL: u64 = 501;
 /// See function-level comments for specific usage details.  
 pub const ELINDAPIABORTED: u64 = 0xE001_0001;
 /// ELINDESRCH: if either the source (targetcage) or destination
-// (handlefunccage) is in the EXITING state.
-/// See function-level comments for specific usage details.  
+/// (handlefunccage) is in the EXITING state.
+/// See function-level comments for specific usage details.
 pub const ELINDESRCH: u64 = 0xE001_0002;
 /// Indicates a successful Grate call.
 /// This value (0) is returned from functions that perform a Grate-side


### PR DESCRIPTION
## Summary

Update outdated 3i comments 
Split 3i internal function pointer API with grate call pointer API

## Related issues

Closes #851 

## Testing

pass `make test` in container env


## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
- [x] I added or updated tests where appropriate.
- [x] I ran the relevant tests locally and they pass.
- [x] I formatted the code and ran the relevant linters.
- [x] I updated documentation for user-visible or architectural changes.
- [x] I disclosed security vulnerabilities privately rather than in this PR.

<!--
Project-wide contribution and review policies:
https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
-->
