### PR TITLE
fix(exec): reuse the cage's linear memory instead of mapping a second 4 GiB

### DIFF
--- a/src/lind-boot/src/lind_wasmtime/execute.rs
+++ b/src/lind-boot/src/lind_wasmtime/execute.rs
@@ -103,6 +103,7 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
         engine,
         module,
         CAGE_START_ID as u64,
+        None, // the first cage has no memory to inherit
     );
 
     match result {
@@ -153,12 +154,18 @@ pub fn execute_wasmtime(lindboot_cli: CliOptions) -> anyhow::Result<i32> {
 /// does not require mutating it. The goal here is to perform the minimal work needed
 /// to re-create a Wasmtime engine/store, attach host APIs, instantiate the module
 /// inside the provided `cageid`, and transfer control to the new guest entrypoint.
+///
+/// `reuse_memory` carries the linear memory the target cage already owns. On the exec
+/// path it is `Some`, so the new image is instantiated on the cage's existing 4 GiB
+/// reservation instead of mapping a second one; the initial boot passes `None` and a
+/// fresh reservation is created.
 pub fn execute_with_lind(
     lind_boot: CliOptions,
     lind_manager: Arc<LindCageManager>,
     engine: Engine,
     module: Module,
     cageid: u64,
+    reuse_memory: Option<SharedMemory>,
 ) -> Result<Vec<Val>> {
     // -- Initialize the Wasmtime execution environment --
     let args = lind_boot.args.clone();
@@ -255,6 +262,7 @@ pub fn execute_with_lind(
         lind_boot.clone(),
         cageid as i32,
         &dylink_metadata,
+        reuse_memory,
     )?;
 
     if dylink_metadata.dylink_enabled {
@@ -361,6 +369,17 @@ pub fn execute_with_lind(
         )
         .with_context(|| format!("failed to run main module"))
     });
+
+    // The grate worker pool `load_main_module` registered for this cage owns one
+    // `Store` (and instance) per worker, all attached to this cage's linear memory.
+    // The registry is a process-wide table, so as long as the entry is there the
+    // cage's 4 GiB reservation stays mapped -- for every cage that ever ran a
+    // program image, for the rest of the host process's lifetime. The program has
+    // now finished, so drop the registry's reference; a grate call still in flight
+    // holds its own `Arc` (see `submit_grate_request`) and finishes normally.
+    //
+    // No handler is registered on the dylink path, so a missing entry is expected.
+    let _ = unregister_grate_handler(cageid);
 
     result
 }
@@ -478,6 +497,7 @@ fn attach_api(
     lindboot_cli: CliOptions,
     cageid: i32,
     dylink_metadata: &DylinkMetadata,
+    reuse_memory: Option<SharedMemory>,
 ) -> Result<()> {
     // Initialize argv/environ data and attach all Lind host functions
     // (syscall dispatch, debug, signals, and argv/environ) to the linker.
@@ -524,7 +544,14 @@ fn attach_api(
     // Pass all modules so the memory is created with limits that satisfy every
     // module's import declaration (union: max of mins, min of maxes).
     let all_modules: Vec<Module> = modules.iter().map(|(_, _, m)| m.clone()).collect();
-    attach_shared_memory(&mut *wstore, &mut linker_guard, &all_modules, true, cageid)?;
+    attach_shared_memory(
+        &mut *wstore,
+        &mut linker_guard,
+        &all_modules,
+        true,
+        cageid,
+        reuse_memory,
+    )?;
 
     // Define the __c_longjmp tag for wasm EH-based setjmp/longjmp.
     // libc.so (wasm_eh_setjmp.o) and user programs both import "env"."__c_longjmp";
@@ -555,7 +582,7 @@ fn attach_api(
                 host.fork()
             }
         },
-        |lindboot_cli, path, args, engine, module, cageid, lind_manager, envs| {
+        |lindboot_cli, path, args, engine, module, cageid, lind_manager, envs, cage_memory| {
             let mut new_lindboot_cli = lindboot_cli.clone();
             new_lindboot_cli.args = vec![String::from(path)];
             // new_lindboot_cli.wasm_file = path.to_string();
@@ -572,6 +599,7 @@ fn attach_api(
                 engine,
                 module,
                 cageid as u64,
+                cage_memory,
             )
         },
     )?);

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -125,6 +125,13 @@ pub enum DylinkErrorCode {
 
 pub const FPCAST_FUNC_SIGNATURE: &str = "$fpcast_emu$";
 
+/// The import namespace / name under which every lind-wasm module imports its
+/// shared linear memory. `wasm-ld --import-memory` always emits `env`.`memory`,
+/// and lind's toolchain builds every module (main, glibc, preloads) that way, so
+/// this is fixed rather than discovered by scanning a module's import section.
+const LIND_MEMORY_IMPORT_MODULE: &str = "env";
+const LIND_MEMORY_IMPORT_NAME: &str = "memory";
+
 /// Maximum number of grate workers that may exist for one grate handler.
 ///
 /// This is a platform-wide configuration constant. lind-wasm preallocates

--- a/src/sysdefs/src/constants/lind_platform_const.rs
+++ b/src/sysdefs/src/constants/lind_platform_const.rs
@@ -129,8 +129,8 @@ pub const FPCAST_FUNC_SIGNATURE: &str = "$fpcast_emu$";
 /// shared linear memory. `wasm-ld --import-memory` always emits `env`.`memory`,
 /// and lind's toolchain builds every module (main, glibc, preloads) that way, so
 /// this is fixed rather than discovered by scanning a module's import section.
-const LIND_MEMORY_IMPORT_MODULE: &str = "env";
-const LIND_MEMORY_IMPORT_NAME: &str = "memory";
+pub const LIND_MEMORY_IMPORT_MODULE: &str = "env";
+pub const LIND_MEMORY_IMPORT_NAME: &str = "memory";
 
 /// Maximum number of grate workers that may exist for one grate handler.
 ///

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -7,7 +7,8 @@ use std::ffi::c_void;
 use std::ptr::NonNull;
 use sysdefs::constants::fs_const::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PROT_NONE};
 use sysdefs::constants::lind_platform_const::{
-    UNUSED_ARG, UNUSED_ID, UNUSED_NAME, unset_stack_arena_base,
+    LIND_MEMORY_IMPORT_MODULE, LIND_MEMORY_IMPORT_NAME, UNUSED_ARG, UNUSED_ID, UNUSED_NAME,
+    unset_stack_arena_base,
 };
 use sysdefs::constants::syscall_const::{EXEC_SYSCALL, EXIT_SYSCALL, FORK_SYSCALL};
 use sysdefs::constants::{Errno, MAX_SHEBANG_DEPTH, MMAP_SYSCALL};
@@ -1467,19 +1468,20 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
 
         // exec replaces the program image but keeps the cage, so the 4 GiB linear
         // memory this cage already owns is handed to the new image instead of
-        // mapping a second reservation. It is looked up under the import name the
-        // current program's main module uses, which is how it was defined in this
-        // cage's linker (see `attach_shared_memory`).
+        // mapping a second reservation. It is looked up under the same fixed name
+        // `attach_shared_memory` defined it under in this cage's linker.
         //
         // If the lookup fails we simply fall back to a fresh reservation, which is
         // the pre-existing behaviour, so exec keeps working either way.
-        let cage_memory = shared_memory_import_name(main_module).and_then(|(module, name)| {
-            self.linker.as_ref().and_then(|linker| {
-                linker
-                    .get(&mut *caller, &module, &name)
-                    .ok()
-                    .and_then(|ext| ext.into_shared_memory())
-            })
+        let cage_memory = self.linker.as_ref().and_then(|linker| {
+            linker
+                .get(
+                    &mut *caller,
+                    LIND_MEMORY_IMPORT_MODULE,
+                    LIND_MEMORY_IMPORT_NAME,
+                )
+                .ok()
+                .and_then(|ext| ext.into_shared_memory())
         });
 
         // get the base address of the memory
@@ -2398,10 +2400,12 @@ where
 // mmap-ed reservation would.
 //
 // Note that reusing the reservation means the pre-exec image's memory really is
-// gone once exec succeeds, so a sibling thread that outlives exec would fault.
-// POSIX requires exec to terminate every other thread in the process first, which
-// lind does not do yet (see the thread cleanup TODO in rawposix `exec_syscall`);
-// exec is currently only reachable from a cage's main thread.
+// gone once exec succeeds, so a sibling thread that outlives exec would keep
+// running against a linear memory whose contents have been discarded. POSIX
+// requires exec to terminate every other thread in the cage first; rawposix's
+// `exec_syscall` documents that as its job but does not do it yet, so multi-
+// threaded exec is not safe on this path. No lind application exercises it today
+// (exec is only reached from a cage's main thread) -- tracked separately.
 pub fn attach_shared_memory<
     T: LindHost<T, U> + Clone + Send + Sync + 'static,
     U: Clone + Send + Sync + 'static,
@@ -2413,14 +2417,11 @@ pub fn attach_shared_memory<
     cageid: i32,
     existing_memory: Option<SharedMemory>,
 ) -> Result<()> {
-    // Find the shared memory import in the first module (main module) to get
-    // the import namespace / name under which to register the memory.
+    // The main module is only needed for its engine; the import name the memory is
+    // registered under is fixed (see LIND_MEMORY_IMPORT_MODULE / _NAME).
     let main_module = all_modules
         .first()
         .ok_or_else(|| anyhow!("no modules provided"))?;
-
-    let (import_module_name, import_name) = shared_memory_import_name(main_module)
-        .ok_or_else(|| anyhow!("Main Module does not contain a shared memory"))?;
 
     // In lind-wasm the linear memory is always a fixed 4 GiB physical
     // reservation (MmapMemory overrides max to MAX_MEMORY_SIZE = 4 GiB).
@@ -2535,27 +2536,14 @@ pub fn attach_shared_memory<
 
         cage::init_vmmap(cageid as u64, memory_base as usize, None);
     }
-    linker.define(&store, &import_module_name, &import_name, mem.clone())?;
+    linker.define(
+        &store,
+        LIND_MEMORY_IMPORT_MODULE,
+        LIND_MEMORY_IMPORT_NAME,
+        mem.clone(),
+    )?;
 
     Ok(())
-}
-
-/// Return the `(module, name)` pair under which `module` imports its shared linear
-/// memory, or `None` if it does not import one.
-///
-/// Both `attach_shared_memory` (which defines the memory in a cage's linker) and
-/// the exec path (which looks the memory back up so it can be reused) need this
-/// name, so it is derived in one place.
-fn shared_memory_import_name(module: &Module) -> Option<(String, String)> {
-    module.imports().find_map(|import| {
-        let ty = import.ty();
-        let memory = ty.memory()?;
-        if memory.is_shared() {
-            Some((import.module().to_string(), import.name().to_string()))
-        } else {
-            None
-        }
-    })
 }
 
 pub fn early_init_stack(cageid: u64, stack_start: i32, stack_end: i32) -> Result<()> {

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -5,6 +5,7 @@ use cfg_if::cfg_if;
 use anyhow::{Context, Result, anyhow};
 use std::ffi::c_void;
 use std::ptr::NonNull;
+use sysdefs::constants::fs_const::{MAP_ANONYMOUS, MAP_FIXED, MAP_PRIVATE, PROT_NONE};
 use sysdefs::constants::lind_platform_const::{
     UNUSED_ARG, UNUSED_ID, UNUSED_NAME, unset_stack_arena_base,
 };
@@ -2392,9 +2393,9 @@ where
 // cage that already owns a 4 GiB linear-memory reservation, so the reservation is
 // reused instead of mapping a second one (the old one would otherwise stay mapped
 // until the exec-ed program finishes, since the pre-exec `Store` is still alive
-// further down the host call stack). When reusing, the region is released back to
-// the kernel (`MADV_DONTNEED`) so the new image starts from zeroed pages, exactly
-// like a freshly mmap-ed reservation.
+// further down the host call stack). When reusing, the region is re-mapped fresh
+// and anonymous so the new image starts from zeroed pages, exactly like a newly
+// mmap-ed reservation would.
 //
 // Note that reusing the reservation means the pre-exec image's memory really is
 // gone once exec succeeds, so a sibling thread that outlives exec would fault.
@@ -2481,33 +2482,55 @@ pub fn attach_shared_memory<
     if need_init {
         let memory_base = mem.get_memory_base();
 
-        unsafe {
-            // A reused reservation still holds the previous image's pages. Hand
-            // them back to the kernel so the new image sees zeroed memory (.bss
-            // and any page the module does not write a data segment into), which
-            // is what a freshly mmap-ed reservation would have given us. On a
-            // private anonymous mapping MADV_DONTNEED drops the pages and the
-            // next touch faults in a zero page, so this also returns the old
-            // program's RSS instead of carrying it across exec.
-            if reused {
-                libc::madvise(
+        // lind-wasm: reset the entire 4 GiB wasm linear memory to PROT_NONE
+        // before handing it to rawposix. rawposix vmmap is solely responsible
+        // for promoting pages to PROT_READ|PROT_WRITE as the guest accesses
+        // them. early_init_stack (dylink) and the make_syscall in
+        // new_started_impl_with_lind re-establish the required initial regions
+        // before any wasm code runs.
+        if reused {
+            // A reused reservation still carries the previous image's mappings,
+            // and `mprotect` alone would only change their permissions: the old
+            // pages stay, so the new image would see stale bytes wherever nothing
+            // writes over them -- .bss above all, which is never written and is
+            // simply assumed to be zero.
+            //
+            // Nor is MADV_DONTNEED enough. The region is not uniformly private and
+            // anonymous: rawposix maps files into it with MAP_FIXED (`mmap_inner`)
+            // and attaches SysV shm with MAP_SHARED|MAP_FIXED (`cage::shmat`).
+            // MADV_DONTNEED only zero-fills on the private anonymous parts; over a
+            // file-backed or shared range it just drops the cached pages and the
+            // contents come straight back on the next access, with the old VMA type
+            // still in place.
+            //
+            // So re-establish a fresh anonymous mapping over the whole region, the
+            // same way rawposix's own `munmap` releases a range. This replaces any
+            // leftover file/shm mapping, discards every page (the next touch faults
+            // in a zero page), and returns the old program's RSS -- while keeping
+            // the address range reserved, since MAP_FIXED lands inside the
+            // reservation Wasmtime's `MmapMemory` already owns.
+            let mapped = unsafe {
+                libc::mmap(
                     memory_base as *mut libc::c_void,
                     1usize << 32,
-                    libc::MADV_DONTNEED,
-                );
+                    PROT_NONE,
+                    (MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED) as i32,
+                    -1,
+                    0,
+                )
+            };
+            if mapped != memory_base as *mut libc::c_void {
+                return Err(anyhow!(
+                    "failed to reset linear memory of cage {} for exec: mmap returned {:p}, expected {:p}",
+                    cageid,
+                    mapped,
+                    memory_base as *mut libc::c_void,
+                ));
             }
-
-            // lind-wasm: reset the entire 4 GiB wasm linear memory to PROT_NONE
-            // before handing it to rawposix. rawposix vmmap is solely responsible
-            // for promoting pages to PROT_READ|PROT_WRITE as the guest accesses
-            // them. early_init_stack (dylink) and the make_syscall in
-            // new_started_impl_with_lind re-establish the required initial regions
-            // before any wasm code runs.
-            libc::mprotect(
-                memory_base as *mut libc::c_void,
-                1usize << 32,
-                libc::PROT_NONE,
-            );
+        } else {
+            unsafe {
+                libc::mprotect(memory_base as *mut libc::c_void, 1usize << 32, PROT_NONE);
+            }
         }
 
         cage::init_vmmap(cageid as u64, memory_base as usize, None);

--- a/src/wasmtime/crates/lind-multi-process/src/lib.rs
+++ b/src/wasmtime/crates/lind-multi-process/src/lib.rs
@@ -125,6 +125,11 @@ pub struct LindCtx<T, U> {
     fork_host: Arc<dyn Fn(&T, bool) -> T + Send + Sync + 'static>,
 
     // exec the host
+    //
+    // The `Option<SharedMemory>` argument is the linear memory the exec-ed image
+    // should be instantiated on. `execve` replaces the program of an existing cage,
+    // so the cage's current 4 GiB reservation is passed here and reused rather than
+    // mapping a second one; `None` falls back to allocating a fresh reservation.
     exec_host: Arc<
         dyn Fn(
                 &U,
@@ -135,6 +140,7 @@ pub struct LindCtx<T, U> {
                 i32,
                 &Arc<LindCageManager>,
                 &Option<Vec<(String, Option<String>)>>,
+                Option<SharedMemory>,
             ) -> Result<Vec<Val>>
             + Send
             + Sync
@@ -174,6 +180,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
             i32,
             &Arc<LindCageManager>,
             &Option<Vec<(String, Option<String>)>>,
+            Option<SharedMemory>,
         ) -> Result<Vec<Val>>
         + Send
         + Sync
@@ -1457,6 +1464,23 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
         }
         let exec_module = exec_module.unwrap();
 
+        // exec replaces the program image but keeps the cage, so the 4 GiB linear
+        // memory this cage already owns is handed to the new image instead of
+        // mapping a second reservation. It is looked up under the import name the
+        // current program's main module uses, which is how it was defined in this
+        // cage's linker (see `attach_shared_memory`).
+        //
+        // If the lookup fails we simply fall back to a fresh reservation, which is
+        // the pre-existing behaviour, so exec keeps working either way.
+        let cage_memory = shared_memory_import_name(main_module).and_then(|(module, name)| {
+            self.linker.as_ref().and_then(|linker| {
+                linker
+                    .get(&mut *caller, &module, &name)
+                    .ok()
+                    .and_then(|ext| ext.into_shared_memory())
+            })
+        });
+
         // get the base address of the memory
         let address = get_memory_base(&mut caller);
 
@@ -1533,6 +1557,7 @@ impl<T: Clone + Send + 'static + std::marker::Sync, U: Clone + Send + 'static + 
                 cloned_cageid,
                 &cloned_lind_manager,
                 &environs,
+                cage_memory,
             );
 
             // If the exec'd module crashed (wasm trap, unreachable, etc.) rather
@@ -2356,12 +2381,26 @@ where
     caller.data().get_ctx().tid as i32
 }
 
-// attach a new SharedMemory to the Linker for multi-threading usage
+// attach a SharedMemory to the Linker for multi-threading usage
 // Warning: only set need_init to true for first cage initialization
 //
 // `all_modules` should include the main module plus all preload library modules.
 // The shared memory is created with limits that satisfy every module's import
 // declaration: min = max(all declared mins), max = min(all declared maxes).
+//
+// `existing_memory` is the `exec` path: `execve` replaces the program image of a
+// cage that already owns a 4 GiB linear-memory reservation, so the reservation is
+// reused instead of mapping a second one (the old one would otherwise stay mapped
+// until the exec-ed program finishes, since the pre-exec `Store` is still alive
+// further down the host call stack). When reusing, the region is released back to
+// the kernel (`MADV_DONTNEED`) so the new image starts from zeroed pages, exactly
+// like a freshly mmap-ed reservation.
+//
+// Note that reusing the reservation means the pre-exec image's memory really is
+// gone once exec succeeds, so a sibling thread that outlives exec would fault.
+// POSIX requires exec to terminate every other thread in the process first, which
+// lind does not do yet (see the thread cleanup TODO in rawposix `exec_syscall`);
+// exec is currently only reachable from a cage's main thread.
 pub fn attach_shared_memory<
     T: LindHost<T, U> + Clone + Send + Sync + 'static,
     U: Clone + Send + Sync + 'static,
@@ -2371,6 +2410,7 @@ pub fn attach_shared_memory<
     all_modules: &[Module],
     need_init: bool,
     cageid: i32,
+    existing_memory: Option<SharedMemory>,
 ) -> Result<()> {
     // Find the shared memory import in the first module (main module) to get
     // the import namespace / name under which to register the memory.
@@ -2378,22 +2418,8 @@ pub fn attach_shared_memory<
         .first()
         .ok_or_else(|| anyhow!("no modules provided"))?;
 
-    let mut import_module_name = "";
-    let mut import_name = "";
-    let mut found = false;
-    for import in main_module.imports() {
-        if let Some(m) = import.ty().memory() {
-            if m.is_shared() {
-                import_module_name = import.module();
-                import_name = import.name();
-                found = true;
-                break;
-            }
-        }
-    }
-    if !found {
-        return Err(anyhow!("Main Module does not contain a shared memory"));
-    }
+    let (import_module_name, import_name) = shared_memory_import_name(main_module)
+        .ok_or_else(|| anyhow!("Main Module does not contain a shared memory"))?;
 
     // In lind-wasm the linear memory is always a fixed 4 GiB physical
     // reservation (MmapMemory overrides max to MAX_MEMORY_SIZE = 4 GiB).
@@ -2422,20 +2448,30 @@ pub fn attach_shared_memory<
     // current_length can be grown to the full physical reservation.
     const LIND_MAX_PAGES: u64 = 65536;
 
-    let mem_type = wasmtime::MemoryTypeBuilder::new()
-        .shared(true)
-        .min(combined_min)
-        .max(Some(LIND_MAX_PAGES))
-        .build()
-        .map_err(anyhow::Error::from)?;
+    let reused = existing_memory.is_some();
+    let mem = match existing_memory {
+        // exec: keep the cage's current reservation instead of mapping a new one.
+        Some(mem) => mem,
+        None => {
+            let mem_type = wasmtime::MemoryTypeBuilder::new()
+                .shared(true)
+                .min(combined_min)
+                .max(Some(LIND_MAX_PAGES))
+                .build()
+                .map_err(anyhow::Error::from)?;
 
-    let mem = SharedMemory::new(main_module.engine(), mem_type)?;
+            SharedMemory::new(main_module.engine(), mem_type)?
+        }
+    };
 
     // Grow to the full 4 GiB so that every wasm address in [0, 4GiB) passes
     // the current_length bounds check.  The physical pages are already reserved
     // by MmapMemory; this just makes them PROT_READ|PROT_WRITE and updates
     // current_length atomically.
-    let delta = LIND_MAX_PAGES.saturating_sub(combined_min);
+    //
+    // A reused memory was already grown to LIND_MAX_PAGES by the cage's previous
+    // image, so `mem.size()` (not `combined_min`) decides what is still missing.
+    let delta = LIND_MAX_PAGES.saturating_sub(mem.size());
     if delta > 0 {
         mem.grow(delta)
             .map_err(anyhow::Error::from)
@@ -2445,13 +2481,28 @@ pub fn attach_shared_memory<
     if need_init {
         let memory_base = mem.get_memory_base();
 
-        // lind-wasm: reset the entire 4 GiB wasm linear memory to PROT_NONE
-        // before handing it to rawposix. rawposix vmmap is solely responsible
-        // for promoting pages to PROT_READ|PROT_WRITE as the guest accesses
-        // them. early_init_stack (dylink) and the make_syscall in
-        // new_started_impl_with_lind re-establish the required initial regions
-        // before any wasm code runs.
         unsafe {
+            // A reused reservation still holds the previous image's pages. Hand
+            // them back to the kernel so the new image sees zeroed memory (.bss
+            // and any page the module does not write a data segment into), which
+            // is what a freshly mmap-ed reservation would have given us. On a
+            // private anonymous mapping MADV_DONTNEED drops the pages and the
+            // next touch faults in a zero page, so this also returns the old
+            // program's RSS instead of carrying it across exec.
+            if reused {
+                libc::madvise(
+                    memory_base as *mut libc::c_void,
+                    1usize << 32,
+                    libc::MADV_DONTNEED,
+                );
+            }
+
+            // lind-wasm: reset the entire 4 GiB wasm linear memory to PROT_NONE
+            // before handing it to rawposix. rawposix vmmap is solely responsible
+            // for promoting pages to PROT_READ|PROT_WRITE as the guest accesses
+            // them. early_init_stack (dylink) and the make_syscall in
+            // new_started_impl_with_lind re-establish the required initial regions
+            // before any wasm code runs.
             libc::mprotect(
                 memory_base as *mut libc::c_void,
                 1usize << 32,
@@ -2461,9 +2512,27 @@ pub fn attach_shared_memory<
 
         cage::init_vmmap(cageid as u64, memory_base as usize, None);
     }
-    linker.define(&store, import_module_name, import_name, mem.clone())?;
+    linker.define(&store, &import_module_name, &import_name, mem.clone())?;
 
     Ok(())
+}
+
+/// Return the `(module, name)` pair under which `module` imports its shared linear
+/// memory, or `None` if it does not import one.
+///
+/// Both `attach_shared_memory` (which defines the memory in a cage's linker) and
+/// the exec path (which looks the memory back up so it can be reused) need this
+/// name, so it is derived in one place.
+fn shared_memory_import_name(module: &Module) -> Option<(String, String)> {
+    module.imports().find_map(|import| {
+        let ty = import.ty();
+        let memory = ty.memory()?;
+        if memory.is_shared() {
+            Some((import.module().to_string(), import.name().to_string()))
+        } else {
+            None
+        }
+    })
 }
 
 pub fn early_init_stack(cageid: u64, stack_start: i32, stack_end: i32) -> Result<()> {

--- a/tests/unit-tests/process_tests/deterministic/exec_bss_reset.c
+++ b/tests/unit-tests/process_tests/deterministic/exec_bss_reset.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+// exec must hand the new program image zeroed .bss.
+//
+// lind reuses the cage's existing 4 GiB linear memory across exec instead of
+// mapping a second reservation, so the region still holds the previous image's
+// pages when the new one is instantiated.  Nothing writes .bss at startup -- it
+// is simply assumed to be zero -- so the runtime has to release those pages
+// before handing the memory to the new program.
+#define BUF_SIZE (4 * 1024 * 1024)
+
+static unsigned char scratch[BUF_SIZE];
+
+int main(int argc, char *argv[]) {
+  if (argc > 1 && strcmp(argv[1], "--execd") == 0) {
+    for (size_t i = 0; i < BUF_SIZE; i++) {
+      if (scratch[i] != 0) {
+        printf("FAIL: .bss byte %zu survived exec with value 0x%02x\n", i,
+               scratch[i]);
+        return 1;
+      }
+    }
+    printf("PASS\n");
+    return 0;
+  }
+
+  // dirty every page of .bss, then replace the program image
+  memset(scratch, 0xa5, BUF_SIZE);
+
+  execl(argv[0], argv[0], "--execd", NULL);
+
+  // only reached if exec fails
+  perror("exec failed");
+  return 1;
+}


### PR DESCRIPTION
## Summary

### Problems

1. `execve` replaces a cage's program image but kept allocating a brand-new 4 GiB linear-memory reservation for the new image. Because the exec-ed program runs nested inside the pre-exec `Store`'s host call stack, the old reservation stays mapped until it finishes so a plain `execv` peaked at two reservations and `fork()`+`execve()` at three.
2. `load_main_module` registers a grate worker pool in the process-wide `GRATE_POOL`, and each worker owns a `Store` attached to the cage's linear memory. `cleanup_grate_handler` is never called from anywhere (`get_runtime_cleanup_funcptr` has zero call sites), so that entry and the 4 GiB behind it survived for the lifetime of the host process.

### Changes:

- `attach_shared_memory` takes an optional existing `SharedMemory`. On the exec path the cage's current reservation is passed in and reused instead of calling `SharedMemory::new`; the grow delta is now computed from `mem.size()` rather than `combined_min`, since a reused memory is already at 65536 pages.
- When reusing, the whole 4 GiB is re-established as a fresh anonymous mapping (`MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED`, `PROT_NONE`)
- `execve_call` looks the cage's memory up in its own linker.
- `execute_with_lind` unregisters the cage's grate handler once the program has finished. 

`execv` goes from 2 reservations to 1, `fork()`+`execve()` from 3 to 2, and a cage's address space is actually returned when it exits.

## Related issues

Closes #1354

## Testing

<!-- List the commands, test cases, or manual checks used to verify the change. -->

## Compatibility and security impact

<!--
Describe user-visible behavior changes, compatibility concerns, new syscalls,
security implications, or performance impact. Write "None" when not applicable.
-->

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/Lind-Project/lind-wasm/blob/main/CONTRIBUTING.md).
- [x] I added or updated tests where appropriate.
- [x] I ran the relevant tests locally and they pass.
- [x] I formatted the code and ran the relevant linters.
- [x] I updated documentation for user-visible or architectural changes.
- [x] I disclosed security vulnerabilities privately rather than in this PR.

<!--
Project-wide contribution and review policies:
https://github.com/Lind-Project/community/blob/main/CONTRIBUTING.md
-->
